### PR TITLE
feat: rutinas de resiliencia WNTR (epic #26: #22, #23, #24, #25)

### DIFF
--- a/backend/services/hydraulic/resilienceService.ts
+++ b/backend/services/hydraulic/resilienceService.ts
@@ -1,0 +1,202 @@
+/**
+ * WNTR Resilience Service - TypeScript Wrapper
+ * Skeletonization, service-interruption simulation, resilience indicators
+ * and seismic fragility curves (epic #26: "Rutinas de resiliencia WNTR").
+ */
+
+import { spawn } from 'child_process';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('WNTRResilienceService');
+
+export interface SkeletonizeResult {
+  success: boolean;
+  data?: {
+    before: { junctions: number; tanks: number; reservoirs: number; pipes: number; pumps: number; valves: number };
+    after: { junctions: number; tanks: number; reservoirs: number; pipes: number; pumps: number; valves: number };
+    reduction: { pipes_pct: number; junctions_pct: number };
+    pipe_diameter_threshold_mm: number;
+    inp_content: string;
+  };
+  error?: string;
+}
+
+export interface ComponentFailureInput {
+  id: string;
+  type?: 'pipe' | 'pump' | 'valve';
+}
+
+export interface SimulateFailureResult {
+  success: boolean;
+  data?: {
+    status: string;
+    execution_time: number;
+    failed_components: string[];
+    failure_start_hours: number;
+    restore_hours: number | null;
+    duration_hours: number;
+    min_pressure_threshold: number;
+    affected_nodes: Array<{
+      id: string;
+      min_pressure: number;
+      baseline_min_pressure: number;
+      pressure_drop: number;
+      outage_hours: number;
+    }>;
+    affected_node_count: number;
+    total_junction_count: number;
+    node_results: Record<string, { pressure: number[] }>;
+    link_results: Record<string, { flowrate: number[] }>;
+    timestamps: number[];
+  };
+  error?: string;
+}
+
+export interface ResilienceSnapshot {
+  todini_index: number;
+  network_entropy: number;
+  hydraulic_redundancy: number;
+  serviceability: {
+    pressure_serviceability: number;
+    junctions_meeting_pressure: number;
+    total_junctions: number;
+  };
+}
+
+export interface ResilienceIndicatorsResult {
+  success: boolean;
+  data?: {
+    before: ResilienceSnapshot;
+    after?: ResilienceSnapshot;
+    delta?: {
+      todini_index: number;
+      network_entropy: number;
+      hydraulic_redundancy: number;
+      pressure_serviceability: number;
+    };
+  };
+  error?: string;
+}
+
+export interface FragilityCurveResult {
+  success: boolean;
+  data?: {
+    hazard_type: string;
+    material: string;
+    median_pgv: number;
+    beta: number;
+    intensities: number[];
+    pipe_failure_probability: number[];
+    expected_failed_pipes: number[];
+    pipe_count: number;
+    total_length_km: number;
+    methodology: string;
+  };
+  error?: string;
+}
+
+export class WNTRResilienceService {
+  private pythonPath: string;
+  private servicePath: string;
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { findPythonPath } = require('./pythonDetector');
+    this.pythonPath = findPythonPath();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { resolvePythonScriptPath } = require('./pythonScriptPath');
+    this.servicePath = resolvePythonScriptPath('wntr_resilience_service.py');
+  }
+
+  async skeletonizeNetwork(networkFile: string, options?: {
+    pipe_diameter_threshold_mm?: number;
+    branch_trim?: boolean;
+    series_pipe_merge?: boolean;
+    parallel_pipe_merge?: boolean;
+  }): Promise<SkeletonizeResult> {
+    return this.executePythonService('skeletonize', networkFile, options);
+  }
+
+  async simulateComponentFailure(networkFile: string, options: {
+    components: ComponentFailureInput[];
+    duration_hours?: number;
+    failure_start_hours?: number;
+    restore_hours?: number;
+    min_pressure_threshold?: number;
+  }): Promise<SimulateFailureResult> {
+    return this.executePythonService('simulate_failure', networkFile, options);
+  }
+
+  async calculateResilienceIndicators(networkFile: string, options?: {
+    duration_hours?: number;
+    min_pressure_threshold?: number;
+    failed_components?: ComponentFailureInput[];
+    failure_start_hours?: number;
+  }): Promise<ResilienceIndicatorsResult> {
+    return this.executePythonService('resilience_indicators', networkFile, options);
+  }
+
+  async generateFragilityCurve(networkFile: string, options?: {
+    hazard_type?: string;
+    material?: 'CI' | 'AC' | 'STEEL' | 'DI' | 'PVC' | 'HDPE' | 'CONCRETE' | 'DEFAULT';
+    max_intensity?: number;
+    steps?: number;
+    beta?: number;
+  }): Promise<FragilityCurveResult> {
+    return this.executePythonService('fragility_curve', networkFile, options);
+  }
+
+  private async executePythonService(command: string, networkFile: string, options?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const args = [this.servicePath, command, networkFile];
+      if (options) {
+        args.push(JSON.stringify(options));
+      }
+
+      logger.debug(`Executing: ${this.pythonPath} ${args.join(' ')}`);
+
+      const pythonProcess = spawn(this.pythonPath, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env }
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      pythonProcess.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      pythonProcess.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      const timeout = setTimeout(() => {
+        pythonProcess.kill();
+        reject(new Error('Resilience analysis timeout'));
+      }, 180000); // 3 minutes - extended-period simulations can be slow
+
+      pythonProcess.on('close', (code) => {
+        clearTimeout(timeout);
+        if (code === 0) {
+          try {
+            resolve(JSON.parse(stdout));
+          } catch (parseError) {
+            logger.error('Failed to parse Python service response:', parseError);
+            logger.error('Raw stdout:', stdout);
+            reject(new Error(`Invalid JSON response: ${parseError}`));
+          }
+        } else {
+          logger.error(`Python service exited with code ${code}`);
+          logger.error('stderr:', stderr);
+          reject(new Error(`Python service failed with code ${code}: ${stderr}`));
+        }
+      });
+
+      pythonProcess.on('error', (error) => {
+        logger.error('Failed to start Python service:', error instanceof Error ? error.message : 'Unknown error');
+        reject(error);
+      });
+    });
+  }
+}

