### PR TITLE
fix: UI congelada al cambiar modelo de embeddings y chat sin contexto de proyecto

### DIFF
--- a/electron/handlers/document.handler.ts
+++ b/electron/handlers/document.handler.ts
@@ -835,10 +835,7 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
       console.log(`[Document Handler] Static providers: ${staticProviders.length}`)
 
       // Get dynamic Ollama providers
-      await ipcMain.emit('wisdom:checkOllamaConnection')
       let dynamicProviders = []
-
-      // Try to get Ollama models directly since emit doesn't return values
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const axios = require('axios')
@@ -928,6 +925,17 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
 
       // Get all available providers (static + dynamic)
       const staticProviders = embeddingService.getProviders()
+      const staticProvider = staticProviders.find((p: any) => p.id === providerId)
+
+      // Static providers (e.g. OpenAI) never need an Ollama round-trip - switch immediately
+      if (staticProvider) {
+        embeddingService.setProvider(providerId)
+        return {
+          success: true,
+          message: `Switched to ${embeddingService.activeProvider.name}`
+        }
+      }
+
       let dynamicProviders = []
 
       // Get dynamic Ollama providers if available
@@ -983,29 +991,19 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
         console.log('[Document Handler] Could not get dynamic providers:', ollamaError.message)
       }
 
-      // Combine all providers
-      const allProviders = [...staticProviders, ...dynamicProviders]
-      const selectedProvider = allProviders.find(p => p.id === providerId)
+      const selectedProvider = dynamicProviders.find((p: any) => p.id === providerId)
 
       if (!selectedProvider) {
+        const allProviders = [...staticProviders, ...dynamicProviders]
         throw new Error(`Provider ${providerId} not found. Available providers: ${allProviders.map(p => p.id).join(', ')}`)
       }
 