--- a/backend/services/hydraulic/wntr_resilience_service.py
+++ b/backend/services/hydraulic/wntr_resilience_service.py
@@ -1,0 +1,460 @@
+
+"""
+WNTR Resilience Service: skeletonization, service-interruption simulation,
+resilience indicators (Todini/entropy/redundancy) and seismic fragility curves.
+
+Covers the 4 sub-features of the "Rutinas de resiliencia WNTR" epic
+(#22 service interruption, #23 resilience indicators, #24 skeletonization,
+#25 fragility curve).
+"""
+import sys
+import json
+import os
+import time
+import tempfile
+import wntr
+import wntr.metrics.hydraulic
+import wntr.network.controls as ctrls
+from wntr.network import LinkStatus
+import warnings
+
+# Suppress specific WNTR warnings that are informational only
+warnings.filterwarnings('ignore', message='Changing the headloss formula from')
+warnings.filterwarnings('ignore', message='Not all curves were used in')
+
+
+class WNTRResilienceService:
+    def __init__(self):
+        pass
+
+    def load_network(self, inp_file):
+        """Load network with robust handling for backdrop units (same fix as the other WNTR services)"""
+        try:
+            with open(inp_file, 'r', encoding='utf-8', errors='ignore') as f:
+                lines = f.readlines()
+
+            fixed_lines = []
+            in_backdrop_section = False
+
+            for line in lines:
+                stripped = line.strip().upper()
+
+                if stripped.startswith('[') and stripped.endswith(']'):
+                    in_backdrop_section = stripped == '[BACKDROP]'
+                    fixed_lines.append(line)
+                    continue
+
+                if in_backdrop_section and stripped.startswith('UNITS'):
+                    parts = stripped.split()
+                    if len(parts) >= 2:
+                        unit = parts[1]
+                        if unit not in ['FEET', 'METERS', 'DEGREES', 'NONE']:
+                            fixed_lines.append(f"; {line.strip()} (Modified by Boorie)\n")
+                            fixed_lines.append("UNITS NONE\n")
+                            continue
+
+                fixed_lines.append(line)
+
+            fd, temp_path = tempfile.mkstemp(suffix='.inp', text=True)
+            with os.fdopen(fd, 'w') as f:
+                f.writelines(fixed_lines)
+
+            try:
+                return wntr.network.WaterNetworkModel(temp_path)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
+        except Exception:
+            return wntr.network.WaterNetworkModel(inp_file)
+
+    def _prepare_wntr_simulator(self, wn):
+        """Fix incompatibilities so WNTRSimulator can run (same pattern as the other services)"""
+        if str(wn.options.hydraulic.headloss).upper() in ['D-W', 'DARCY-WEISBACH', 'DW']:
+            wn.options.hydraulic.headloss = 'H-W'
+
+        if len(wn.gpv_name_list) > 0:
+            for name in list(wn.gpv_name_list):
+                gpv = wn.get_link(name)
+                u, v = gpv.start_node_name, gpv.end_node_name
+                wn.remove_link(name)
+                wn.add_pipe(name, u, v, length=1.0, diameter=0.3, roughness=130, check_valve=False)
+
+        try:
+            if wn.options.time.hydraulic_timestep <= 0:
+                wn.options.time.hydraulic_timestep = 3600.0
+            if wn.options.time.report_timestep <= 0:
+                wn.options.time.report_timestep = wn.options.time.hydraulic_timestep
+        except Exception:
+            pass
+
+    def _network_summary(self, wn):
+        return {
+            'junctions': len(wn.junction_name_list),
+            'tanks': len(wn.tank_name_list),
+            'reservoirs': len(wn.reservoir_name_list),
+            'pipes': len(wn.pipe_name_list),
+            'pumps': len(wn.pump_name_list),
+            'valves': len(wn.valve_name_list),
+        }
+
+    # ------------------------------------------------------------------
+    # Feature: Esqueletización de redes (#24)
+    # ------------------------------------------------------------------
+    def skeletonize(self, inp_file, options=None):
+        try:
+            options = options or {}
+            wn = self.load_network(inp_file)
+            before = self._network_summary(wn)
+
+            threshold_mm = float(options.get('pipe_diameter_threshold_mm', 100))
+            threshold_m = threshold_mm / 1000.0
+
+            # use_epanet=False forces the pure-Python skeletonization path.
+            # The default (True) shells out to the compiled EPANET toolkit,
+            # which crashes with SIGKILL under macOS code-signing restrictions
+            # (same class of issue documented for EpanetSimulator elsewhere
+            # in this codebase) - verified against this repo's Python setup.
+            wn_skel = wntr.morph.skeletonize(
+                wn,
+                pipe_diameter_threshold=threshold_m,
+                branch_trim=bool(options.get('branch_trim', True)),
+                series_pipe_merge=bool(options.get('series_pipe_merge', True)),
+                parallel_pipe_merge=bool(options.get('parallel_pipe_merge', True)),
+                use_epanet=bool(options.get('use_epanet', False)),
+                return_copy=True
+            )
+            after = self._network_summary(wn_skel)
+
+            fd, temp_path = tempfile.mkstemp(suffix='.inp')
+            os.close(fd)
+            try:
+                wntr.network.write_inpfile(wn_skel, temp_path)
+                with open(temp_path, 'r', encoding='utf-8') as f:
+                    inp_content = f.read()
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
+            def reduction_pct(b, a):
+                return round((1 - (a / b)) * 100, 1) if b > 0 else 0.0
+
+            result = {
+                'success': True,
+                'data': {
+                    'before': before,
+                    'after': after,
+                    'reduction': {
+                        'pipes_pct': reduction_pct(before['pipes'], after['pipes']),
+                        'junctions_pct': reduction_pct(before['junctions'], after['junctions'])
+                    },
+                    'pipe_diameter_threshold_mm': threshold_mm,
+                    'inp_content': inp_content
+                }
+            }
+            print(json.dumps(result))
+        except Exception as e:
+            print(json.dumps({'success': False, 'error': str(e)}))
+
+    # ------------------------------------------------------------------
+    # Feature: Simulación de interrupción del servicio (#22)
+    # ------------------------------------------------------------------
+    def _apply_component_failures(self, wn, components, failure_start_hours, restore_hours):
+        """Close one or more components (pipe/pump/valve) using wntr.network.controls."""
+        failure_start_s = float(failure_start_hours) * 3600.0
+        applied = []
+        for comp in components:
+            comp_id = comp.get('id') if isinstance(comp, dict) else comp
+            try:
+                link = wn.get_link(comp_id)
+            except KeyError:
+                continue
+
+            close_action = ctrls.ControlAction(link, 'status', LinkStatus.Closed)
+            close_condition = ctrls.SimTimeCondition(wn, '=', failure_start_s)
+            wn.add_control(
+                f'fail_close_{comp_id}',
+                ctrls.Control(close_condition, close_action, name=f'fail_close_{comp_id}')
+            )
+
+            if restore_hours is not None:
+                restore_s = float(restore_hours) * 3600.0
+                open_action = ctrls.ControlAction(link, 'status', LinkStatus.Open)
+                open_condition = ctrls.SimTimeCondition(wn, '=', restore_s)
+                wn.add_control(
+                    f'fail_open_{comp_id}',
+                    ctrls.Control(open_condition, open_action, name=f'fail_open_{comp_id}')
+                )
+
+            applied.append(comp_id)
+        return applied
+
+    def _run_extended(self, wn, duration_hours):
+        wn.options.time.duration = float(duration_hours) * 3600.0
+        self._prepare_wntr_simulator(wn)
+        sim = wntr.sim.WNTRSimulator(wn)
+        return sim.run_sim()
+
+    def simulate_failure(self, inp_file, options=None):
+        start_time = time.time()
+        try:
+            options = options or {}
+            components = options.get('components', [])
+            if not components:
+                print(json.dumps({'success': False, 'error': 'No components specified'}))
+                return
+
+            duration_hours = float(options.get('duration_hours', 24))
+            failure_start_hours = float(options.get('failure_start_hours', 0))
+            restore_hours = options.get('restore_hours')
+            min_pressure_threshold = float(options.get('min_pressure_threshold', 10.0))
+
+            # Baseline (undisturbed) run, used to report the pressure drop caused by the failure
+            wn_baseline = self.load_network(inp_file)
+            baseline_results = self._run_extended(wn_baseline, duration_hours)
+            baseline_pressure = baseline_results.node['pressure']
+
+            # Failure run
+            wn_failure = self.load_network(inp_file)
+            applied = self._apply_component_failures(wn_failure, components, failure_start_hours, restore_hours)
+            if not applied:
+                print(json.dumps({'success': False, 'error': 'None of the specified components exist in the network'}))
+                return
+
+            failure_results = self._run_extended(wn_failure, duration_hours)
+            pressure = failure_results.node['pressure']
+            report_ts_hours = wn_failure.options.time.report_timestep / 3600.0
+
+            affected_nodes = []
+            for node_name in wn_failure.junction_name_list:
+                node_pressure = pressure.loc[:, node_name]
+                min_p = float(node_pressure.min())
+                baseline_min_p = float(baseline_pressure.loc[:, node_name].min()) if node_name in baseline_pressure.columns else min_p
+                below_threshold_steps = int((node_pressure < min_pressure_threshold).sum())
+                outage_hours = below_threshold_steps * report_ts_hours
+
+                if min_p < min_pressure_threshold or outage_hours > 0:
+                    affected_nodes.append({
+                        'id': node_name,
+                        'min_pressure': min_p,
+                        'baseline_min_pressure': baseline_min_p,
+                        'pressure_drop': baseline_min_p - min_p,
+                        'outage_hours': outage_hours
+                    })
+            affected_nodes.sort(key=lambda n: n['outage_hours'], reverse=True)
+
+            node_results = {}
+            for node_name in wn_failure.node_name_list:
+                node_results[node_name] = {
+                    'pressure': pressure.loc[:, node_name].tolist(),
+                }
+            link_results = {}
+            for link_name in wn_failure.link_name_list:
+                link_results[link_name] = {
+                    'flowrate': failure_results.link['flowrate'].loc[:, link_name].tolist(),
+                }
+
+            result = {
+                'success': True,
+                'data': {
+                    'status': 'Completed',
+                    'execution_time': time.time() - start_time,
+                    'failed_components': applied,
+                    'failure_start_hours': failure_start_hours,
+                    'restore_hours': restore_hours,
+                    'duration_hours': duration_hours,
+                    'min_pressure_threshold': min_pressure_threshold,
+                    'affected_nodes': affected_nodes,
+                    'affected_node_count': len(affected_nodes),
+                    'total_junction_count': len(wn_failure.junction_name_list),
+                    'node_results': node_results,
+                    'link_results': link_results,
+                    'timestamps': pressure.index.tolist(),
+                }
+            }
+            print(json.dumps(result))
+        except Exception as e:
+            print(json.dumps({'success': False, 'error': str(e)}))
+
+    # ------------------------------------------------------------------
+    # Feature: Indicadores de resiliencia (#23)
+    # ------------------------------------------------------------------
+    def _resilience_snapshot(self, wn, min_pressure_threshold):
+        """Compute Todini index, network entropy, hydraulic redundancy and serviceability for a network state."""
+        self._prepare_wntr_simulator(wn)
+        sim = wntr.sim.WNTRSimulator(wn)
+        results = sim.run_sim()
+
+        head = results.node['head']
+        pressure = results.node['pressure']
+        demand = results.node['demand']
+        flowrate = results.link['flowrate']
+
+        todini = wntr.metrics.hydraulic.todini_index(head, pressure, demand, flowrate, wn, 30)
+        todini_score = float(todini.mean())
+
+        # Network entropy: directed graph weighted by flow at the last report step
+        try:
+            last_flow = flowrate.iloc[-1]
+            G = wn.to_graph(link_weight=last_flow, modify_direction=True)
+            _, system_entropy = wntr.metrics.hydraulic.entropy(G)
+            entropy_score = float(system_entropy) if system_entropy == system_entropy else 0.0  # NaN guard
+        except Exception:
+            entropy_score = 0.0
+
+        # Hydraulic redundancy: modified resilience index (surplus power vs. min required power)
+        try:
+            elevation = wn.query_node_attribute('elevation')
+            junction_pressure = pressure[wn.junction_name_list]
+            junction_elevation = elevation[wn.junction_name_list]
+            junction_demand = demand[wn.junction_name_list]
+            mri = wntr.metrics.hydraulic.modified_resilience_index(
+                junction_pressure, junction_elevation, min_pressure_threshold,
+                demand=junction_demand, per_junction=False
+            )
+            redundancy_score = float(mri.mean())
+        except Exception:
+            redundancy_score = 0.0
+
+        # Serviceability: fraction of junctions meeting minimum pressure at every reported timestep
+        junction_pressure = pressure[wn.junction_name_list]
+        meets_min = (junction_pressure >= min_pressure_threshold).all(axis=0)
+        pressure_serviceability = float(meets_min.mean()) if len(meets_min) > 0 else 0.0
+
+        return {
+            'todini_index': todini_score,
+            'network_entropy': entropy_score,
+            'hydraulic_redundancy': redundancy_score,
+            'serviceability': {
+                'pressure_serviceability': pressure_serviceability,
+                'junctions_meeting_pressure': int(meets_min.sum()),
+                'total_junctions': len(meets_min)
+            }
+        }
+
+    def resilience_indicators(self, inp_file, options=None):
+        try:
+            options = options or {}
+            duration_hours = float(options.get('duration_hours', 24))
+            min_pressure_threshold = float(options.get('min_pressure_threshold', 10.0))
+            failed_components = options.get('failed_components', [])
+            failure_start_hours = float(options.get('failure_start_hours', 0))
+
+            wn_before = self.load_network(inp_file)
+            wn_before.options.time.duration = duration_hours * 3600.0
+            before = self._resilience_snapshot(wn_before, min_pressure_threshold)
+
+            data = {'before': before}
+
+            if failed_components:
+                wn_after = self.load_network(inp_file)
+                wn_after.options.time.duration = duration_hours * 3600.0
+                self._apply_component_failures(wn_after, failed_components, failure_start_hours, None)
+                after = self._resilience_snapshot(wn_after, min_pressure_threshold)
+                data['after'] = after
+                data['delta'] = {
+                    'todini_index': after['todini_index'] - before['todini_index'],
+                    'network_entropy': after['network_entropy'] - before['network_entropy'],
+                    'hydraulic_redundancy': after['hydraulic_redundancy'] - before['hydraulic_redundancy'],
+                    'pressure_serviceability': (
+                        after['serviceability']['pressure_serviceability'] -
+                        before['serviceability']['pressure_serviceability']
+                    )
+                }
+
+            print(json.dumps({'success': True, 'data': data}))
+        except Exception as e:
+            print(json.dumps({'success': False, 'error': str(e)}))
+
+    # ------------------------------------------------------------------
+    # Feature: Curva de fragilidad (#25)
+    # ------------------------------------------------------------------
+    def fragility_curve(self, inp_file, options=None):
+        """
+        Seismic fragility curve for network pipes: probability of failure
+        (leak/break) vs. hazard intensity (PGV, cm/s), using the ALA
+        (American Lifelines Alliance, 2001) repair-rate methodology and a
+        lognormal fragility function per pipe material.
+
+        NOTE: the median-PGV coefficients below are generic published
+        defaults for a pipeline population, NOT calibrated against any
+        specific network. Boorie issue #25 explicitly requires these to be
+        validated with an APyS domain expert before being used for real
+        decision-making — treat this as a first estimate only.
+        """
+        try:
+            import numpy as np
+            from scipy.stats import lognorm
+
+            options = options or {}
+            wn = self.load_network(inp_file)
+
+            hazard_type = options.get('hazard_type', 'seismic_pgv')
+            material = str(options.get('material', 'DEFAULT')).upper()
+            max_intensity = float(options.get('max_intensity', 100))
+            steps = int(options.get('steps', 21))
+            intensities = list(np.linspace(0, max_intensity, steps))
+
+            # ALA (2001)-style median PGV (cm/s) at 50% failure probability, by material.
+            median_by_material = {
+                'CI': 15.0, 'AC': 15.0, 'STEEL': 30.0, 'DI': 25.0,
+                'PVC': 28.0, 'HDPE': 35.0, 'CONCRETE': 20.0, 'DEFAULT': 20.0
+            }
+            median = median_by_material.get(material, median_by_material['DEFAULT'])
+            beta = float(options.get('beta', 0.5))  # lognormal dispersion, ALA default ~0.5
+
+            pipe_failure_probability = [float(p) for p in lognorm.cdf(intensities, s=beta, scale=median)]
+            pipe_count = len(wn.pipe_name_list)
+            expected_failed_pipes = [p * pipe_count for p in pipe_failure_probability]
+            total_length_km = sum(wn.get_link(p).length for p in wn.pipe_name_list) / 1000.0
+
+            result = {
+                'success': True,
+                'data': {
+                    'hazard_type': hazard_type,
+                    'material': material,
+                    'median_pgv': median,
+                    'beta': beta,
+                    'intensities': [float(i) for i in intensities],
+                    'pipe_failure_probability': pipe_failure_probability,
+                    'expected_failed_pipes': expected_failed_pipes,
+                    'pipe_count': pipe_count,
+                    'total_length_km': total_length_km,
+                    'methodology': (
+                        'ALA (2001) repair-rate lognormal fragility (parametros genericos por material) '
+                        '- requiere validacion de un experto APyS antes de usarse en decisiones reales.'
+                    )
+                }
+            }
+            print(json.dumps(result))
+        except Exception as e:
+            print(json.dumps({'success': False, 'error': str(e)}))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(json.dumps({'success': False, 'error': 'Insufficient arguments'}))
+        sys.exit(1)
+
+    command = sys.argv[1]
+    inp_file = sys.argv[2]
+
+    cli_options = {}
+    if len(sys.argv) > 3:
+        try:
+            cli_options = json.loads(sys.argv[3])
+        except Exception:
+            pass
+
+    service = WNTRResilienceService()
+
+    if command == 'skeletonize':
+        service.skeletonize(inp_file, cli_options)
+    elif command == 'simulate_failure':
+        service.simulate_failure(inp_file, cli_options)
+    elif command == 'resilience_indicators':
+        service.resilience_indicators(inp_file, cli_options)
+    elif command == 'fragility_curve':
+        service.fragility_curve(inp_file, cli_options)
+    else:
+        print(json.dumps({'success': False, 'error': f'Unknown command: {command}'}))

--- a/electron/handlers/wntr.handler.ts
+++ b/electron/handlers/wntr.handler.ts
@@ -4,6 +4,7 @@ import { wntrWrapper } from '../../backend/services/hydraulic/wntrWrapper'
 import { WNTRSimulationService } from '../../backend/services/hydraulic/simulationService'
 import { WNTRAnalysisService } from '../../backend/services/hydraulic/analysisService'
 import { WNTRReportService } from '../../backend/services/hydraulic/reportService'
+import { WNTRResilienceService } from '../../backend/services/hydraulic/resilienceService'
 import { getPythonStatus } from '../../backend/services/hydraulic/pythonDetector'
 import { guardrailsWrapper } from '../../backend/services/guardrails/guardrailsWrapper'
 
@@ -11,6 +12,7 @@ import { guardrailsWrapper } from '../../backend/services/guardrails/guardrailsW
 const simulationService = new WNTRSimulationService()
 const analysisService = new WNTRAnalysisService()
 const reportService = new WNTRReportService()
+const resilienceService = new WNTRResilienceService()
 
 export function setupWNTRHandlers() {
   // Check Python/WNTR availability
@@ -422,6 +424,93 @@ export function setupWNTRHandlers() {
       return result // Return the result directly, it already has the correct structure
     } catch (error) {
       console.error('Error generating simulation report:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  })
+
+  // --- Resilience routines epic (#26): skeletonization, service interruption,
+  // resilience indicators, fragility curve ---
+
+  // Skeletonize network (#24)
+  ipcMain.handle('wntr:skeletonize-network', async (event, options: any) => {
+    try {
+      if (!global.currentWNTRFile) {
+        return { success: false, error: 'No EPANET file loaded' }
+      }
+
+      const result = await resilienceService.skeletonizeNetwork(global.currentWNTRFile, options)
+      return result
+    } catch (error) {
+      console.error('Error skeletonizing network:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  })
+
+  // Simulate service interruption / component failure (#22)
+  ipcMain.handle('wntr:simulate-component-failure', async (event, options: any) => {
+    try {
+      if (!global.currentWNTRFile) {
+        return { success: false, error: 'No EPANET file loaded' }
+      }
+
+      const verdict = await guardrailsWrapper.validateExecution('wntr.simulateComponentFailure', {
+        file: global.currentWNTRFile,
+        components: options?.components,
+      })
+      if (!verdict.allow) {
+        return {
+          success: false,
+          blockedBy: 'guardrail:execution',
+          error: `Simulación rechazada por guardrail: ${verdict.reason}`,
+        }
+      }
+
+      const result = await resilienceService.simulateComponentFailure(global.currentWNTRFile, options)
+      return result
+    } catch (error) {
+      console.error('Error simulating component failure:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  })
+
+  // Resilience indicators: Todini, entropy, hydraulic redundancy (#23)
+  ipcMain.handle('wntr:calculate-resilience-indicators', async (event, options: any) => {
+    try {
+      if (!global.currentWNTRFile) {
+        return { success: false, error: 'No EPANET file loaded' }
+      }
+
+      const result = await resilienceService.calculateResilienceIndicators(global.currentWNTRFile, options)
+      return result
+    } catch (error) {
+      console.error('Error calculating resilience indicators:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  })
+
+  // Fragility curve (#25)
+  ipcMain.handle('wntr:generate-fragility-curve', async (event, options: any) => {
+    try {
+      if (!global.currentWNTRFile) {
+        return { success: false, error: 'No EPANET file loaded' }
+      }
+
+      const result = await resilienceService.generateFragilityCurve(global.currentWNTRFile, options)
+      return result
+    } catch (error) {
+      console.error('Error generating fragility curve:', error)
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error'

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -216,6 +216,13 @@ const electronAPI = {
 
     // Export
     exportJSON: () => ipcRenderer.invoke('wntr:export-json'),
+
+    // Resilience routines (epic #26): skeletonization, service interruption,
+    // resilience indicators, fragility curve
+    skeletonizeNetwork: (options?: any) => ipcRenderer.invoke('wntr:skeletonize-network', options),
+    simulateComponentFailure: (options: any) => ipcRenderer.invoke('wntr:simulate-component-failure', options),
+    calculateResilienceIndicators: (options?: any) => ipcRenderer.invoke('wntr:calculate-resilience-indicators', options),
+    generateFragilityCurve: (options?: any) => ipcRenderer.invoke('wntr:generate-fragility-curve', options),
   },
 
   // Document management for RAG

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -15,6 +15,7 @@ const FILES_TO_COPY = [
     'backend/services/hydraulic/wntrService.py',
     'backend/services/hydraulic/wntr_analysis_service.py',
     'backend/services/hydraulic/wntr_simulation_service.py',
+    'backend/services/hydraulic/wntr_resilience_service.py',
     'backend/services/guardrails/guardrailsService.py',
     'backend/services/guardrails/rails/config.yml',
     'backend/services/guardrails/rails/input.co',

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -15,7 +15,8 @@ import {
   FileUp, Play, Map, Network,
   RefreshCw, AlertCircle,
   Activity, Database,
-  Target, FolderOpen, ChevronDown
+  Target, FolderOpen, ChevronDown,
+  Scissors, Zap, ShieldAlert, AlertTriangle, Download
 } from 'lucide-react';
 import {
   Chart as ChartJS,
@@ -27,6 +28,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import { Line } from 'react-chartjs-2';
 
 ChartJS.register(
   CategoryScale,
@@ -274,6 +276,33 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   const [simulationTimestep, setSimulationTimestep] = useState<number>(60); // minutes
   const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] = useState(false);
 
+  // --- Resilience routines (epic #26): skeletonization, service interruption,
+  // resilience indicators, fragility curve ---
+  const [skeletonizeThresholdMm, setSkeletonizeThresholdMm] = useState<number>(100);
+  const [isSkeletonizing, setIsSkeletonizing] = useState(false);
+  const [skeletonizePreview, setSkeletonizePreview] = useState<any>(null);
+  const [skeletonizeError, setSkeletonizeError] = useState<string | null>(null);
+
+  const [failureComponentIds, setFailureComponentIds] = useState('');
+  const [failureDurationHours, setFailureDurationHours] = useState<number>(24);
+  const [failureStartHours, setFailureStartHours] = useState<number>(0);
+  const [failureRestoreHours, setFailureRestoreHours] = useState<string>('');
+  const [minPressureThreshold, setMinPressureThreshold] = useState<number>(10);
+  const [isSimulatingFailure, setIsSimulatingFailure] = useState(false);
+  const [failureResult, setFailureResult] = useState<any>(null);
+  const [failureError, setFailureError] = useState<string | null>(null);
+
+  const [compareWithFailure, setCompareWithFailure] = useState(false);
+  const [isCalculatingIndicators, setIsCalculatingIndicators] = useState(false);
+  const [resilienceIndicatorsResult, setResilienceIndicatorsResult] = useState<any>(null);
+  const [resilienceIndicatorsError, setResilienceIndicatorsError] = useState<string | null>(null);
+
+  const [fragilityMaterial, setFragilityMaterial] = useState('PVC');
+  const [fragilityMaxIntensity, setFragilityMaxIntensity] = useState<number>(100);
+  const [isGeneratingFragility, setIsGeneratingFragility] = useState(false);
+  const [fragilityResult, setFragilityResult] = useState<any>(null);
+  const [fragilityError, setFragilityError] = useState<string | null>(null);
+
   // Load network file
   const handleLoadNetwork = useCallback(async () => {
     try {
@@ -461,8 +490,196 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     }
   }, [networkData, onSimulationComplete, simulationDuration, simulationTimestep, currentProject, handleSaveCalculationToProject]);
 
+  // --- Resilience routines handlers (epic #26) ---
 
+  // #24: Esqueletización de redes
+  const handlePreviewSkeletonize = useCallback(async () => {
+    if (!networkData) return;
+    setIsSkeletonizing(true);
+    setSkeletonizeError(null);
+    setSkeletonizePreview(null);
+    try {
+      const res = await window.electronAPI.wntr.skeletonizeNetwork({
+        pipe_diameter_threshold_mm: skeletonizeThresholdMm
+      });
+      if (res.success) {
+        setSkeletonizePreview(res.data);
+      } else {
+        setSkeletonizeError(res.error || 'No se pudo esqueletizar la red');
+      }
+    } catch (err) {
+      setSkeletonizeError(err instanceof Error ? err.message : 'Error al esqueletizar la red');
+    } finally {
+      setIsSkeletonizing(false);
+    }
+  }, [networkData, skeletonizeThresholdMm]);
 
+  const handleSaveSkeletonizedNetwork = useCallback(async () => {
+    if (!skeletonizePreview || !currentProject || !networkData) return;
+    try {
+      const saveRes = await window.electronAPI.wntr.saveINPFile(
+        skeletonizePreview.inp_content,
+        `${networkData.name}_skeletonized.inp`
+      );
+      if (!saveRes.success || !saveRes.filePath) {
+        setSkeletonizeError(saveRes.error || 'Guardado cancelado');
+        return;
+      }
+
+      const newProject = await hydraulicService.createProject({
+        name: `${currentProject.name} (esqueletizada)`,
+        description: `Red esqueletizada a partir de "${currentProject.name}" (umbral ${skeletonizeThresholdMm}mm, reducción ${skeletonizePreview.reduction.pipes_pct}% tuberías / ${skeletonizePreview.reduction.junctions_pct}% nudos). Red original trazable: proyecto "${currentProject.name}" (${currentProject.id}).`,
+        type: 'analysis' as any,
+        location: { country: '', region: '' }
+      });
+
+      const loadRes = await window.electronAPI.wntr.loadINPFromPath(saveRes.filePath);
+      if (loadRes.success && loadRes.data) {
+        const networkAsset: NetworkAsset = {
+          id: `net_${Date.now()}`,
+          name: loadRes.data.name,
+          filePath: saveRes.filePath,
+          uploadDate: new Date().toISOString(),
+          nodeCount: loadRes.data.summary?.junctions || 0,
+          linkCount: loadRes.data.summary?.pipes || 0,
+          data: loadRes.data
+        };
+        setProjectAssets(prev => ({
+          ...prev,
+          [newProject.id]: { networks: [networkAsset], calculations: [] }
+        }));
+      }
+
+      await refreshProjects();
+      setSkeletonizePreview(null);
+    } catch (err) {
+      setSkeletonizeError(err instanceof Error ? err.message : 'Error al guardar la red esqueletizada');
+    }
+  }, [skeletonizePreview, currentProject, networkData, skeletonizeThresholdMm, refreshProjects]);
+
+  // #22: Simulación de interrupción del servicio
+  const handleSimulateFailure = useCallback(async () => {
+    if (!networkData) return;
+    const components = failureComponentIds
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .map(id => ({ id }));
+
+    if (components.length === 0) {
+      setFailureError('Especifica al menos un componente (ID de tubería, bomba o válvula)');
+      return;
+    }
+
+    setIsSimulatingFailure(true);
+    setFailureError(null);
+    try {
+      const res = await window.electronAPI.wntr.simulateComponentFailure({
+        components,
+        duration_hours: failureDurationHours,
+        failure_start_hours: failureStartHours,
+        restore_hours: failureRestoreHours ? Number(failureRestoreHours) : undefined,
+        min_pressure_threshold: minPressureThreshold
+      });
+
+      if (res.success) {
+        setFailureResult(res.data);
+        if (currentProject) {
+          const currentNetwork = currentProject.networks.find(n => n.name === networkData.name);
+          const networkId = currentNetwork?.id || 'unknown';
+          handleSaveCalculationToProject(
+            `Interrupción de Servicio: ${res.data.failed_components.join(', ')}`,
+            networkId,
+            res.data
+          );
+        }
+      } else {
+        setFailureError(res.error || 'No se pudo simular la interrupción del servicio');
+      }
+    } catch (err) {
+      setFailureError(err instanceof Error ? err.message : 'Error al simular la interrupción');
+    } finally {
+      setIsSimulatingFailure(false);
+    }
+  }, [networkData, failureComponentIds, failureDurationHours, failureStartHours, failureRestoreHours, minPressureThreshold, currentProject, handleSaveCalculationToProject]);
+
+  // #23: Indicadores de resiliencia
+  const handleCalculateResilienceIndicators = useCallback(async () => {
+    if (!networkData) return;
+    setIsCalculatingIndicators(true);
+    setResilienceIndicatorsError(null);
+    try {
+      const options: any = {
+        duration_hours: failureDurationHours,
+        min_pressure_threshold: minPressureThreshold
+      };
+      if (compareWithFailure && failureResult?.failed_components?.length) {
+        options.failed_components = failureResult.failed_components.map((id: string) => ({ id }));
+        options.failure_start_hours = failureStartHours;
+      }
+
+      const res = await window.electronAPI.wntr.calculateResilienceIndicators(options);
+      if (res.success) {
+        setResilienceIndicatorsResult(res.data);
+        if (currentProject) {
+          const currentNetwork = currentProject.networks.find(n => n.name === networkData.name);
+          const networkId = currentNetwork?.id || 'unknown';
+          handleSaveCalculationToProject('Indicadores de Resiliencia', networkId, res.data);
+        }
+      } else {
+        setResilienceIndicatorsError(res.error || 'No se pudieron calcular los indicadores de resiliencia');
+      }
+    } catch (err) {
+      setResilienceIndicatorsError(err instanceof Error ? err.message : 'Error al calcular los indicadores');
+    } finally {
+      setIsCalculatingIndicators(false);
+    }
+  }, [networkData, failureDurationHours, minPressureThreshold, compareWithFailure, failureResult, failureStartHours, currentProject, handleSaveCalculationToProject]);
+
+  const handleExportResilienceCSV = useCallback(() => {
+    if (!resilienceIndicatorsResult) return;
+    const b = resilienceIndicatorsResult.before;
+    const a = resilienceIndicatorsResult.after;
+    const d = resilienceIndicatorsResult.delta;
+    const rows = [
+      ['Métrica', 'Antes', 'Después', 'Delta'],
+      ['Índice de Todini', b.todini_index.toFixed(4), a ? a.todini_index.toFixed(4) : '', d ? d.todini_index.toFixed(4) : ''],
+      ['Entropía de red', b.network_entropy.toFixed(4), a ? a.network_entropy.toFixed(4) : '', d ? d.network_entropy.toFixed(4) : ''],
+      ['Redundancia hidráulica', b.hydraulic_redundancy.toFixed(4), a ? a.hydraulic_redundancy.toFixed(4) : '', d ? d.hydraulic_redundancy.toFixed(4) : ''],
+      ['Serviceability (presión)', b.serviceability.pressure_serviceability.toFixed(4), a ? a.serviceability.pressure_serviceability.toFixed(4) : '', d ? d.pressure_serviceability.toFixed(4) : '']
+    ];
+    const csv = rows.map(r => r.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `indicadores_resiliencia_${networkData?.name || 'red'}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [resilienceIndicatorsResult, networkData]);
+
+  // #25: Curva de fragilidad
+  const handleGenerateFragilityCurve = useCallback(async () => {
+    if (!networkData) return;
+    setIsGeneratingFragility(true);
+    setFragilityError(null);
+    try {
+      const res = await window.electronAPI.wntr.generateFragilityCurve({
+        hazard_type: 'seismic_pgv',
+        material: fragilityMaterial,
+        max_intensity: fragilityMaxIntensity
+      });
+      if (res.success) {
+        setFragilityResult(res.data);
+      } else {
+        setFragilityError(res.error || 'No se pudo generar la curva de fragilidad');
+      }
+    } catch (err) {
+      setFragilityError(err instanceof Error ? err.message : 'Error al generar la curva de fragilidad');
+    } finally {
+      setIsGeneratingFragility(false);
+    }
+  }, [networkData, fragilityMaterial, fragilityMaxIntensity]);
 
 
   // Dashboard Layout Render
@@ -607,12 +824,15 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
           <Tabs defaultValue="simulate" className="flex-1 flex flex-col min-h-0">
             <div className="px-4 pt-2 border-b bg-muted/10">
-              <TabsList className="grid w-full grid-cols-4">
+              <TabsList className="grid w-full grid-cols-5">
                 <TabsTrigger value="simulate" title="Simulation">
                   <Play className="h-4 w-4" />
                 </TabsTrigger>
                 <TabsTrigger value="analyze" title="Analysis">
                   <Target className="h-4 w-4" />
+                </TabsTrigger>
+                <TabsTrigger value="resilience" title="Resilience">
+                  <ShieldAlert className="h-4 w-4" />
                 </TabsTrigger>
 
                 <TabsTrigger value="layers" title="Layers">
@@ -941,6 +1161,332 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
               {/* RESULTS TAB - Aggregating Analysis/Sim Results */}
 
+              {/* RESILIENCE TAB (epic #26) */}
+              <TabsContent value="resilience" className="mt-0 space-y-4">
+                <div className="space-y-6">
+                  <h3 className="font-semibold text-sm flex items-center gap-2">
+                    <ShieldAlert className="h-4 w-4 text-amber-500" />
+                    Rutinas de Resiliencia
+                  </h3>
+
+                  {/* Skeletonization (#24) */}
+                  <div className="space-y-2 p-3 bg-muted/20 rounded-lg">
+                    <h4 className="text-xs font-semibold flex items-center gap-2 text-foreground">
+                      <Scissors className="h-3.5 w-3.5" /> Esqueletización de Red
+                    </h4>
+                    <p className="text-[11px] text-muted-foreground">
+                      Simplifica la red fusionando/eliminando tuberías bajo un diámetro umbral. Se guarda como un proyecto nuevo, sin modificar el original.
+                    </p>
+                    <div className="bg-background p-2 rounded border">
+                      <div className="text-[10px] text-muted-foreground mb-1">Umbral de diámetro (mm)</div>
+                      <input
+                        type="number"
+                        value={skeletonizeThresholdMm}
+                        onChange={(e) => setSkeletonizeThresholdMm(Number(e.target.value))}
+                        className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                      />
+                    </div>
+                    <Button size="sm" className="w-full" onClick={handlePreviewSkeletonize} disabled={isSkeletonizing}>
+                      {isSkeletonizing ? (
+                        <><RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" /> Esqueletizando...</>
+                      ) : (
+                        <><Scissors className="h-3.5 w-3.5 mr-2" /> Vista Previa</>
+                      )}
+                    </Button>
+
+                    {skeletonizeError && (
+                      <Alert variant="destructive" className="text-xs">
+                        <AlertCircle className="h-3 w-3 inline mr-1" /> {skeletonizeError}
+                      </Alert>
+                    )}
+
+                    {skeletonizePreview && (
+                      <Card>
+                        <CardContent className="p-3 text-xs space-y-2">
+                          <div className="grid grid-cols-2 gap-2">
+                            <div>
+                              <div className="text-[10px] text-muted-foreground">Tuberías</div>
+                              <div className="font-mono">
+                                {skeletonizePreview.before.pipes} → {skeletonizePreview.after.pipes}{' '}
+                                <span className="text-green-600">(-{skeletonizePreview.reduction.pipes_pct}%)</span>
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-[10px] text-muted-foreground">Nudos</div>
+                              <div className="font-mono">
+                                {skeletonizePreview.before.junctions} → {skeletonizePreview.after.junctions}{' '}
+                                <span className="text-green-600">(-{skeletonizePreview.reduction.junctions_pct}%)</span>
+                              </div>
+                            </div>
+                          </div>
+                          <Button size="sm" variant="outline" className="w-full" onClick={handleSaveSkeletonizedNetwork}>
+                            Guardar como nuevo proyecto
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    )}
+                  </div>
+
+                  {/* Service interruption simulation (#22) */}
+                  <div className="space-y-2 p-3 bg-muted/20 rounded-lg border-t pt-4">
+                    <h4 className="text-xs font-semibold flex items-center gap-2 text-foreground">
+                      <Zap className="h-3.5 w-3.5" /> Simulación de Interrupción del Servicio
+                    </h4>
+                    <p className="text-[11px] text-muted-foreground">
+                      Simula la falla de uno o más componentes (tubería, bomba, válvula) y estima el impacto sobre el servicio.
+                    </p>
+                    <div className="bg-background p-2 rounded border">
+                      <div className="text-[10px] text-muted-foreground mb-1">IDs de componentes (separados por coma)</div>
+                      <input
+                        type="text"
+                        value={failureComponentIds}
+                        onChange={(e) => setFailureComponentIds(e.target.value)}
+                        placeholder="ej. P-12, PUMP-1"
+                        className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Inicio falla (h)</div>
+                        <input
+                          type="number"
+                          value={failureStartHours}
+                          onChange={(e) => setFailureStartHours(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Restaurar en (h, opcional)</div>
+                        <input
+                          type="number"
+                          value={failureRestoreHours}
+                          onChange={(e) => setFailureRestoreHours(e.target.value)}
+                          placeholder="permanente"
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Duración simulación (h)</div>
+                        <input
+                          type="number"
+                          value={failureDurationHours}
+                          onChange={(e) => setFailureDurationHours(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Presión mínima (m)</div>
+                        <input
+                          type="number"
+                          value={minPressureThreshold}
+                          onChange={(e) => setMinPressureThreshold(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                    </div>
+                    <Button size="sm" className="w-full" onClick={handleSimulateFailure} disabled={isSimulatingFailure}>
+                      {isSimulatingFailure ? (
+                        <><RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" /> Simulando...</>
+                      ) : (
+                        <><Zap className="h-3.5 w-3.5 mr-2" /> Simular Interrupción</>
+                      )}
+                    </Button>
+
+                    {failureError && (
+                      <Alert variant="destructive" className="text-xs">
+                        <AlertCircle className="h-3 w-3 inline mr-1" /> {failureError}
+                      </Alert>
+                    )}
+
+                    {failureResult && (
+                      <Card>
+                        <CardContent className="p-3 text-xs space-y-2">
+                          <div className="flex justify-between">
+                            <span>Nudos afectados:</span>
+                            <span className="font-mono">{failureResult.affected_node_count} / {failureResult.total_junction_count}</span>
+                          </div>
+                          <div className="text-[10px] text-muted-foreground">Click en un nudo para resaltarlo en el mapa</div>
+                          <div className="flex flex-wrap gap-1">
+                            {failureResult.affected_nodes.slice(0, 8).map((n: any) => (
+                              <Badge
+                                key={n.id}
+                                variant={highlightedComponents.includes(n.id) ? "default" : "outline"}
+                                className="text-[10px] h-5 cursor-pointer hover:bg-primary/20"
+                                onClick={() => setHighlightedComponents(prev => prev.includes(n.id) ? prev.filter(x => x !== n.id) : [...prev, n.id])}
+                                title={`Presión residual: ${n.min_pressure.toFixed(2)}m · ${n.outage_hours.toFixed(1)}h fuera de servicio`}
+                              >
+                                {n.id}
+                              </Badge>
+                            ))}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    )}
+                  </div>
+
+                  {/* Resilience indicators (#23) */}
+                  <div className="space-y-2 p-3 bg-muted/20 rounded-lg border-t pt-4">
+                    <h4 className="text-xs font-semibold flex items-center gap-2 text-foreground">
+                      <Target className="h-3.5 w-3.5" /> Indicadores de Resiliencia
+                    </h4>
+                    <p className="text-[11px] text-muted-foreground">
+                      Índice de Todini, entropía de red y redundancia hidráulica. Compara antes/después del escenario de interrupción simulado arriba.
+                    </p>
+                    <label className="flex items-center gap-2 text-xs">
+                      <input
+                        type="checkbox"
+                        checked={compareWithFailure}
+                        onChange={(e) => setCompareWithFailure(e.target.checked)}
+                        disabled={!failureResult}
+                      />
+                      Comparar con la interrupción simulada {!failureResult && '(simula una interrupción primero)'}
+                    </label>
+                    <Button size="sm" className="w-full" onClick={handleCalculateResilienceIndicators} disabled={isCalculatingIndicators}>
+                      {isCalculatingIndicators ? (
+                        <><RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" /> Calculando...</>
+                      ) : (
+                        <><Target className="h-3.5 w-3.5 mr-2" /> Calcular Indicadores</>
+                      )}
+                    </Button>
+
+                    {resilienceIndicatorsError && (
+                      <Alert variant="destructive" className="text-xs">
+                        <AlertCircle className="h-3 w-3 inline mr-1" /> {resilienceIndicatorsError}
+                      </Alert>
+                    )}
+
+                    {resilienceIndicatorsResult && (
+                      <Card>
+                        <CardContent className="p-3 text-xs space-y-2">
+                          {[
+                            { label: 'Índice de Todini', key: 'todini_index' },
+                            { label: 'Entropía de red', key: 'network_entropy' },
+                            { label: 'Redundancia hidráulica', key: 'hydraulic_redundancy' },
+                          ].map(({ label, key }) => (
+                            <div key={key} className="flex justify-between">
+                              <span>{label}:</span>
+                              <span className="font-mono">
+                                {resilienceIndicatorsResult.before[key]?.toFixed(4)}
+                                {resilienceIndicatorsResult.after && (
+                                  <span className={resilienceIndicatorsResult.delta[key] < 0 ? 'text-red-500' : 'text-green-600'}>
+                                    {' → '}{resilienceIndicatorsResult.after[key]?.toFixed(4)}
+                                  </span>
+                                )}
+                              </span>
+                            </div>
+                          ))}
+                          <div className="flex justify-between">
+                            <span>Serviceability (presión):</span>
+                            <span className="font-mono">
+                              {(resilienceIndicatorsResult.before.serviceability.pressure_serviceability * 100).toFixed(1)}%
+                              {resilienceIndicatorsResult.after && (
+                                <span className={resilienceIndicatorsResult.delta.pressure_serviceability < 0 ? 'text-red-500' : 'text-green-600'}>
+                                  {' → '}{(resilienceIndicatorsResult.after.serviceability.pressure_serviceability * 100).toFixed(1)}%
+                                </span>
+                              )}
+                            </span>
+                          </div>
+                          <Button size="sm" variant="outline" className="w-full mt-2" onClick={handleExportResilienceCSV}>
+                            <Download className="h-3 w-3 mr-2" /> Exportar CSV
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    )}
+                  </div>
+
+                  {/* Fragility curve (#25) */}
+                  <div className="space-y-2 p-3 bg-muted/20 rounded-lg border-t pt-4">
+                    <h4 className="text-xs font-semibold flex items-center gap-2 text-foreground">
+                      <AlertTriangle className="h-3.5 w-3.5" /> Curva de Fragilidad (Sismo)
+                    </h4>
+                    <p className="text-[11px] text-muted-foreground">
+                      Probabilidad de falla de tubería vs. intensidad sísmica (PGV). Modelo genérico ALA (2001) por material —{' '}
+                      <strong>requiere validación de un experto APyS antes de usarse en decisiones reales.</strong>
+                    </p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Material predominante</div>
+                        <select
+                          value={fragilityMaterial}
+                          onChange={(e) => setFragilityMaterial(e.target.value)}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        >
+                          <option value="PVC">PVC</option>
+                          <option value="HDPE">PEAD/HDPE</option>
+                          <option value="DI">Hierro Dúctil</option>
+                          <option value="CI">Hierro Fundido</option>
+                          <option value="AC">Asbesto-Cemento</option>
+                          <option value="STEEL">Acero</option>
+                          <option value="CONCRETE">Concreto</option>
+                          <option value="DEFAULT">Genérico</option>
+                        </select>
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">PGV máximo (cm/s)</div>
+                        <input
+                          type="number"
+                          value={fragilityMaxIntensity}
+                          onChange={(e) => setFragilityMaxIntensity(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                    </div>
+                    <Button size="sm" className="w-full" onClick={handleGenerateFragilityCurve} disabled={isGeneratingFragility}>
+                      {isGeneratingFragility ? (
+                        <><RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" /> Generando...</>
+                      ) : (
+                        <><AlertTriangle className="h-3.5 w-3.5 mr-2" /> Generar Curva</>
+                      )}
+                    </Button>
+
+                    {fragilityError && (
+                      <Alert variant="destructive" className="text-xs">
+                        <AlertCircle className="h-3 w-3 inline mr-1" /> {fragilityError}
+                      </Alert>
+                    )}
+
+                    {fragilityResult && (
+                      <Card>
+                        <CardContent className="p-3 text-xs space-y-2">
+                          <div className="h-40">
+                            <Line
+                              data={{
+                                labels: fragilityResult.intensities.map((v: number) => v.toFixed(0)),
+                                datasets: [{
+                                  label: 'Prob. falla de tubería',
+                                  data: fragilityResult.pipe_failure_probability,
+                                  borderColor: 'rgb(234, 88, 12)',
+                                  backgroundColor: 'rgba(234, 88, 12, 0.3)',
+                                  borderWidth: 2,
+                                  pointRadius: 0,
+                                  tension: 0.3
+                                }]
+                              }}
+                              options={{
+                                responsive: true,
+                                maintainAspectRatio: false,
+                                animation: { duration: 0 },
+                                plugins: { legend: { display: false } },
+                                scales: {
+                                  x: { title: { display: true, text: 'PGV (cm/s)', font: { size: 9 } }, ticks: { maxTicksLimit: 6, font: { size: 9 } } },
+                                  y: { min: 0, max: 1, ticks: { font: { size: 9 } } }
+                                }
+                              }}
+                            />
+                          </div>
+                          <div className="flex justify-between">
+                            <span>Tuberías afectadas esperadas (PGV máx.):</span>
+                            <span className="font-mono">
+                              {fragilityResult.expected_failed_pipes[fragilityResult.expected_failed_pipes.length - 1]?.toFixed(1)} / {fragilityResult.pipe_count}
+                            </span>
+                          </div>
+                          <div className="text-[10px] text-muted-foreground italic">{fragilityResult.methodology}</div>
+                        </CardContent>
+                      </Card>
+                    )}
+                  </div>
+                </div>
+              </TabsContent>
 
               {/* LAYERS / VIEW SETTINGS TAB */}
               <TabsContent value="layers" className="mt-0 space-y-4">


### PR DESCRIPTION
## Summary

Implementa las 4 sub-features del epic #26 ("Rutinas de resiliencia WNTR en módulo WNTR Network"), como PR **draft** para pruebas antes de decidir el merge — es una feature grande y nueva, sin uso previo en producción.

- **#24 Esqueletización de redes**: `wntr.morph.skeletonize` (ruta pura Python, `use_epanet=False` — evita un crash SIGKILL del binario EPANET bajo macOS, verificado en este entorno). El resultado se guarda como un **nuevo proyecto independiente**, trazable al original vía su descripción, sin sobrescribir la red original.
- **#22 Simulación de interrupción del servicio**: cierre de componentes (tubería/bomba/válvula) usando `wntr.network.controls` (en vez del `link.status = 0` directo que había antes), comparado contra una simulación baseline para reportar nudos afectados, presión residual y horas de interrupción. El resultado queda guardado como registro histórico del proyecto.
- **#23 Indicadores de resiliencia**: índice de Todini (ya existía), + **entropía de red** (`wntr.metrics.hydraulic.entropy`) y **redundancia hidráulica** (`modified_resilience_index`), nuevos. Soporta comparación antes/después del escenario de interrupción simulado en #22, y exportación a CSV.
- **#25 Curva de fragilidad**: modelo sísmico lognormal tipo ALA (2001) por material de tubería predominante de la red. **El propio issue #25 pide validación de un experto APyS antes de usar esto en decisiones reales** — así queda documentado explícitamente en el código y en la UI (nota visible bajo el formulario).

## Arquitectura

- Nuevo script `backend/services/hydraulic/wntr_resilience_service.py` (4 comandos: `skeletonize`, `simulate_failure`, `resilience_indicators`, `fragility_curve`), probado end-to-end contra `test-files/Net1v3.inp` antes de conectar la capa TS.
- Wrapper TS `backend/services/hydraulic/resilienceService.ts` (mismo patrón que `analysisService.ts`/`simulationService.ts`).
- 4 canales IPC nuevos en `electron/handlers/wntr.handler.ts`: `wntr:skeletonize-network`, `wntr:simulate-component-failure` (con guardrail de ejecución), `wntr:calculate-resilience-indicators`, `wntr:generate-fragility-curve`.
- Expuestos en `electron/preload.ts` bajo `window.electronAPI.wntr.*`.
- Nueva pestaña **"Resilience"** en `WNTRMainInterface.tsx` (5ª pestaña junto a Simulate/Analyze/Layers) con las 4 rutinas.
- `scripts/copy-assets.js` actualizado para empaquetar el nuevo script Python en builds de producción.

## Decisiones de diseño relevantes

- La esqueletización crea un **proyecto nuevo** (no una fila en la tabla `HydraulicNetwork`, que existe en el schema pero está desconectada de la UI real) para reutilizar el flujo de proyectos ya funcional y evitar una migración de Prisma.
- Los resultados de interrupción/indicadores se persisten con el mismo patrón `projectAssets` (localStorage) que ya usan las pestañas Simulate/Analyze existentes, para mantener consistencia dentro del componente.
- La curva de fragilidad NO usa `wntr.scenario.FragilityCurve` (API interna poco documentada) sino `scipy.stats.lognorm` directamente con coeficientes ALA/HAZUS publicados — más verificable y defendible.

## Test plan
- [x] Los 4 comandos Python probados manualmente end-to-end (`skeletonize`, `simulate_failure`, `resilience_indicators` con comparación antes/después, `fragility_curve`) contra `test-files/Net1v3.inp`
- [x] `npm run typecheck` sin errores
- [x] `npx eslint` sobre los archivos nuevos/modificados — solo warnings preexistentes (`any`), sin errores
- [x] `npm run build:electron-ts` y `npm run build:vite` compilan correctamente
- [ ] Probar manualmente en la app: cargar una red, ejecutar cada una de las 4 rutinas desde la pestaña "Resilience" y confirmar resultados en la UI
- [ ] QA con un caso real de red APyS (pendiente, según Definición de "Hecho" del epic #26)
- [ ] Validación de los coeficientes de la curva de fragilidad (#25) con un experto APyS antes de cualquier uso en decisiones reales

🤖 Generated with [Claude Code](https://claude.com/claude-code)