-      // For static providers, use the existing service
-      if (staticProviders.find((p: any) => p.id === providerId)) {
-        embeddingService.setProvider(providerId)
-        return {
-          success: true,
-          message: `Switched to ${embeddingService.activeProvider.name}`
-        }
-      } else {
-        // For dynamic providers, set manually
-        embeddingService.activeProvider = selectedProvider
-        console.log(`[Document Handler] Set dynamic provider: ${selectedProvider.name}`)
-        return {
-          success: true,
-          message: `Switched to ${selectedProvider.name}`
-        }
+      // For dynamic (Ollama) providers, set manually
+      embeddingService.activeProvider = selectedProvider
+      console.log(`[Document Handler] Set dynamic provider: ${selectedProvider.name}`)
+      return {
+        success: true,
+        message: `Switched to ${selectedProvider.name}`
       }
 
     } catch (error: any) {

--- a/src/components/chat/ProjectSelector.tsx
+++ b/src/components/chat/ProjectSelector.tsx
@@ -42,9 +42,15 @@ export function ProjectSelector({ selectedProjectId, onProjectSelect, className 
   
   return (
     <div className={cn("flex items-center gap-2", className)}>
-      <Select.Root value={currentProjectId || 'none'} onValueChange={(value) => {
-        onProjectSelect(value === 'none' ? undefined : value)
-      }}>
+      <Select.Root
+        value={currentProjectId || 'none'}
+        onValueChange={(value) => {
+          onProjectSelect(value === 'none' ? undefined : value)
+        }}
+        onOpenChange={(open) => {
+          if (open) loadProjects()
+        }}
+      >
         <Select.Trigger className={cn(
           "inline-flex items-center justify-between gap-2 px-3 py-2 rounded-lg",
           "bg-card border border-border/50 text-sm",

--- a/src/components/wisdom/UnifiedWisdomPanel.tsx
+++ b/src/components/wisdom/UnifiedWisdomPanel.tsx
@@ -75,6 +75,7 @@ export function UnifiedWisdomPanel() {
 
   // UI State
   const [loading, setLoading] = useState(false)
+  const [providerChangeLoading, setProviderChangeLoading] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const [showSettings, setShowSettings] = useState(false)
   const [showVectorGraph, setShowVectorGraph] = useState(false)
@@ -506,7 +507,7 @@ export function UnifiedWisdomPanel() {
   */
 
   const handleProviderChange = async (providerId: string) => {
-    setLoading(true)
+    setProviderChangeLoading(true)
     try {
       const result = await window.electronAPI.wisdom.setEmbeddingProvider(providerId)
       if (result.success) {
@@ -519,7 +520,7 @@ export function UnifiedWisdomPanel() {
       logger.error('Error changing embedding provider:', error)
       showNotification('Error changing embedding provider', 'error')
     } finally {
-      setLoading(false)
+      setProviderChangeLoading(false)
     }
   }
 
@@ -1099,21 +1100,21 @@ export function UnifiedWisdomPanel() {
                       <button
                         onClick={async () => {
                           logger.debug('🔄 Manual refresh of embedding providers triggered')
-                          setLoading(true)
+                          setProviderChangeLoading(true)
                           try {
                             await loadEmbeddingProviders()
                             logger.debug('✅ Embedding providers refreshed')
                           } catch (error) {
                             logger.error('❌ Failed to refresh providers:', error)
                           } finally {
-                            setLoading(false)
+                            setProviderChangeLoading(false)
                           }
                         }}
-                        disabled={loading}
+                        disabled={providerChangeLoading}
                         className="p-1 text-muted-foreground hover:text-foreground transition-colors"
                         title="Refresh Ollama models and providers"
                       >
-                        <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                        <RefreshCw className={`w-4 h-4 ${providerChangeLoading ? 'animate-spin' : ''}`} />
                       </button>
                     </div>
 
@@ -1129,7 +1130,7 @@ export function UnifiedWisdomPanel() {
                       key={`provider-select-${embeddingProviders.length}`}
                       value={selectedProviderId}
                       onChange={(e) => handleProviderChange(e.target.value)}
-                      disabled={loading}
+                      disabled={providerChangeLoading}
                       className="w-full px-3 py-2 bg-background border border-border rounded-lg text-foreground text-sm mb-3"
                     >
                       {embeddingProviders.length > 0 ? (

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -72,6 +72,9 @@ interface ChatState {
   // Wisdom/RAG actions
   setWisdomConfig: (config: WisdomConfiguration | undefined) => void
   enhancePromptWithRAG: (originalPrompt: string) => Promise<{ enhancedPrompt: string; sources?: any[] }>
+
+  // Hydraulic project context
+  buildProjectContext: (projectId: string) => Promise<string>
 }
 
 export const useChatStore = create<ChatState>()(
@@ -265,6 +268,24 @@ export const useChatStore = create<ChatState>()(
 
             const conversation = get().conversations.find(c => c.id === conversationId)
             if (!conversation) throw new Error('Conversation not found')
+
+            // Prepend hydraulic project context when the conversation is linked to a project
+            if (conversation.projectId) {
+              try {
+                const projectContextTimeout = new Promise<string>((resolve) =>
+                  setTimeout(() => resolve(''), 10000)
+                )
+                const projectContext = await Promise.race([
+                  get().buildProjectContext(conversation.projectId),
+                  projectContextTimeout
+                ])
+                if (projectContext) {
+                  enhancedPrompt = projectContext + enhancedPrompt
+                }
+              } catch (error) {
+                logger.warn('Failed to attach project context, continuing without it:', error)
+              }
+            }
 
             // Clear any previous streaming message
             get().clearStreamingMessage()
@@ -727,6 +748,44 @@ export const useChatStore = create<ChatState>()(
         } catch (error) {
           logger.error('Failed to enhance prompt with RAG:', error)
           return { enhancedPrompt: originalPrompt, sources: [] }
+        }
+      },
+
+      buildProjectContext: async (projectId: string): Promise<string> => {
+        try {
+          const result = await window.electronAPI.hydraulic.getProject(projectId)
+          if (!result.success || !result.data) {
+            return ''
+          }
+
+          const project = result.data
+          let context = '=== HYDRAULIC PROJECT CONTEXT ===\n\n'
+          context += `Project: ${project.name}\n`
+          if (project.description) context += `Description: ${project.description}\n`
+          if (project.type) context += `Type: ${project.type}\n`
+          if (project.status) context += `Status: ${project.status}\n`
+          if (project.location?.country || project.location?.region) {
+            context += `Location: ${[project.location?.city, project.location?.region, project.location?.country].filter(Boolean).join(', ')}\n`
+          }
+
+          if (project.network) {
+            context += `\nNetwork model: loaded (EPANET .inp data available for this project)\n`
+          }
+
+          if (project.calculations && project.calculations.length > 0) {
+            context += `\nCalculations performed on this project (${project.calculations.length}):\n`
+            project.calculations.slice(0, 10).forEach((calc: any) => {
+              context += `- ${calc.name} (${calc.type})${calc.verified ? ' [verified]' : ''}\n`
+            })
+          }
+
+          context += '\n=== END PROJECT CONTEXT ===\n\n'
+          context += 'Utiliza el contexto del proyecto anterior cuando sea relevante para responder la consulta del usuario.\n\n'
+
+          return context
+        } catch (error) {
+          logger.warn('Failed to build project context:', error)
+          return ''
         }
       }
     }),


### PR DESCRIPTION
## Summary
- Fixes #16 — la UI se congelaba al seleccionar el modelo de IA de indexación en el Wisdom Center. Causa raíz: el cambio de proveedor reutilizaba el estado `loading` global que oculta toda la lista de documentos tras un spinner, y el handler de main process hacía una llamada de red bloqueante a Ollama en cada cambio de proveedor (incluso para proveedores no-Ollama).
- Fixes #17 (parcial) — el chat no se vinculaba de forma útil a los proyectos hidráulicos:
  - `ProjectSelector` ahora refresca la lista de proyectos al abrirse (antes solo cargaba una vez al montar, así que un proyecto recién creado no aparecía).
  - El contador "CHATS" en las tarjetas de proyecto ya funcionaba correctamente en el código actual (usa `_count` de Prisma) — verificado, sin cambios necesarios.
  - Se añade inyección real de contexto del proyecto hidráulico (nombre, ubicación, cálculos) en el prompt enviado al LLM cuando la conversación está vinculada a un proyecto (`chatStore.buildProjectContext`), con timeout de 10s para no bloquear el envío si falla.

## Test plan
- [x] `npm run typecheck` sin errores
- [x] `npx eslint` sobre los 4 archivos modificados — solo warnings preexistentes (`any`/`console`), sin errores nuevos
- [x] `npm run build:electron` completa correctamente (TS + empaquetado DMG)
- [ ] Probar manualmente en la app: cambiar el proveedor de embeddings en Wisdom Center (especialmente con modelos Ollama) y confirmar que la UI no se congela
- [ ] Probar manualmente: crear un proyecto, abrir Chat, seleccionar el proyecto en "Select a project", iniciar una conversación y confirmar que el LLM referencia el contexto del proyecto

🤖 Generated with [Claude Code](https://claude.com/claude-code)