### PR TITLE
Arranque de Python/WNTR en Windows, indexado RAG y rutinas 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,44 @@ jobs:
     - name: Run TypeScript check
       run: npm run typecheck
 
-  test-frontend:
-    name: Test Frontend
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
-        
+
+    - name: Install dependencies
+      run: npm ci --legacy-peer-deps
+
+    # La bateria de vitest no era un check del CI: se ejecutaba solo en local.
+    # Entre otras cosas verifica que la entrada superior del CHANGELOG.md coincide
+    # con la version de package.json, de modo que una release no pueda documentar
+    # una version distinta de la que empaqueta.
+    - name: Run test suite
+      run: npm test
+
+  test-frontend:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
+
     - name: Install dependencies
       run: npm ci --legacy-peer-deps
 
@@ -88,7 +112,9 @@ jobs:
 
   build-electron:
     name: Build Electron Apps
-    needs: [lint-and-typecheck, test-frontend]
+    # Los tests entran como requisito previo: empaquetar en tres sistemas cuesta
+    # varios minutos y no tiene sentido gastarlos si la bateria ya falla.
+    needs: [lint-and-typecheck, unit-tests, test-frontend]
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ prisma/app.db-journal
 .env.development.local
 .env.test.local
 .env.production.local
+.env.bak
 
 # OS generated files
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+Todas las versiones liberadas de Boorie Cliente. El formato sigue
+[Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y el versionado es
+[SemVer](https://semver.org/lang/es/).
+
+La entrada superior debe coincidir con la versión de `package.json`. El proceso de
+actualización está descrito en `docs/ACERCA_DE_HISTORIAL_VERSIONES.md`.
+
+## [1.5.1] - 2026-08-10
+
+Estabilización del arranque de Python/WNTR en Windows, corrección del indexado RAG y mejoras
+en las rutinas de resiliencia.
+
+- WNTR vuelve a detectarse tras reiniciar la aplicación en Windows: la ruta del entorno de
+  Python ahora se conserva entre sesiones.
+- El asistente de preparación explica por qué falla una instalación en lugar de mostrar sólo
+  «verification-failed», e indica qué paquete falta y por qué.
+- Se requiere Python 3.10 – 3.13. La 3.14 no sirve todavía, porque WNTR no publica paquete
+  para esa versión. Un entorno anterior fuera de ese rango se conserva y se recrea.
+- «Reindexar» en el Wisdom Center vuelve a reindexar: antes borraba los fragmentos del
+  documento y reportaba éxito sin recrearlos.
+- El estado de la base vectorial que muestra la aplicación se consulta de verdad, en vez de
+  darse por bueno.
+- Los indicadores de resiliencia se presentan en tabla con encabezados, distinguiendo el
+  escenario anterior del posterior a la interrupción simulada.
+- Los nudos afectados por una interrupción del servicio se resaltan sobre el mapa.
+- La curva de fragilidad y los indicadores de resiliencia se pueden exportar a CSV.
+- Cada rutina de resiliencia avisa de cuánto puede tardar antes de ejecutarse.
+- Nueva sección «Acerca de» en Configuración, con la versión instalada y este historial.
+
+Validada mediante nueve candidatos de liberación (rc.1 – rc.9).
+
+## [1.5.0] - 2026-07-27
+
+Rutinas de resiliencia para el módulo WNTR Network.
+
+- Esqueletización de redes, con guardado de la red simplificada como proyecto nuevo.
+- Simulación de interrupción del servicio por falla de componentes.
+- Indicadores de resiliencia de la red: índice de Todini, entropía y redundancia hidráulica.
+- Curva de fragilidad de componentes frente a intensidad sísmica.
+- Corregida la interfaz que se quedaba congelada al cambiar el modelo de embeddings.
+- El chat vuelve a recibir el contexto del proyecto activo.
+
+## [1.4.4] - 2026-07-09
+
+Base vectorial integrada en la aplicación.
+
+- Milvus embebido: ya no hace falta Docker ni un servicio externo para el indexado.
+- Mejoras en la visualización de redes sobre mapa y en el chat.
+- Documentación de instalación actualizada en castellano, inglés y catalán.
+
+## [1.4.3] - 2026-06-30
+
+Correcciones de indexado en Windows y de contexto de proyecto.
+
+- Los proyectos vuelven a aparecer en el chat.
+- Corregida la indexación del Wisdom Center en Windows.
+- Resueltas varias vulnerabilidades en dependencias.
+- El registro de actividad de la aplicación deja de escribir traza de depuración en uso
+  normal, reduciendo el tamaño de los logs.
+
+## [1.4.2] - 2026-05-11
+
+Estabilización de la integración continua y corrección de defectos asociados.
+
+- Corregido el empaquetado, que se invocaba dos veces y podía publicar sin querer.
+- Resueltos los errores de tipos y de estilo que impedían compilar el proceso principal,
+  junto con cinco defectos reales detectados al hacerlo.
+- Restaurada la auditoría de seguridad en el proceso de integración continua.

--- a/backend/services/hydraulic/analysisService.ts
+++ b/backend/services/hydraulic/analysisService.ts
@@ -95,14 +95,16 @@ export interface VulnerabilityAnalysis {
 }
 
 export class WNTRAnalysisService {
-  private pythonPath: string;
   private servicePath: string;
 
-  constructor() {
-    // Use shared Python detection utility
+  /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
+  private get pythonPath(): string {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { findPythonPath } = require('./pythonDetector');
-    this.pythonPath = findPythonPath();
+    return findPythonPath();
+  }
+
+  constructor() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolvePythonScriptPath } = require('./pythonScriptPath');
     this.servicePath = resolvePythonScriptPath('wntr_analysis_service.py');

--- a/backend/services/hydraulic/calculatorWrapper.ts
+++ b/backend/services/hydraulic/calculatorWrapper.ts
@@ -3,19 +3,20 @@ import * as path from 'path'
 import { HydraulicFormula, CalculationResult } from '../../../src/types/hydraulic'
 
 export class HydraulicCalculatorWrapper {
-  private pythonPath: string
   private scriptPath: string
 
-  constructor() {
-    // Use shared Python detection utility
+  /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
+  private get pythonPath(): string {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { findPythonPath } = require('./pythonDetector')
-    this.pythonPath = findPythonPath()
+    return findPythonPath()
+  }
+
+  constructor() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolvePythonScriptPath } = require('./pythonScriptPath')
     this.scriptPath = resolvePythonScriptPath('hydraulicCalculator.py')
     console.log('HydraulicCalculatorWrapper initialized with:', {
-      pythonPath: this.pythonPath,
       scriptPath: this.scriptPath
     })
   }

--- a/backend/services/hydraulic/pythonDetector.integration.test.ts
+++ b/backend/services/hydraulic/pythonDetector.integration.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  findPythonPath,
+  getPythonStatus,
+  resetPythonPathCache,
+  savePythonPath,
+} from './pythonDetector'
+
+/**
+ * Tests con un intérprete real (el venv-wntr del repo, sin mocks). Reproducen
+ * el fallo que dejaba a los usuarios de Windows con "Python/WNTR no
+ * instalado": el asistente de preparación crea el venv dentro de userData,
+ * pero al reiniciar la app `PYTHON_PATH` ya no existe y el detector tiene que
+ * volver a encontrarlo por sí mismo.
+ *
+ * Se omiten si el repo no tiene venv-wntr preparado (./setup-python-wntr.sh).
+ */
+const REPO_VENV = path.resolve(__dirname, '..', '..', '..', 'venv-wntr')
+const REPO_VENV_PYTHON = path.join(REPO_VENV, process.platform === 'win32' ? 'Scripts' : 'bin', process.platform === 'win32' ? 'python.exe' : 'python')
+const hasLocalVenv = fs.existsSync(REPO_VENV_PYTHON)
+
+/** `import wntr` arrastra pandas/scipy/matplotlib: tarda varios segundos. */
+const IMPORT_WNTR_TIMEOUT = 60_000
+
+describe.skipIf(!hasLocalVenv)('pythonDetector con intérprete real', () => {
+  let userData = ''
+  const savedEnv = { pythonPath: process.env.PYTHON_PATH, userData: process.env.BOORIE_USER_DATA }
+
+  beforeEach(() => {
+    userData = fs.mkdtempSync(path.join(os.tmpdir(), 'boorie-userdata-'))
+    process.env.BOORIE_USER_DATA = userData
+    // El escenario a cubrir es precisamente el arranque sin PYTHON_PATH
+    delete process.env.PYTHON_PATH
+    resetPythonPathCache()
+  })
+
+  afterEach(() => {
+    if (savedEnv.pythonPath === undefined) delete process.env.PYTHON_PATH
+    else process.env.PYTHON_PATH = savedEnv.pythonPath
+    if (savedEnv.userData === undefined) delete process.env.BOORIE_USER_DATA
+    else process.env.BOORIE_USER_DATA = savedEnv.userData
+    resetPythonPathCache()
+    fs.rmSync(userData, { recursive: true, force: true })
+  })
+
+  it('recupera el intérprete persistido tras reiniciar la app', () => {
+    // Lo que hace setup:install al terminar
+    savePythonPath(REPO_VENV_PYTHON)
+
+    // Arranque nuevo: caché limpia y sin PYTHON_PATH en el entorno
+    resetPythonPathCache()
+
+    expect(findPythonPath()).toBe(REPO_VENV_PYTHON)
+
+    const status = getPythonStatus()
+    expect(status.pythonFound).toBe(true)
+    expect(status.wntrAvailable).toBe(true)
+    expect(status.instructions).toBeNull()
+  }, IMPORT_WNTR_TIMEOUT)
+
+  it('descubre el venv gestionado en userData sin configuración previa', () => {
+    // Simula el venv que crea el asistente dentro de userData
+    fs.symlinkSync(REPO_VENV, path.join(userData, 'venv-wntr'), 'dir')
+    resetPythonPathCache()
+
+    const expected = path.join(userData, 'venv-wntr', path.basename(path.dirname(REPO_VENV_PYTHON)), path.basename(REPO_VENV_PYTHON))
+    expect(findPythonPath()).toBe(expected)
+    expect(getPythonStatus().wntrAvailable).toBe(true)
+  }, IMPORT_WNTR_TIMEOUT)
+
+  it('descarta una ruta persistida que ya no existe', () => {
+    savePythonPath(path.join(userData, 'venv-borrado', 'bin', 'python'))
+    resetPythonPathCache()
+
+    expect(findPythonPath()).not.toContain('venv-borrado')
+  }, IMPORT_WNTR_TIMEOUT)
+})

--- a/backend/services/hydraulic/pythonDetector.priority.test.ts
+++ b/backend/services/hydraulic/pythonDetector.priority.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  findPythonPath,
+  findPythonForMilvus,
+  getMissingWntrModules,
+  getPythonStatus,
+  resetPythonPathCache,
+  savePythonPath,
+} from './pythonDetector'
+
+/**
+ * Prioridad de selección del intérprete, con "pythons" simulados: scripts que
+ * responden a `--version` y a `-c "import a, b"` según los módulos que digamos
+ * que tienen. Así se prueba la lógica sin depender de lo que haya instalado en
+ * la máquina, y de forma instantánea.
+ *
+ * El caso que motivó estos tests: un tester con WNTR ya instalado en su
+ * sistema al que Boorie se lo apartaba en favor de su propio venv.
+ */
+describe.skipIf(process.platform === 'win32')('prioridad del detector de Python', () => {
+  let tmp = ''
+  let originalCwd = ''
+  let originalHome = ''
+
+  function fakePython(dir: string, modules: string[]): string {
+    fs.mkdirSync(dir, { recursive: true })
+    const file = path.join(dir, 'python3')
+    fs.writeFileSync(
+      file,
+      [
+        '#!/bin/sh',
+        'if [ "$1" = "--version" ]; then echo "Python 3.11.9"; exit 0; fi',
+        'if [ "$1" = "-c" ]; then',
+        `  available="${modules.join(' ')}"`,
+        '  requested=$(echo "$2" | sed "s/^import //" | tr -d ",")',
+        '  for m in $requested; do',
+        '    echo "$available" | tr " " "\\n" | grep -qx "$m" || exit 1',
+        '  done',
+        '  exit 0',
+        'fi',
+        'exit 1',
+      ].join('\n'),
+      { mode: 0o755 },
+    )
+    // El detector prueba primero Scripts/python.exe y bin/python; con crear
+    // bin/python3 basta para que lo encuentre en la tercera variante.
+    return file
+  }
+
+  const FULL_STACK = ['wntr', 'numpy', 'scipy', 'pandas', 'networkx']
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    originalHome = process.env.HOME ?? ''
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'boorie-prio-'))
+    // cwd limpio: el detector mira ./venv y ./venv-wntr relativos a él
+    fs.mkdirSync(path.join(tmp, 'cwd'), { recursive: true })
+    process.chdir(path.join(tmp, 'cwd'))
+    // HOME limpio: si no, ~/venv o ~/.venv de la máquina real ganarían la
+    // carrera y el test dependería de quién lo ejecuta.
+    fs.mkdirSync(path.join(tmp, 'home'), { recursive: true })
+    process.env.HOME = path.join(tmp, 'home')
+    process.env.BOORIE_USER_DATA = path.join(tmp, 'userdata')
+    delete process.env.PYTHON_PATH
+    resetPythonPathCache()
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    process.env.HOME = originalHome
+    delete process.env.BOORIE_USER_DATA
+    resetPythonPathCache()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('usa el venv gestionado cuando el sistema no tiene WNTR', () => {
+    const managed = fakePython(path.join(tmp, 'userdata', 'venv-wntr', 'bin'), FULL_STACK)
+    expect(findPythonPath()).toBe(managed)
+  })
+
+  it('prefiere el Python del sistema sobre el venv gestionado', () => {
+    const system = fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
+    fakePython(path.join(tmp, 'userdata', 'venv-wntr', 'bin'), FULL_STACK)
+
+    // './venv/bin/python3' es un candidato de sistema relativo al cwd
+    expect(path.resolve(findPythonPath())).toBe(path.resolve(system))
+  })
+
+  it('descarta un venv que importa wntr pero le falta el resto del stack', () => {
+    const system = fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
+    const incomplete = fakePython(path.join(tmp, 'userdata', 'venv-wntr', 'bin'), ['wntr', 'numpy'])
+
+    expect(getMissingWntrModules(incomplete)).toEqual(['scipy', 'pandas', 'networkx'])
+    expect(path.resolve(findPythonPath())).toBe(path.resolve(system))
+  })
+
+  it('la ruta fijada por el usuario gana a la autodetección', () => {
+    fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
+    const chosen = fakePython(path.join(tmp, 'elegido'), FULL_STACK)
+
+    savePythonPath(chosen, 'user')
+    resetPythonPathCache()
+
+    expect(findPythonPath()).toBe(chosen)
+    const status = getPythonStatus()
+    expect(status.userConfigured).toBe(true)
+    expect(status.wntrAvailable).toBe(true)
+  })
+
+  it('Milvus usa el venv gestionado aunque WNTR use el del sistema', () => {
+    const system = fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
+    const managed = fakePython(
+      path.join(tmp, 'userdata', 'venv-wntr', 'bin'),
+      [...FULL_STACK, 'milvus_lite'],
+    )
+
+    expect(path.resolve(findPythonPath())).toBe(path.resolve(system))
+    expect(findPythonForMilvus()).toBe(managed)
+  })
+
+  it('informa de los módulos que faltan en el intérprete en uso', () => {
+    fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), ['numpy', 'pandas'])
+
+    const status = getPythonStatus()
+    expect(status.pythonFound).toBe(true)
+    expect(status.wntrAvailable).toBe(false)
+    expect(status.missingModules).toEqual(['wntr', 'scipy', 'networkx'])
+    expect(status.instructions).toContain('pip install wntr scipy networkx')
+  })
+})

--- a/backend/services/hydraulic/pythonDetector.priority.test.ts
+++ b/backend/services/hydraulic/pythonDetector.priority.test.ts
@@ -114,11 +114,21 @@ describe.skipIf(process.platform === 'win32')('prioridad del detector de Python'
     const system = fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
     const managed = fakePython(
       path.join(tmp, 'userdata', 'venv-wntr', 'bin'),
-      [...FULL_STACK, 'milvus_lite'],
+      [...FULL_STACK, 'milvus_lite', 'pymilvus'],
     )
 
     expect(path.resolve(findPythonPath())).toBe(path.resolve(system))
     expect(findPythonForMilvus()).toBe(managed)
+  })
+
+  it('no acepta para Milvus un venv con milvus_lite pero sin pymilvus', () => {
+    // milvus-lite 3.x importa, pero su servidor gRPC necesita pymilvus: sin él
+    // Milvus muere al arrancar y el RAG se queda con 0 chunks.
+    const system = fakePython(path.join(tmp, 'cwd', 'venv', 'bin'), FULL_STACK)
+    fakePython(path.join(tmp, 'userdata', 'venv-wntr', 'bin'), [...FULL_STACK, 'milvus_lite'])
+
+    // El venv no gana por tener milvus_lite: se cae al intérprete general
+    expect(path.resolve(findPythonForMilvus())).toBe(path.resolve(system))
   })
 
   it('informa de los módulos que faltan en el intérprete en uso', () => {

--- a/backend/services/hydraulic/pythonDetector.test.ts
+++ b/backend/services/hydraulic/pythonDetector.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { findPythonPath, resetPythonPathCache } from './pythonDetector'
+import * as path from 'path'
+import * as fs from 'fs'
+import { findPythonPath, resetPythonPathCache, savePythonPath, getManagedVenvDir } from './pythonDetector'
 
 // Mock fs and child_process
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal() as any
-  return {
-    ...actual,
-    default: { ...actual.default, existsSync: vi.fn().mockReturnValue(false) },
-    existsSync: vi.fn().mockReturnValue(false),
+  const mocks = {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
   }
+  return { ...actual, default: { ...actual.default, ...mocks }, ...mocks }
 })
 
 vi.mock('child_process', async (importOriginal) => {
@@ -19,10 +23,16 @@ vi.mock('child_process', async (importOriginal) => {
   }
 })
 
+const USER_DATA = path.join('/tmp', 'boorie-userdata')
+const CONFIG_FILE = path.join(USER_DATA, 'python-path.json')
+
 describe('pythonDetector', () => {
   beforeEach(() => {
     resetPythonPathCache()
     vi.unstubAllEnvs()
+    delete process.env.PYTHON_PATH
+    delete process.env.BOORIE_USER_DATA
+    vi.mocked(fs.existsSync).mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -55,11 +65,39 @@ describe('pythonDetector', () => {
   })
 
   it('should return a string path when no PYTHON_PATH is set', () => {
-    // When PYTHON_PATH is not set, findPythonPath should still return a valid string
-    delete process.env.PYTHON_PATH
-    resetPythonPathCache()
     const result = findPythonPath()
     expect(typeof result).toBe('string')
     expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('resolves the managed venv directory inside userData', () => {
+    vi.stubEnv('BOORIE_USER_DATA', USER_DATA)
+    expect(getManagedVenvDir()).toBe(path.join(USER_DATA, 'venv-wntr'))
+  })
+
+  it('has no managed venv directory outside Electron', () => {
+    expect(getManagedVenvDir()).toBeNull()
+  })
+
+  it('persists the python path under userData', () => {
+    vi.stubEnv('BOORIE_USER_DATA', USER_DATA)
+    savePythonPath(path.join(USER_DATA, 'venv-wntr', 'bin', 'python'))
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      CONFIG_FILE,
+      expect.stringContaining(path.join(USER_DATA, 'venv-wntr', 'bin', 'python')),
+      'utf-8',
+    )
+  })
+
+  it('ignores a persisted path that no longer exists on disk', () => {
+    vi.stubEnv('BOORIE_USER_DATA', USER_DATA)
+    vi.mocked(fs.existsSync).mockImplementation(((p: string) => String(p) === CONFIG_FILE) as any)
+    vi.mocked(fs.readFileSync).mockImplementation(((p: string) => {
+      if (String(p) === CONFIG_FILE) return JSON.stringify({ pythonPath: '/deleted/venv/bin/python' })
+      throw new Error(`unexpected read: ${p}`)
+    }) as any)
+
+    expect(findPythonPath()).not.toBe('/deleted/venv/bin/python')
   })
 })

--- a/backend/services/hydraulic/pythonDetector.ts
+++ b/backend/services/hydraulic/pythonDetector.ts
@@ -10,6 +10,16 @@ const MANAGED_VENV_DIR = 'venv-wntr'
 const PYTHON_CONFIG_FILE = 'python-path.json'
 
 /**
+ * Módulos que los servicios Python de Boorie importan en tiempo de ejecución.
+ * Comprobar sólo `wntr` era insuficiente: un venv a medio instalar importaba
+ * wntr pero reventaba luego con ModuleNotFoundError, y además desplazaba a la
+ * instalación buena que el usuario ya tenía en su sistema.
+ */
+const WNTR_RUNTIME_MODULES = ['wntr', 'numpy', 'scipy', 'pandas', 'networkx']
+
+export type PythonSource = 'user' | 'auto'
+
+/**
  * Directorio userData de Electron. Se resuelve de forma perezosa porque este
  * módulo también se carga desde tests y desde scripts fuera de Electron.
  */
@@ -48,45 +58,63 @@ function getPythonConfigFile(): string | null {
 }
 
 /**
- * Persiste la ruta del intérprete que Boorie debe usar. Sin esto la ruta del
- * venv recién creado sólo vivía en `process.env.PYTHON_PATH` y se perdía al
- * cerrar la app: al siguiente arranque WNTR volvía a "no instalado".
+ * Persiste la ruta del intérprete que Boorie debe usar.
+ *
+ * `source: 'user'` marca una ruta elegida a mano en Ajustes → General: gana a
+ * la autodetección, porque el usuario sabe mejor que la heurística dónde tiene
+ * su entorno (conda, venv propio, instalación fuera de las rutas habituales).
+ * `source: 'auto'` es la que guarda el asistente tras crear su venv.
  */
-export function savePythonPath(pythonPath: string): void {
+export function savePythonPath(pythonPath: string, source: PythonSource = 'auto'): void {
   const configFile = getPythonConfigFile()
   if (!configFile) return
   try {
     fs.mkdirSync(path.dirname(configFile), { recursive: true })
-    fs.writeFileSync(configFile, JSON.stringify({ pythonPath }, null, 2), 'utf-8')
-    console.log(`[PythonDetector] Saved Python path to ${configFile}: ${pythonPath}`)
+    fs.writeFileSync(configFile, JSON.stringify({ pythonPath, source }, null, 2), 'utf-8')
+    console.log(`[PythonDetector] Saved Python path (${source}) to ${configFile}: ${pythonPath}`)
   } catch (error) {
     console.warn('[PythonDetector] Could not persist Python path:', error)
   }
 }
 
-function readSavedPythonPath(): string | null {
+/** Borra la ruta fijada a mano y devuelve a Boorie a la autodetección. */
+export function clearUserPythonPath(): void {
+  const configFile = getPythonConfigFile()
+  if (!configFile) return
+  try {
+    if (fs.existsSync(configFile)) fs.rmSync(configFile)
+  } catch (error) {
+    console.warn('[PythonDetector] Could not clear Python path:', error)
+  }
+}
+
+function readSavedPythonPath(): { pythonPath: string; source: PythonSource } | null {
   const configFile = getPythonConfigFile()
   if (!configFile) return null
   try {
     if (!fs.existsSync(configFile)) return null
     const parsed = JSON.parse(fs.readFileSync(configFile, 'utf-8'))
-    return typeof parsed?.pythonPath === 'string' && parsed.pythonPath.length > 0
-      ? parsed.pythonPath
-      : null
+    if (typeof parsed?.pythonPath !== 'string' || parsed.pythonPath.length === 0) return null
+    return { pythonPath: parsed.pythonPath, source: parsed.source === 'user' ? 'user' : 'auto' }
   } catch {
     return null
   }
 }
 
+export function getUserPythonPath(): string | null {
+  const saved = readSavedPythonPath()
+  return saved?.source === 'user' ? saved.pythonPath : null
+}
+
 /**
- * Intérpretes "gestionados": el guardado en configuración y los venv que
- * Boorie crea (userData en producción, raíz del repo en desarrollo).
+ * Venv que gestiona Boorie: el guardado por el asistente y los venv-wntr de
+ * userData (producción) o del repo (desarrollo).
  */
 function getManagedPythonCandidates(): string[] {
   const candidates: string[] = []
 
   const saved = readSavedPythonPath()
-  if (saved) candidates.push(saved)
+  if (saved?.source === 'auto') candidates.push(saved.pythonPath)
 
   const managedVenv = getManagedVenvDir()
   if (managedVenv) candidates.push(...venvPythonCandidates(managedVenv))
@@ -98,25 +126,45 @@ function getManagedPythonCandidates(): string[] {
 }
 
 /**
- * Shared Python path detection utility.
- * Finds the best available Python installation with WNTR support.
- * Caches the result so detection only runs once per app session.
+ * Resuelve el intérprete de Python para WNTR.
+ *
+ * Orden: PYTHON_PATH → ruta fijada por el usuario en Ajustes → Python del
+ * sistema con el stack completo → venv de Boorie con el stack completo →
+ * cualquier intérprete real como último recurso.
+ *
+ * El sistema va por delante del venv gestionado a propósito: si el usuario ya
+ * tiene WNTR instalado, Boorie no debe apartarlo en favor de un entorno propio
+ * que quizá esté incompleto. El venv sigue cubriendo a quien no tiene nada,
+ * que es el caso que arreglamos originalmente.
  */
 export function findPythonPath(): string {
   if (cachedPythonPath) {
     return cachedPythonPath
   }
 
-  // 1. Use environment variable if set
+  // 1. Variable de entorno: override explícito, gana siempre
   if (process.env.PYTHON_PATH) {
     console.log(`[PythonDetector] Using PYTHON_PATH env: ${process.env.PYTHON_PATH}`)
     cachedPythonPath = process.env.PYTHON_PATH
     return cachedPythonPath
   }
 
-  // 2. Intérpretes gestionados por Boorie (ruta persistida + venv-wntr).
-  //    Si uno tiene WNTR es el ganador: es el entorno que la propia app
-  //    preparó y el que contiene también milvus-lite/langchain.
+  // 2. Ruta elegida a mano en Ajustes → General
+  const userPath = getUserPythonPath()
+  if (userPath && (fs.existsSync(userPath) || testPythonIsReal(userPath))) {
+    console.log(`[PythonDetector] Using user-configured Python: ${userPath}`)
+    cachedPythonPath = userPath
+    return cachedPythonPath
+  }
+
+  // 3. Python del sistema, con el stack completo de WNTR
+  const detected = detectSystemPython()
+  if (detected.hasWntr) {
+    cachedPythonPath = detected.path
+    return cachedPythonPath
+  }
+
+  // 4. Venv gestionado por Boorie, con el stack completo
   let managedFallback: string | null = null
   for (const candidate of getManagedPythonCandidates()) {
     if (!fs.existsSync(candidate)) continue
@@ -126,23 +174,13 @@ export function findPythonPath(): string {
       return cachedPythonPath
     }
     if (!managedFallback && testPythonIsReal(candidate)) {
-      // Venv a medio preparar: sólo lo usaremos si no aparece nada mejor.
       managedFallback = candidate
     }
   }
 
-  // 3. Platform-specific detection
-  let detected: { path: string; hasWntr: boolean }
-  if (process.platform === 'darwin') {
-    detected = findPythonMacOS()
-  } else if (process.platform === 'win32') {
-    detected = findPythonWindows()
-  } else {
-    detected = findPythonLinux()
-  }
-
-  if (!detected.hasWntr && managedFallback) {
-    console.log(`[PythonDetector] Falling back to managed venv Python: ${managedFallback}`)
+  // 5. Nada tiene el stack completo: preferimos un intérprete real a un nombre suelto
+  if (managedFallback) {
+    console.warn(`[PythonDetector] No complete WNTR environment; falling back to ${managedFallback}`)
     cachedPythonPath = managedFallback
     return cachedPythonPath
   }
@@ -151,9 +189,30 @@ export function findPythonPath(): string {
   return cachedPythonPath
 }
 
+/**
+ * Intérprete para el servidor embebido de Milvus Lite. Es el venv gestionado,
+ * no el del sistema: `milvus_lite` sólo lo instala el asistente de Boorie y el
+ * Python del usuario casi nunca lo tiene (issues #19/#20/#21).
+ */
+export function findPythonForMilvus(): string {
+  for (const candidate of getManagedPythonCandidates()) {
+    if (!fs.existsSync(candidate)) continue
+    if (testPythonHasModules(candidate, ['milvus_lite'])) {
+      console.log(`[PythonDetector] Milvus interpreter: ${candidate}`)
+      return candidate
+    }
+  }
+  return findPythonPath()
+}
+
+function detectSystemPython(): { path: string; hasWntr: boolean } {
+  if (process.platform === 'darwin') return findPythonMacOS()
+  if (process.platform === 'win32') return findPythonWindows()
+  return findPythonLinux()
+}
+
 function findPythonMacOS(): { path: string; hasWntr: boolean } {
   const possiblePaths = [
-    `${process.env.HOME}/repositorio/uruguay_wihisper/venv/bin/python3`,
     `${process.env.HOME}/venv/bin/python3`,
     `${process.env.HOME}/.venv/bin/python3`,
     './venv/bin/python3',
@@ -167,17 +226,7 @@ function findPythonMacOS(): { path: string; hasWntr: boolean } {
     `${process.env.HOME}/anaconda3/bin/python3`,
   ]
 
-  for (const pythonPath of possiblePaths) {
-    if (fs.existsSync(pythonPath)) {
-      if (testPythonHasWntr(pythonPath)) {
-        console.log(`[PythonDetector] Found Python with WNTR on macOS: ${pythonPath}`)
-        return { path: pythonPath, hasWntr: true }
-      }
-    }
-  }
-
-  console.warn('[PythonDetector] No Python with WNTR found on macOS, using fallback')
-  return { path: 'python3', hasWntr: false }
+  return pickFirstWithWntr(possiblePaths, 'python3', 'macOS')
 }
 
 function findPythonWindows(): { path: string; hasWntr: boolean } {
@@ -186,63 +235,29 @@ function findPythonWindows(): { path: string; hasWntr: boolean } {
   const versions = ['313', '312', '311', '310', '39']
 
   const possiblePaths = [
-    // Common virtual environment locations
-    path.join(process.cwd(), 'venv-wntr', 'Scripts', 'python.exe'),
+    // Entornos virtuales junto al proyecto (desarrollo)
     path.join(process.cwd(), 'venv', 'Scripts', 'python.exe'),
     path.join(process.cwd(), '.venv', 'Scripts', 'python.exe'),
-    // Python.org installer, instalación por usuario
+    // Python.org, instalación por usuario y para todos los usuarios
     ...versions.map((v) =>
       path.join(home, 'AppData', 'Local', 'Programs', 'Python', `Python${v}`, 'python.exe')
     ),
-    // Python.org installer, instalación para todos los usuarios
     ...versions.map((v) => path.join(programFiles, `Python${v}`, 'python.exe')),
     // Anaconda / Miniconda
     path.join(home, 'Anaconda3', 'python.exe'),
     path.join(home, 'Miniconda3', 'python.exe'),
-    path.join('C:', 'Anaconda3', 'python.exe'),
-    path.join('C:', 'Miniconda3', 'python.exe'),
+    path.join('C:\\', 'Anaconda3', 'python.exe'),
+    path.join('C:\\', 'Miniconda3', 'python.exe'),
     // Chocolatey
-    ...versions.map((v) => path.join('C:', `Python${v}`, 'python.exe')),
+    ...versions.map((v) => path.join('C:\\', `Python${v}`, 'python.exe')),
     // pyenv-win
     path.join(home, '.pyenv', 'pyenv-win', 'shims', 'python.exe'),
     path.join(home, '.pyenv', 'pyenv-win', 'shims', 'python3.exe'),
   ]
 
-  let realPythonWithoutWntr: string | null = null
-
-  for (const pythonPath of possiblePaths) {
-    if (fs.existsSync(pythonPath)) {
-      console.log(`[PythonDetector] Found Python on Windows: ${pythonPath}`)
-      // On Windows we first check if it's a real Python (not MS Store redirect)
-      if (testPythonIsReal(pythonPath)) {
-        if (testPythonHasWntr(pythonPath)) {
-          console.log(`[PythonDetector] Python has WNTR: ${pythonPath}`)
-          return { path: pythonPath, hasWntr: true }
-        }
-        // Even without WNTR, a real Python is better than the MS Store alias
-        console.log(`[PythonDetector] Python found (no WNTR): ${pythonPath}`)
-        if (!realPythonWithoutWntr) realPythonWithoutWntr = pythonPath
-      }
-    }
-  }
-
-  // Try 'python' command directly (may work if Python is in PATH and not MS Store alias)
-  if (testPythonIsReal('python')) {
-    if (testPythonHasWntr('python')) {
-      console.log('[PythonDetector] Using "python" from PATH (has WNTR)')
-      return { path: 'python', hasWntr: true }
-    }
-    if (!realPythonWithoutWntr) realPythonWithoutWntr = 'python'
-  }
-
-  if (realPythonWithoutWntr) {
-    console.warn(`[PythonDetector] Python without WNTR on Windows: ${realPythonWithoutWntr}`)
-    return { path: realPythonWithoutWntr, hasWntr: false }
-  }
-
-  console.warn('[PythonDetector] No Python installation found on Windows')
-  console.warn('[PythonDetector] Please install Python from python.org and set PYTHON_PATH in .env')
-  return { path: 'python', hasWntr: false }
+  // En Windows `python` puede ser el alias de Microsoft Store, que no ejecuta
+  // nada: por eso se comprueba con testPythonIsReal antes de aceptarlo.
+  return pickFirstWithWntr(possiblePaths, 'python', 'Windows', ['python', 'python3'])
 }
 
 function findPythonLinux(): { path: string; hasWntr: boolean } {
@@ -257,17 +272,47 @@ function findPythonLinux(): { path: string; hasWntr: boolean } {
     `${process.env.HOME}/anaconda3/bin/python3`,
   ]
 
+  return pickFirstWithWntr(possiblePaths, 'python3', 'Linux', ['python3'])
+}
+
+/**
+ * Recorre rutas concretas y, después, comandos que dependen del PATH. Devuelve
+ * el primero con el stack de WNTR completo; si no hay ninguno, el primer
+ * intérprete real que haya encontrado, y como último recurso `fallback`.
+ */
+function pickFirstWithWntr(
+  possiblePaths: string[],
+  fallback: string,
+  platformName: string,
+  pathCommands: string[] = [],
+): { path: string; hasWntr: boolean } {
+  let realWithoutWntr: string | null = null
+
   for (const pythonPath of possiblePaths) {
-    if (fs.existsSync(pythonPath)) {
-      if (testPythonHasWntr(pythonPath)) {
-        console.log(`[PythonDetector] Found Python with WNTR on Linux: ${pythonPath}`)
-        return { path: pythonPath, hasWntr: true }
-      }
+    if (!fs.existsSync(pythonPath)) continue
+    if (testPythonHasWntr(pythonPath)) {
+      console.log(`[PythonDetector] Found system Python with WNTR on ${platformName}: ${pythonPath}`)
+      return { path: pythonPath, hasWntr: true }
     }
+    if (!realWithoutWntr && testPythonIsReal(pythonPath)) realWithoutWntr = pythonPath
   }
 
-  console.warn('[PythonDetector] No Python with WNTR found on Linux, using fallback')
-  return { path: 'python3', hasWntr: false }
+  for (const command of pathCommands) {
+    if (!testPythonIsReal(command)) continue
+    if (testPythonHasWntr(command)) {
+      console.log(`[PythonDetector] Found "${command}" in PATH with WNTR on ${platformName}`)
+      return { path: command, hasWntr: true }
+    }
+    if (!realWithoutWntr) realWithoutWntr = command
+  }
+
+  if (realWithoutWntr) {
+    console.warn(`[PythonDetector] Python without complete WNTR stack on ${platformName}: ${realWithoutWntr}`)
+    return { path: realWithoutWntr, hasWntr: false }
+  }
+
+  console.warn(`[PythonDetector] No Python found on ${platformName}, using fallback "${fallback}"`)
+  return { path: fallback, hasWntr: false }
 }
 
 /**
@@ -280,28 +325,34 @@ function testPythonIsReal(pythonPath: string): boolean {
       timeout: 5000,
       windowsHide: true,
     })
-    const version = result.toString().trim()
-    console.log(`[PythonDetector] Python version: ${version}`)
-    return version.startsWith('Python ')
+    return result.toString().trim().startsWith('Python ')
   } catch {
     return false
   }
 }
 
-/**
- * Test if a Python installation has WNTR and NumPy
- */
-function testPythonHasWntr(pythonPath: string): boolean {
+function testPythonHasModules(pythonPath: string, modules: string[]): boolean {
   try {
-    execSync(`"${pythonPath}" -c "import wntr; import numpy"`, {
+    execSync(`"${pythonPath}" -c "import ${modules.join(', ')}"`, {
       stdio: 'pipe',
-      timeout: 10000,
+      timeout: 30000,
       windowsHide: true,
     })
     return true
   } catch {
     return false
   }
+}
+
+/** ¿Tiene este intérprete todo lo que los servicios WNTR necesitan? */
+function testPythonHasWntr(pythonPath: string): boolean {
+  return testPythonHasModules(pythonPath, WNTR_RUNTIME_MODULES)
+}
+
+/** Lista de módulos del stack que faltan; `null` si el intérprete no arranca. */
+export function getMissingWntrModules(pythonPath: string): string[] | null {
+  if (!testPythonIsReal(pythonPath)) return null
+  return WNTR_RUNTIME_MODULES.filter((m) => !testPythonHasModules(pythonPath, [m]))
 }
 
 /**
@@ -322,12 +373,15 @@ export function getPythonStatus(): {
   pythonVersion: string | null
   platform: string
   managedVenvPath: string | null
+  userConfigured: boolean
+  missingModules: string[]
   instructions: string | null
 } {
   const pythonPath = findPythonPath()
-  const isReal = testPythonIsReal(pythonPath)
-  const hasWntr = isReal ? testPythonHasWntr(pythonPath) : false
-  const managedVenvPath = getManagedVenvDir()
+  const missing = getMissingWntrModules(pythonPath)
+  const isReal = missing !== null
+  const hasWntr = isReal && missing.length === 0
+  const userConfigured = getUserPythonPath() === pythonPath && !!getUserPythonPath()
 
   let pythonVersion: string | null = null
   if (isReal) {
@@ -340,15 +394,16 @@ export function getPythonStatus(): {
   let instructions: string | null = null
   if (!isReal) {
     if (process.platform === 'win32') {
-      instructions = 'Python is not installed. Download it from python.org/downloads (3.10 or newer), check "Add Python to PATH" during installation, then restart Boorie and let the setup assistant install the dependencies.'
+      instructions = 'Python is not installed. Download it from python.org/downloads (3.10 or newer), check "Add Python to PATH" during installation, then restart Boorie and let the setup assistant install the dependencies. If you already have Python in a custom location (conda, your own venv), set its path in Settings → General → Python.'
     } else if (process.platform === 'darwin') {
       instructions = 'Python is not installed. Run: brew install python@3.11 — then restart Boorie and let the setup assistant install the dependencies.'
     } else {
       instructions = 'Python is not installed. Run: sudo apt install python3 python3-pip python3-venv — then restart Boorie and let the setup assistant install the dependencies.'
     }
   } else if (!hasWntr) {
-    instructions = 'Python is installed but WNTR is missing in the environment Boorie uses. Open Settings → General → "Preparar dependencias" to let Boorie install it, or run manually:\n' +
-      `  "${pythonPath}" -m pip install wntr`
+    instructions = `Python works but these modules are missing: ${missing.join(', ')}.\n` +
+      'Open Settings → General → "Preparar dependencias" to let Boorie install them, point Boorie at another interpreter in Settings → General → Python, or run manually:\n' +
+      `  "${pythonPath}" -m pip install ${missing.join(' ')}`
   }
 
   return {
@@ -357,7 +412,9 @@ export function getPythonStatus(): {
     wntrAvailable: hasWntr,
     pythonVersion,
     platform: process.platform,
-    managedVenvPath,
+    managedVenvPath: getManagedVenvDir(),
+    userConfigured,
+    missingModules: missing ?? WNTR_RUNTIME_MODULES,
     instructions,
   }
 }

--- a/backend/services/hydraulic/pythonDetector.ts
+++ b/backend/services/hydraulic/pythonDetector.ts
@@ -4,6 +4,99 @@ import { execSync } from 'child_process'
 
 let cachedPythonPath: string | null = null
 
+/** Nombre del venv que gestiona el propio Boorie (SetupWizard / setup.handler). */
+const MANAGED_VENV_DIR = 'venv-wntr'
+/** Fichero donde persistimos la ruta del Python elegido, dentro de userData. */
+const PYTHON_CONFIG_FILE = 'python-path.json'
+
+/**
+ * Directorio userData de Electron. Se resuelve de forma perezosa porque este
+ * módulo también se carga desde tests y desde scripts fuera de Electron.
+ */
+function getUserDataDir(): string | null {
+  if (process.env.BOORIE_USER_DATA) return process.env.BOORIE_USER_DATA
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { app } = require('electron')
+    if (app && typeof app.getPath === 'function') return app.getPath('userData')
+  } catch {
+    // fuera de Electron (tests, scripts) — no hay userData
+  }
+  return null
+}
+
+/**
+ * Ruta del venv gestionado por Boorie. En la app instalada vive en userData
+ * porque el directorio de instalación no es escribible.
+ */
+export function getManagedVenvDir(): string | null {
+  const userData = getUserDataDir()
+  return userData ? path.join(userData, MANAGED_VENV_DIR) : null
+}
+
+function venvPythonCandidates(venvDir: string): string[] {
+  return [
+    path.join(venvDir, 'Scripts', 'python.exe'), // Windows
+    path.join(venvDir, 'bin', 'python'),         // macOS / Linux
+    path.join(venvDir, 'bin', 'python3'),
+  ]
+}
+
+function getPythonConfigFile(): string | null {
+  const userData = getUserDataDir()
+  return userData ? path.join(userData, PYTHON_CONFIG_FILE) : null
+}
+
+/**
+ * Persiste la ruta del intérprete que Boorie debe usar. Sin esto la ruta del
+ * venv recién creado sólo vivía en `process.env.PYTHON_PATH` y se perdía al
+ * cerrar la app: al siguiente arranque WNTR volvía a "no instalado".
+ */
+export function savePythonPath(pythonPath: string): void {
+  const configFile = getPythonConfigFile()
+  if (!configFile) return
+  try {
+    fs.mkdirSync(path.dirname(configFile), { recursive: true })
+    fs.writeFileSync(configFile, JSON.stringify({ pythonPath }, null, 2), 'utf-8')
+    console.log(`[PythonDetector] Saved Python path to ${configFile}: ${pythonPath}`)
+  } catch (error) {
+    console.warn('[PythonDetector] Could not persist Python path:', error)
+  }
+}
+
+function readSavedPythonPath(): string | null {
+  const configFile = getPythonConfigFile()
+  if (!configFile) return null
+  try {
+    if (!fs.existsSync(configFile)) return null
+    const parsed = JSON.parse(fs.readFileSync(configFile, 'utf-8'))
+    return typeof parsed?.pythonPath === 'string' && parsed.pythonPath.length > 0
+      ? parsed.pythonPath
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Intérpretes "gestionados": el guardado en configuración y los venv que
+ * Boorie crea (userData en producción, raíz del repo en desarrollo).
+ */
+function getManagedPythonCandidates(): string[] {
+  const candidates: string[] = []
+
+  const saved = readSavedPythonPath()
+  if (saved) candidates.push(saved)
+
+  const managedVenv = getManagedVenvDir()
+  if (managedVenv) candidates.push(...venvPythonCandidates(managedVenv))
+
+  // Dev: el repo tiene su propio venv-wntr
+  candidates.push(...venvPythonCandidates(path.join(process.cwd(), MANAGED_VENV_DIR)))
+
+  return candidates
+}
+
 /**
  * Shared Python path detection utility.
  * Finds the best available Python installation with WNTR support.
@@ -21,33 +114,44 @@ export function findPythonPath(): string {
     return cachedPythonPath
   }
 
-  // 2. Check for venv-wntr in the app directory (works in dev and packaged)
-  const appVenvPaths = [
-    path.join(process.cwd(), 'venv-wntr', 'bin', 'python3'),
-    path.join(process.cwd(), 'venv-wntr', 'Scripts', 'python.exe'),
-  ]
-  for (const venvPath of appVenvPaths) {
-    if (fs.existsSync(venvPath)) {
-      if (testPythonHasWntr(venvPath)) {
-        cachedPythonPath = venvPath
-        return cachedPythonPath
-      }
+  // 2. Intérpretes gestionados por Boorie (ruta persistida + venv-wntr).
+  //    Si uno tiene WNTR es el ganador: es el entorno que la propia app
+  //    preparó y el que contiene también milvus-lite/langchain.
+  let managedFallback: string | null = null
+  for (const candidate of getManagedPythonCandidates()) {
+    if (!fs.existsSync(candidate)) continue
+    if (testPythonHasWntr(candidate)) {
+      console.log(`[PythonDetector] Found managed Python with WNTR: ${candidate}`)
+      cachedPythonPath = candidate
+      return cachedPythonPath
+    }
+    if (!managedFallback && testPythonIsReal(candidate)) {
+      // Venv a medio preparar: sólo lo usaremos si no aparece nada mejor.
+      managedFallback = candidate
     }
   }
 
   // 3. Platform-specific detection
+  let detected: { path: string; hasWntr: boolean }
   if (process.platform === 'darwin') {
-    cachedPythonPath = findPythonMacOS()
+    detected = findPythonMacOS()
   } else if (process.platform === 'win32') {
-    cachedPythonPath = findPythonWindows()
+    detected = findPythonWindows()
   } else {
-    cachedPythonPath = findPythonLinux()
+    detected = findPythonLinux()
   }
 
+  if (!detected.hasWntr && managedFallback) {
+    console.log(`[PythonDetector] Falling back to managed venv Python: ${managedFallback}`)
+    cachedPythonPath = managedFallback
+    return cachedPythonPath
+  }
+
+  cachedPythonPath = detected.path
   return cachedPythonPath
 }
 
-function findPythonMacOS(): string {
+function findPythonMacOS(): { path: string; hasWntr: boolean } {
   const possiblePaths = [
     `${process.env.HOME}/repositorio/uruguay_wihisper/venv/bin/python3`,
     `${process.env.HOME}/venv/bin/python3`,
@@ -67,42 +171,44 @@ function findPythonMacOS(): string {
     if (fs.existsSync(pythonPath)) {
       if (testPythonHasWntr(pythonPath)) {
         console.log(`[PythonDetector] Found Python with WNTR on macOS: ${pythonPath}`)
-        return pythonPath
+        return { path: pythonPath, hasWntr: true }
       }
     }
   }
 
   console.warn('[PythonDetector] No Python with WNTR found on macOS, using fallback')
-  return 'python3'
+  return { path: 'python3', hasWntr: false }
 }
 
-function findPythonWindows(): string {
+function findPythonWindows(): { path: string; hasWntr: boolean } {
   const home = process.env.USERPROFILE || process.env.HOME || ''
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+  const versions = ['313', '312', '311', '310', '39']
 
   const possiblePaths = [
     // Common virtual environment locations
     path.join(process.cwd(), 'venv-wntr', 'Scripts', 'python.exe'),
     path.join(process.cwd(), 'venv', 'Scripts', 'python.exe'),
     path.join(process.cwd(), '.venv', 'Scripts', 'python.exe'),
-    // Python.org installer default locations
-    path.join(home, 'AppData', 'Local', 'Programs', 'Python', 'Python313', 'python.exe'),
-    path.join(home, 'AppData', 'Local', 'Programs', 'Python', 'Python312', 'python.exe'),
-    path.join(home, 'AppData', 'Local', 'Programs', 'Python', 'Python311', 'python.exe'),
-    path.join(home, 'AppData', 'Local', 'Programs', 'Python', 'Python310', 'python.exe'),
-    path.join(home, 'AppData', 'Local', 'Programs', 'Python', 'Python39', 'python.exe'),
+    // Python.org installer, instalación por usuario
+    ...versions.map((v) =>
+      path.join(home, 'AppData', 'Local', 'Programs', 'Python', `Python${v}`, 'python.exe')
+    ),
+    // Python.org installer, instalación para todos los usuarios
+    ...versions.map((v) => path.join(programFiles, `Python${v}`, 'python.exe')),
     // Anaconda / Miniconda
     path.join(home, 'Anaconda3', 'python.exe'),
     path.join(home, 'Miniconda3', 'python.exe'),
     path.join('C:', 'Anaconda3', 'python.exe'),
     path.join('C:', 'Miniconda3', 'python.exe'),
     // Chocolatey
-    path.join('C:', 'Python313', 'python.exe'),
-    path.join('C:', 'Python312', 'python.exe'),
-    path.join('C:', 'Python311', 'python.exe'),
+    ...versions.map((v) => path.join('C:', `Python${v}`, 'python.exe')),
     // pyenv-win
     path.join(home, '.pyenv', 'pyenv-win', 'shims', 'python.exe'),
     path.join(home, '.pyenv', 'pyenv-win', 'shims', 'python3.exe'),
   ]
+
+  let realPythonWithoutWntr: string | null = null
 
   for (const pythonPath of possiblePaths) {
     if (fs.existsSync(pythonPath)) {
@@ -111,26 +217,35 @@ function findPythonWindows(): string {
       if (testPythonIsReal(pythonPath)) {
         if (testPythonHasWntr(pythonPath)) {
           console.log(`[PythonDetector] Python has WNTR: ${pythonPath}`)
-          return pythonPath
+          return { path: pythonPath, hasWntr: true }
         }
         // Even without WNTR, a real Python is better than the MS Store alias
         console.log(`[PythonDetector] Python found (no WNTR): ${pythonPath}`)
+        if (!realPythonWithoutWntr) realPythonWithoutWntr = pythonPath
       }
     }
   }
 
   // Try 'python' command directly (may work if Python is in PATH and not MS Store alias)
   if (testPythonIsReal('python')) {
-    console.log('[PythonDetector] Using "python" from PATH')
-    return 'python'
+    if (testPythonHasWntr('python')) {
+      console.log('[PythonDetector] Using "python" from PATH (has WNTR)')
+      return { path: 'python', hasWntr: true }
+    }
+    if (!realPythonWithoutWntr) realPythonWithoutWntr = 'python'
+  }
+
+  if (realPythonWithoutWntr) {
+    console.warn(`[PythonDetector] Python without WNTR on Windows: ${realPythonWithoutWntr}`)
+    return { path: realPythonWithoutWntr, hasWntr: false }
   }
 
   console.warn('[PythonDetector] No Python installation found on Windows')
   console.warn('[PythonDetector] Please install Python from python.org and set PYTHON_PATH in .env')
-  return 'python'
+  return { path: 'python', hasWntr: false }
 }
 
-function findPythonLinux(): string {
+function findPythonLinux(): { path: string; hasWntr: boolean } {
   const possiblePaths = [
     `${process.env.HOME}/venv/bin/python3`,
     `${process.env.HOME}/.venv/bin/python3`,
@@ -146,13 +261,13 @@ function findPythonLinux(): string {
     if (fs.existsSync(pythonPath)) {
       if (testPythonHasWntr(pythonPath)) {
         console.log(`[PythonDetector] Found Python with WNTR on Linux: ${pythonPath}`)
-        return pythonPath
+        return { path: pythonPath, hasWntr: true }
       }
     }
   }
 
   console.warn('[PythonDetector] No Python with WNTR found on Linux, using fallback')
-  return 'python3'
+  return { path: 'python3', hasWntr: false }
 }
 
 /**
@@ -206,11 +321,13 @@ export function getPythonStatus(): {
   wntrAvailable: boolean
   pythonVersion: string | null
   platform: string
+  managedVenvPath: string | null
   instructions: string | null
 } {
   const pythonPath = findPythonPath()
   const isReal = testPythonIsReal(pythonPath)
   const hasWntr = isReal ? testPythonHasWntr(pythonPath) : false
+  const managedVenvPath = getManagedVenvDir()
 
   let pythonVersion: string | null = null
   if (isReal) {
@@ -223,14 +340,15 @@ export function getPythonStatus(): {
   let instructions: string | null = null
   if (!isReal) {
     if (process.platform === 'win32') {
-      instructions = 'Python is not installed. Download it from python.org/downloads and check "Add Python to PATH" during installation. Then run: pip install wntr'
+      instructions = 'Python is not installed. Download it from python.org/downloads (3.10 or newer), check "Add Python to PATH" during installation, then restart Boorie and let the setup assistant install the dependencies.'
     } else if (process.platform === 'darwin') {
-      instructions = 'Python is not installed. Run: brew install python@3.11 && pip3 install wntr'
+      instructions = 'Python is not installed. Run: brew install python@3.11 — then restart Boorie and let the setup assistant install the dependencies.'
     } else {
-      instructions = 'Python is not installed. Run: sudo apt install python3 python3-pip && pip3 install wntr'
+      instructions = 'Python is not installed. Run: sudo apt install python3 python3-pip python3-venv — then restart Boorie and let the setup assistant install the dependencies.'
     }
   } else if (!hasWntr) {
-    instructions = 'Python is installed but WNTR is missing. Run: pip install wntr'
+    instructions = 'Python is installed but WNTR is missing in the environment Boorie uses. Open Settings → General → "Preparar dependencias" to let Boorie install it, or run manually:\n' +
+      `  "${pythonPath}" -m pip install wntr`
   }
 
   return {
@@ -239,6 +357,7 @@ export function getPythonStatus(): {
     wntrAvailable: hasWntr,
     pythonVersion,
     platform: process.platform,
+    managedVenvPath,
     instructions,
   }
 }

--- a/backend/services/hydraulic/pythonDetector.ts
+++ b/backend/services/hydraulic/pythonDetector.ts
@@ -17,6 +17,9 @@ const PYTHON_CONFIG_FILE = 'python-path.json'
  */
 const WNTR_RUNTIME_MODULES = ['wntr', 'numpy', 'scipy', 'pandas', 'networkx']
 
+/** Lo que el servidor embebido de Milvus Lite necesita para arrancar de verdad. */
+export const MILVUS_RUNTIME_MODULES = ['milvus_lite', 'pymilvus']
+
 export type PythonSource = 'user' | 'auto'
 
 /**
@@ -197,7 +200,9 @@ export function findPythonPath(): string {
 export function findPythonForMilvus(): string {
   for (const candidate of getManagedPythonCandidates()) {
     if (!fs.existsSync(candidate)) continue
-    if (testPythonHasModules(candidate, ['milvus_lite'])) {
+    // pymilvus incluido: milvus_lite importa sin él, pero su servidor gRPC no
+    // arranca, y elegir ese intérprete dejaría el RAG sin indexar en silencio.
+    if (testPythonHasModules(candidate, MILVUS_RUNTIME_MODULES)) {
       console.log(`[PythonDetector] Milvus interpreter: ${candidate}`)
       return candidate
     }

--- a/backend/services/hydraulic/ragService.reindex.test.ts
+++ b/backend/services/hydraulic/ragService.reindex.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { HydraulicRAGService } from './ragService'
+
+// Milvus se importa dinámicamente dentro de reindexDocument; lo mockeamos para
+// que el test sea rápido y determinista (el servicio real reintenta 7,5 s).
+const milvusMock = {
+  ensureConnection: vi.fn(),
+  delete: vi.fn(),
+  insert: vi.fn(),
+}
+vi.mock('../milvus.service', () => ({
+  MilvusService: { getInstance: () => milvusMock },
+}))
+
+/**
+ * El reindexado antiguo borraba los chunks y no recreaba nada: devolvía éxito y
+ * el documento quedaba "Not Indexed" para siempre. Estos tests fijan las dos
+ * propiedades que impiden que eso vuelva a pasar.
+ */
+function fakePrisma(doc: any, chunkIds: string[] = ['c1']) {
+  return {
+    hydraulicKnowledge: {
+      findUnique: vi.fn().mockResolvedValue(
+        doc ? { ...doc, chunks: chunkIds.map((id) => ({ id })) } : null
+      ),
+      update: vi.fn(),
+    },
+    knowledgeChunk: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    $transaction: vi.fn().mockResolvedValue([]),
+  } as any
+}
+
+const DOC = { id: 'doc-1', title: 'Redes de distribución', category: 'hydraulics', content: 'x '.repeat(400) }
+
+describe('reindexDocument', () => {
+  beforeEach(() => {
+    milvusMock.ensureConnection.mockReset().mockResolvedValue(undefined)
+    milvusMock.delete.mockReset().mockResolvedValue(undefined)
+    milvusMock.insert.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('genera los embeddings, sustituye los chunks e inserta en Milvus', async () => {
+    const prisma = fakePrisma(DOC, ['viejo-1'])
+    prisma.knowledgeChunk.findMany.mockResolvedValue([
+      { id: 'nuevo-1', content: 'x', embedding: '[0.1,0.2,0.3]' },
+    ])
+    const embeddingService = { generateEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]) }
+    const rag = new HydraulicRAGService(prisma, embeddingService)
+
+    const result = await rag.reindexDocument('doc-1')
+
+    expect(embeddingService.generateEmbedding).toHaveBeenCalled()
+    expect(result.chunkCount).toBeGreaterThan(0)
+    expect(result.failedCount).toBe(0)
+    // Un solo $transaction con el borrado y la creación: nunca queda a medias
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    // Los vectores viejos se retiran y los nuevos se insertan
+    expect(milvusMock.delete).toHaveBeenCalledWith('hydraulic_knowledge', ['viejo-1'])
+    expect(milvusMock.insert).toHaveBeenCalledOnce()
+    expect(result.milvusSynced).toBe(true)
+  })
+
+  it('deja los chunks escritos aunque Milvus no esté disponible', async () => {
+    milvusMock.ensureConnection.mockRejectedValue(new Error('Milvus unavailable'))
+    const prisma = fakePrisma(DOC)
+    const rag = new HydraulicRAGService(prisma, {
+      generateEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    })
+
+    const result = await rag.reindexDocument('doc-1')
+
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    expect(result.chunkCount).toBeGreaterThan(0)
+    expect(result.milvusSynced).toBe(false)
+  })
+
+  it('no toca los chunks existentes si el proveedor de embeddings falla', async () => {
+    const prisma = fakePrisma(DOC)
+    const embeddingService = {
+      generateEmbedding: vi.fn().mockRejectedValue(new Error('Ollama unreachable')),
+    }
+    const rag = new HydraulicRAGService(prisma, embeddingService)
+
+    await expect(rag.reindexDocument('doc-1')).rejects.toThrow(/embedding provider/i)
+
+    // Lo esencial: nada se ha borrado. El documento sigue indexado como estaba.
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.knowledgeChunk.deleteMany).not.toHaveBeenCalled()
+  })
+
+  it('rechaza reindexar un documento sin texto almacenado', async () => {
+    const prisma = fakePrisma({ ...DOC, content: '   ' })
+    const rag = new HydraulicRAGService(prisma, { generateEmbedding: vi.fn() })
+
+    await expect(rag.reindexDocument('doc-1')).rejects.toThrow(/no conserva su texto/i)
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('falla si el documento no existe', async () => {
+    const prisma = fakePrisma(null)
+    const rag = new HydraulicRAGService(prisma, { generateEmbedding: vi.fn() })
+
+    await expect(rag.reindexDocument('nope')).rejects.toThrow(/not found/i)
+  })
+})

--- a/backend/services/hydraulic/ragService.ts
+++ b/backend/services/hydraulic/ragService.ts
@@ -128,97 +128,183 @@ export class HydraulicRAGService {
     }
   }
 
+  /**
+   * Trocea un texto y genera los embeddings de cada trozo. Es la única ruta
+   * que produce chunks indexados, y la comparten la subida de documentos y el
+   * reindexado: antes el reindexado sólo borraba chunks y nadie los recreaba,
+   * así que un documento reindexado se quedaba "Not Indexed" para siempre.
+   */
+  private async buildIndexedChunks(
+    content: string,
+    onProgress?: (progress: { current: number; total: number; message: string }) => void
+  ): Promise<{
+    chunks: { content: string; embedding: number[]; chunkIndex: number }[]
+    failedCount: number
+    totalChunks: number
+  }> {
+    const chunks = this.chunkDocument(content, {
+      maxChunkSize: 1000, // Larger chunks = fewer embeddings = faster indexing
+      overlap: 150
+    })
+
+    console.log(`[RAG Service] Chunked document into ${chunks.length} parts`)
+
+    const generateWithTimeout = async (text: string, timeoutMs: number = 60000) => {
+      return Promise.race([
+        this.embeddingService.generateEmbedding(text),
+        new Promise<number[]>((_, reject) =>
+          setTimeout(() => reject(new Error('Embedding generation timed out')), timeoutMs)
+        )
+      ])
+    }
+
+    // Process embeddings in concurrent batches for much faster indexing
+    const CONCURRENCY = 3
+    const chunkEmbeddings: (number[] | null)[] = new Array(chunks.length).fill(null)
+    const chunkTimings: number[] = []
+    let completedCount = 0
+
+    for (let batchStart = 0; batchStart < chunks.length; batchStart += CONCURRENCY) {
+      const batchEnd = Math.min(batchStart + CONCURRENCY, chunks.length)
+      const batchIndices = Array.from({ length: batchEnd - batchStart }, (_, k) => batchStart + k)
+
+      await Promise.all(batchIndices.map(async (i) => {
+        const chunkStart = Date.now()
+        try {
+          chunkEmbeddings[i] = await generateWithTimeout(chunks[i], 60000)
+          const duration = Date.now() - chunkStart
+          chunkTimings.push(duration)
+          if (duration > 5000) {
+            console.warn(`[RAG Service] Slow embedding for chunk ${i + 1}: ${duration}ms`)
+          }
+        } catch (err: any) {
+          console.error(`[RAG Service] Failed embedding for chunk ${i + 1}:`, err.message)
+          chunkEmbeddings[i] = null
+        }
+      }))
+
+      completedCount = batchEnd
+
+      if (onProgress) {
+        const avgTime = chunkTimings.length > 0
+          ? chunkTimings.reduce((a, b) => a + b, 0) / chunkTimings.length
+          : 0
+        const remainingChunks = chunks.length - completedCount
+        const etaSeconds = Math.round((avgTime * remainingChunks / CONCURRENCY) / 1000)
+        const etaText = etaSeconds > 0 ? ` (~${etaSeconds}s restantes)` : ''
+
+        onProgress({
+          current: completedCount,
+          total: chunks.length,
+          message: `Chunk ${completedCount}/${chunks.length}: Generando embeddings...${etaText}`
+        })
+      }
+
+      if (batchStart === 0 || completedCount % 10 === 0 || completedCount === chunks.length) {
+        console.log(`[RAG Service] Progress: ${completedCount}/${chunks.length} chunks processed`)
+      }
+    }
+
+    const successfulChunks = chunks
+      .map((chunk, index) => ({ content: chunk, embedding: chunkEmbeddings[index], chunkIndex: index }))
+      .filter((item): item is { content: string; embedding: number[]; chunkIndex: number } => item.embedding !== null)
+
+    const failedCount = chunks.length - successfulChunks.length
+    if (failedCount > 0) {
+      console.warn(`[RAG Service] ${failedCount}/${chunks.length} chunks failed embedding generation`)
+    }
+
+    if (successfulChunks.length === 0 && chunks.length > 0) {
+      throw new Error('Failed to generate embeddings for any chunk. The embedding provider (Ollama/OpenAI) may be unreachable or misconfigured.')
+    }
+
+    return { chunks: successfulChunks, failedCount, totalChunks: chunks.length }
+  }
+
+  /**
+   * Reindexa un documento que ya está en la base de datos, a partir del texto
+   * que guarda en `content`. Los embeddings se generan ANTES de tocar los
+   * chunks existentes: si el proveedor de embeddings no responde, el documento
+   * se queda como estaba en lugar de perder su indexado.
+   */
+  async reindexDocument(
+    documentId: string,
+    onProgress?: (progress: { current: number; total: number; message: string }) => void
+  ): Promise<{ chunkCount: number; failedCount: number; totalChunks: number; milvusSynced: boolean }> {
+    const doc = await this.prisma.hydraulicKnowledge.findUnique({
+      where: { id: documentId },
+      include: { chunks: { select: { id: true } } }
+    })
+
+    if (!doc) throw new Error('Document not found')
+    if (!doc.content || doc.content.trim().length === 0) {
+      throw new Error(
+        'El documento no conserva su texto en la base de datos, así que no se puede reindexar. Vuelve a subirlo.'
+      )
+    }
+
+    const { chunks: newChunks, failedCount, totalChunks } = await this.buildIndexedChunks(doc.content, onProgress)
+    const staleChunkIds = doc.chunks.map((c) => c.id)
+
+    // Sustitución atómica: si algo falla, no queda a medias
+    await this.prisma.$transaction([
+      this.prisma.knowledgeChunk.deleteMany({ where: { knowledgeId: documentId } }),
+      this.prisma.knowledgeChunk.createMany({
+        data: newChunks.map((item) => ({
+          knowledgeId: documentId,
+          content: item.content,
+          embedding: JSON.stringify(item.embedding),
+          chunkIndex: item.chunkIndex
+        }))
+      }),
+      this.prisma.hydraulicKnowledge.update({
+        where: { id: documentId },
+        data: { updatedAt: new Date() }
+      })
+    ])
+
+    // Milvus: quitar los vectores viejos e insertar los nuevos
+    let milvusSynced = false
+    try {
+      const milvusService = (await import('../milvus.service')).MilvusService.getInstance()
+      await milvusService.ensureConnection()
+
+      if (staleChunkIds.length > 0) {
+        await milvusService.delete('hydraulic_knowledge', staleChunkIds)
+      }
+
+      const persisted = await this.prisma.knowledgeChunk.findMany({ where: { knowledgeId: documentId } })
+      const rows = persisted
+        .filter((c) => c.embedding)
+        .map((c) => ({
+          id: c.id,
+          vector: JSON.parse(c.embedding as string),
+          content: c.content,
+          metadata: { chunkId: c.id, docId: doc.id, title: doc.title, category: doc.category },
+          timestamp: Date.now()
+        }))
+
+      if (rows.length > 0) {
+        await milvusService.insert('hydraulic_knowledge', rows)
+        console.log(`[RAG Service] Reindexed ${rows.length} chunks into Milvus for "${doc.title}"`)
+      }
+      milvusSynced = true
+    } catch (milvusErr) {
+      // Los chunks y sus embeddings ya están en la base relacional: la búsqueda
+      // por texto sigue funcionando y `wisdom:syncMilvus` puede reintentarlo.
+      console.error('[RAG Service] Reindex: failed to sync Milvus:', milvusErr)
+    }
+
+    return { chunkCount: newChunks.length, failedCount, totalChunks, milvusSynced }
+  }
+
   // Add new document to knowledge base
   async addDocument(
     document: Omit<HydraulicDocument, 'id' | 'lastUpdated'>,
     onProgress?: (progress: { current: number; total: number; message: string }) => void
   ): Promise<string> {
     try {
-      // Generate chunks from content
-      const chunks = this.chunkDocument(document.content, {
-        maxChunkSize: 1000, // Larger chunks = fewer embeddings = faster indexing
-        overlap: 150
-      })
-
-      console.log(`[RAG Service] Chunked document into ${chunks.length} parts`)
-
-      // Helper for timeout
-      const generateWithTimeout = async (text: string, timeoutMs: number = 60000) => {
-        return Promise.race([
-          this.embeddingService.generateEmbedding(text),
-          new Promise<number[]>((_, reject) =>
-            setTimeout(() => reject(new Error('Embedding generation timed out')), timeoutMs)
-          )
-        ])
-      }
-
-      // Process embeddings in concurrent batches for much faster indexing
-      const CONCURRENCY = 3 // Process 3 chunks at a time
-      const chunkEmbeddings: (number[] | null)[] = new Array(chunks.length).fill(null)
-      const chunkTimings: number[] = []
-      let completedCount = 0
-
-      for (let batchStart = 0; batchStart < chunks.length; batchStart += CONCURRENCY) {
-        const batchEnd = Math.min(batchStart + CONCURRENCY, chunks.length)
-        const batchIndices = Array.from({ length: batchEnd - batchStart }, (_, k) => batchStart + k)
-
-        const batchPromises = batchIndices.map(async (i) => {
-          const chunk = chunks[i]
-          const chunkStart = Date.now()
-
-          try {
-            const embedding = await generateWithTimeout(chunk, 60000)
-            chunkEmbeddings[i] = embedding
-
-            const duration = Date.now() - chunkStart
-            chunkTimings.push(duration)
-
-            if (duration > 5000) {
-              console.warn(`[RAG Service] Slow embedding for chunk ${i + 1}: ${duration}ms`)
-            }
-          } catch (err: any) {
-            console.error(`[RAG Service] Failed embedding for chunk ${i + 1}:`, err.message)
-            chunkEmbeddings[i] = null
-          }
-        })
-
-        await Promise.all(batchPromises)
-        completedCount = batchEnd
-
-        // Report progress with ETA
-        if (onProgress) {
-          const avgTime = chunkTimings.length > 0
-            ? chunkTimings.reduce((a, b) => a + b, 0) / chunkTimings.length
-            : 0
-          const remainingChunks = chunks.length - completedCount
-          const etaSeconds = Math.round((avgTime * remainingChunks / CONCURRENCY) / 1000)
-          const etaText = etaSeconds > 0 ? ` (~${etaSeconds}s restantes)` : ''
-
-          onProgress({
-            current: completedCount,
-            total: chunks.length,
-            message: `Chunk ${completedCount}/${chunks.length}: Generando embeddings...${etaText}`
-          })
-        }
-
-        if (batchStart === 0 || completedCount % 10 === 0 || completedCount === chunks.length) {
-          console.log(`[RAG Service] Progress: ${completedCount}/${chunks.length} chunks processed`)
-        }
-      }
-
-      // Filter out chunks with failed embeddings
-      const successfulChunks = chunks
-        .map((chunk, index) => ({ content: chunk, embedding: chunkEmbeddings[index], chunkIndex: index }))
-        .filter(item => item.embedding !== null)
-
-      const failedCount = chunks.length - successfulChunks.length
-      if (failedCount > 0) {
-        console.warn(`[RAG Service] ${failedCount}/${chunks.length} chunks failed embedding generation`)
-      }
-
-      if (successfulChunks.length === 0 && chunks.length > 0) {
-        throw new Error('Failed to generate embeddings for any chunk. The embedding provider (Ollama/OpenAI) may be unreachable or misconfigured.')
-      }
+      const { chunks: successfulChunks } = await this.buildIndexedChunks(document.content, onProgress)
 
       console.log(`[RAG Service] Creating document with ${successfulChunks.length} indexed chunks`)
 

--- a/backend/services/hydraulic/reportService.ts
+++ b/backend/services/hydraulic/reportService.ts
@@ -39,15 +39,17 @@ export interface ComprehensiveReportData {
 }
 
 export class WNTRReportService {
-  private pythonPath: string;
   private servicePath: string;
   private reportsDirectory: string;
 
-  constructor(reportsDirectory?: string) {
-    // Use shared Python detection utility
+  /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
+  private get pythonPath(): string {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { findPythonPath } = require('./pythonDetector');
-    this.pythonPath = findPythonPath();
+    return findPythonPath();
+  }
+
+  constructor(reportsDirectory?: string) {
     this.servicePath = path.join(__dirname, 'wntr_report_generator.py');
     this.reportsDirectory = reportsDirectory || path.join(process.cwd(), 'reports');
   }

--- a/backend/services/hydraulic/resilienceService.ts
+++ b/backend/services/hydraulic/resilienceService.ts
@@ -96,13 +96,16 @@ export interface FragilityCurveResult {
 }
 
 export class WNTRResilienceService {
-  private pythonPath: string;
   private servicePath: string;
 
-  constructor() {
+  /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
+  private get pythonPath(): string {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { findPythonPath } = require('./pythonDetector');
-    this.pythonPath = findPythonPath();
+    return findPythonPath();
+  }
+
+  constructor() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolvePythonScriptPath } = require('./pythonScriptPath');
     this.servicePath = resolvePythonScriptPath('wntr_resilience_service.py');

--- a/backend/services/hydraulic/simulationService.ts
+++ b/backend/services/hydraulic/simulationService.ts
@@ -68,14 +68,16 @@ export interface SimulationResults {
 }
 
 export class WNTRSimulationService {
-  private pythonPath: string;
   private servicePath: string;
 
-  constructor() {
-    // Use shared Python detection utility
+  /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
+  private get pythonPath(): string {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { findPythonPath } = require('./pythonDetector');
-    this.pythonPath = findPythonPath();
+    return findPythonPath();
+  }
+
+  constructor() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolvePythonScriptPath } = require('./pythonScriptPath');
     this.servicePath = resolvePythonScriptPath('wntr_simulation_service.py');

--- a/backend/services/hydraulic/wntrWrapper.ts
+++ b/backend/services/hydraulic/wntrWrapper.ts
@@ -69,18 +69,25 @@ export interface NetworkAnalysis {
 }
 
 class WNTRWrapper {
-  private pythonPath: string
   private scriptPath: string
 
   constructor() {
-    // Use shared Python detection utility (supports macOS, Windows, Linux)
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { findPythonPath } = require('./pythonDetector')
-    this.pythonPath = findPythonPath()
-
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolvePythonScriptPath } = require('./pythonScriptPath')
     this.scriptPath = resolvePythonScriptPath('wntrService.py')
+  }
+
+  /**
+   * La ruta de Python se resuelve en cada ejecución, no en el constructor:
+   * esta clase se instancia al arrancar la app, antes de que el asistente de
+   * preparación haya creado el venv, así que congelarla dejaba WNTR apuntando
+   * para siempre a un intérprete sin WNTR (findPythonPath ya cachea el
+   * resultado y setup.handler invalida la caché al terminar).
+   */
+  private get pythonPath(): string {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { findPythonPath } = require('./pythonDetector')
+    return findPythonPath()
   }
 
   private async runPythonScript(command: string, args: string[]): Promise<any> {

--- a/backend/services/milvus.service.ts
+++ b/backend/services/milvus.service.ts
@@ -30,7 +30,23 @@ export class MilvusService {
         // each cold start. Falls back to 19530 if not present.
         const address = MilvusService.resolveAddress();
         console.log('[MilvusService] Connecting to Milvus Lite at', address);
-        this.client = new MilvusClient({ address });
+        this.client = MilvusService.createClient(address);
+    }
+
+    /**
+     * Crea el cliente y **recoge su promesa de conexión**. El SDK arranca la
+     * conexión dentro del constructor y expone `connectPromise`; si el servidor
+     * no está escuchando, esa promesa se rechaza sin dueño y aparece como
+     * "Unhandled promise rejection" (cuatro por arranque en los logs, que
+     * despistaron al diagnosticar un caso real) o mata el proceso si se usa
+     * este servicio fuera de Electron. El fallo real ya se detecta y reporta en
+     * ensureConnection().
+     */
+    private static createClient(address: string): MilvusClient {
+        const client = new MilvusClient({ address });
+        const pending = (client as unknown as { connectPromise?: Promise<void> }).connectPromise;
+        if (pending && typeof pending.catch === 'function') pending.catch(() => { /* reportado en ensureConnection */ });
+        return client;
     }
 
     private static resolveAddress(): string {
@@ -99,7 +115,7 @@ export class MilvusService {
             // up on a different port than what was resolved back then.
             this.unavailable = false;
             this.connectionAttempted = false;
-            this.client = new MilvusClient({ address: MilvusService.resolveAddress() });
+            this.client = MilvusService.createClient(MilvusService.resolveAddress());
         }
 
         if (this.connectionAttempted) {
@@ -119,7 +135,7 @@ export class MilvusService {
                     // start_milvus.py writes it, instead of retrying a stale address.
                     const resolved = MilvusService.resolveAddress();
                     if (resolved !== lastResolvedAddress || retries === 5) {
-                        this.client = new MilvusClient({ address: resolved });
+                        this.client = MilvusService.createClient(resolved);
                         lastResolvedAddress = resolved;
                     }
                     await this.client.listCollections();

--- a/docs/ACERCA_DE_HISTORIAL_VERSIONES.md
+++ b/docs/ACERCA_DE_HISTORIAL_VERSIONES.md
@@ -1,0 +1,147 @@
+# Sección «Acerca de» con historial de versiones
+
+Diseño y decisiones de la funcionalidad pedida en el [issue #30](https://github.com/Boorie-AI/boorie_cliente/issues/30).
+
+Se entrega dentro de la rama `fix/wisdom-reindex`, junto al resto del trabajo de la v1.5.1, por petición expresa: son ajustes solicitados antes de cerrar el PR.
+
+## Qué se construye
+
+Una pestaña **«Acerca de»** al final del panel de Configuración, con dos bloques:
+
+1. **Identidad de la aplicación** — versión instalada, fecha de compilación y canal.
+2. **Historial de versiones** — línea de tiempo descendente, con versión, fecha y resumen de cambios.
+
+## Qué NO se construye
+
+Descartado explícitamente en esta entrega, para acotar el alcance:
+
+| Fuera de alcance | Motivo |
+|---|---|
+| Versión en la barra lateral | Complementario; no está en los criterios de aceptación |
+| Menú «Ayuda → Acerca de» | Obligaría a sustituir el `role: 'about'` de macOS para no dejar dos diálogos «Acerca de» distintos |
+| Botón «Buscar actualizaciones» | `electron-updater` ya está integrado, pero abre la gestión de estados de descarga y error |
+| Botón «Copiar información de versión» | No está en los criterios |
+
+El mockup del issue muestra los dos últimos botones; no forman parte de esta entrega.
+
+## Decisiones
+
+### 1. La versión sale de `app.getVersion()`, no de una constante
+
+Ya existía la fontanería: el handler `get-app-version` (`electron/main.ts`) expuesto como
+`window.electronAPI.getAppVersion()`. No se añade IPC nueva.
+
+`app.getVersion()` lee la versión de `package.json`, que es la misma que consume
+electron-builder para nombrar el instalador. Así hay **una sola fuente de verdad** y la
+pantalla no puede desincronizarse del artefacto entregado.
+
+### 2. El historial vive en `CHANGELOG.md`, con parser propio
+
+Alternativas consideradas:
+
+| Opción | Descartada porque |
+|---|---|
+| JSON versionado en el repo | Más simple de renderizar, pero no sirve como notas de release ni se lee en GitHub |
+| API de GitHub Releases | Necesita red: sin conexión la sección queda vacía. Además hoy el repo tiene tags pero no releases publicadas |
+| Derivar de los tags de git | Un tag no trae resumen de cambios; derivarlo de los mensajes de commit da un resultado pobre |
+
+Se elige `CHANGELOG.md` en formato [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)
+porque es la convención del sector, es legible en GitHub y sirve de origen para las notas
+de cada release. El coste es mantener un parser, asumido a cambio de esas ventajas.
+
+### 3. El markdown se resuelve en tiempo de compilación, no en runtime
+
+`CHANGELOG.md` se importa con el sufijo `?raw` de Vite, de modo que su contenido queda
+**dentro del bundle**. No se lee del disco al arrancar.
+
+El motivo no es la comodidad: en la app empaquetada los recursos viven en `resources/`, de
+solo lectura y con rutas distintas a las de desarrollo. Leer ficheros de ahí en runtime es
+justo la clase de divergencia entre dev y producción que provocó la retirada de la v1.5.1-rc.7
+(el cliente de Prisma empaquetado apuntaba a un motor distinto al declarado). Resolviendo en
+compilación, si el fichero falta el build falla; nunca falla en el equipo del usuario.
+
+### 4. Un error de formato no puede vaciar la sección en silencio
+
+Es el riesgo real de parsear un fichero que se edita a mano: una cabecera mal escrita y esa
+versión desaparece sin que nadie se entere. Dos defensas:
+
+- **Tests del parser con entradas malformadas**, no solo con el camino feliz: cabecera sin
+  fecha, versión sin cuerpo, fichero vacío, orden alterado.
+- **Verificación de coherencia**: la entrada superior del `CHANGELOG.md` debe coincidir con
+  la versión de `package.json`. Es la misma clase de comprobación que faltó en el rc.7, donde
+  lo declarado y lo empaquetado no coincidían.
+
+### 5. Historial inicial acotado a las 5 últimas versiones
+
+El issue pide «historial completo». Hay **19 tags** en el repositorio y de ninguno existe un
+resumen de cambios redactado: completarlos es trabajo de redacción, no de código, y es lo que
+puede convertir tres días en dos semanas.
+
+Se entregan las 5 últimas (`v1.5.1`, `v1.5.0`, `v1.4.4`, `v1.4.3`, `v1.4.2`), redactadas a
+partir del historial de git, y el fichero queda preparado para añadir las anteriores cuando
+haya criterio para resumirlas. **Es una desviación consciente del criterio de aceptación** y
+debe validarse en la revisión.
+
+### 6. La pestaña sí se localiza
+
+A diferencia del panel WNTR —que tiene el texto en castellano codificado en el componente—,
+el panel de Configuración ya usa i18next con claves `settings.*` en `es`, `ca` y `en`. Esta
+pestaña sigue esa convención: todo su texto de interfaz pasa por `t()`.
+
+El **contenido** del `CHANGELOG.md` no se traduce: son notas de release, se mantienen en un
+solo idioma.
+
+### 7. La fecha de compilación se inyecta en el build
+
+No existía ninguna forma de conocerla. Se inyecta mediante `define` en `vite.config.ts`. No
+puede calcularse en runtime: `new Date()` daría la fecha en que el usuario abre la app, no la
+de la compilación.
+
+## Proceso de release
+
+**Al preparar cada versión, antes de empaquetar:**
+
+1. Añadir la entrada nueva al principio de `CHANGELOG.md`, respetando el formato:
+
+   ```markdown
+   ## [1.5.2] - 2026-08-20
+
+   Resumen en una o dos frases de lo que cambia para el usuario.
+
+   - Detalle relevante
+   - Otro detalle
+   ```
+
+2. Subir la versión de `package.json` al mismo número.
+3. Comprobar que ambos coinciden: la verificación de coherencia falla si no.
+
+**La fecha es la del merge a `main`, no la de la compilación del candidato.** Una versión
+puede pasar por varios `rc` antes de entrar, y lo que el usuario ve como «fecha de la versión»
+debe ser cuándo quedó liberada. Si el merge se retrasa respecto a lo previsto, hay que
+actualizar la fecha antes de integrar: ninguna comprobación automática puede detectarlo,
+porque una fecha pasada es sintácticamente válida.
+
+El resumen se escribe **para el usuario final**, no para el equipo: qué cambia en su uso de
+la aplicación, no qué ficheros se tocaron.
+
+## Ficheros afectados
+
+| Fichero | Papel |
+|---|---|
+| `CHANGELOG.md` | Fuente única del historial |
+| `src/utils/changelog.ts` | Parser y tipos |
+| `src/utils/changelog.test.ts` | Tests del parser, incluidas entradas malformadas |
+| `src/components/settings/tabs/AboutTab.tsx` | La pestaña |
+| `src/components/settings/SettingsPanel.tsx` | Registro de la pestaña |
+| `src/locales/{es,ca,en}.json` | Claves `settings.about.*` |
+| `vite.config.ts` | Inyección de la fecha de compilación |
+| `.github/workflows/ci.yml` | Job que ejecuta la batería de tests |
+
+## Nota sobre el CI
+
+El criterio de aceptación exige que pasen «lint, tests y build». El CI **no ejecutaba la
+batería de vitest**: corría lint, typecheck, `build:vite`, la integración de WNTR y
+`build-electron` en matriz macOS/Ubuntu/Windows, pero nunca `npm test`.
+
+Se añade el job correspondiente. Es un cambio pequeño en un fichero compartido, y conviene
+saber que a partir de ahora un test roto en cualquier rama bloquea su PR.

--- a/electron/handlers/document.handler.ts
+++ b/electron/handlers/document.handler.ts
@@ -389,29 +389,27 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
 
       console.log(`[Document Handler] Reindexing document: "${document.title}"`)
 
-      // Delete existing chunks first
-      const deletedChunks = await prismaClient.knowledgeChunk.deleteMany({
-        where: { knowledgeId: documentId }
+      // Reindexado real: trocear, generar embeddings y sustituir los chunks.
+      // Antes esto sólo borraba los chunks y devolvía éxito, así que el
+      // documento quedaba "Not Indexed" de forma permanente.
+      const result = await ragService.reindexDocument(documentId, (progress) => {
+        event.sender.send('wisdom:reindex-progress', { documentId, ...progress })
       })
 
-      console.log(`[Document Handler] Deleted ${deletedChunks.count} existing chunks`)
-
-      // Update the document's updatedAt to trigger reprocessing
-      // The chunks were already deleted, so the system should recreate them
-      await prismaClient.hydraulicKnowledge.update({
-        where: { id: documentId },
-        data: {
-          updatedAt: new Date(),
-          // Optionally trigger reprocessing by changing a field slightly
-          version: document.version + '.reindexed'
-        }
-      })
-
-      console.log(`[Document Handler] Document reindexed successfully`)
+      console.log(
+        `[Document Handler] Reindexed "${document.title}": ${result.chunkCount}/${result.totalChunks} chunks` +
+        (result.milvusSynced ? '' : ' (sin sincronizar con Milvus)')
+      )
 
       return {
         success: true,
-        message: 'Document reindexed successfully'
+        chunkCount: result.chunkCount,
+        failedCount: result.failedCount,
+        totalChunks: result.totalChunks,
+        milvusSynced: result.milvusSynced,
+        message: result.failedCount > 0
+          ? `Reindexado con ${result.chunkCount} de ${result.totalChunks} fragmentos (${result.failedCount} fallaron al generar embedding).`
+          : `Reindexado: ${result.chunkCount} fragmentos indexados.`
       }
     } catch (error: any) {
       console.error('Document reindex error:', error)
@@ -598,30 +596,40 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
         totalProcessed: 0,
         successful: 0,
         failed: 0,
+        /** Fragmentos realmente indexados, para poder verificar el resultado. */
+        indexedChunks: 0,
+        /** Documentos reindexados en la BD pero no sincronizados con Milvus. */
+        milvusFailures: 0,
         errors: [] as string[]
       }
 
+      let docIndex = 0
       for (const doc of documentsToReindex) {
+        docIndex += 1
         try {
           console.log(`[Document Handler] Reindexing: "${doc.title}"`)
 
-          if (!options.clearAllEmbeddings) {
-            // Delete existing chunks for this document
-            await prismaClient.knowledgeChunk.deleteMany({
-              where: { knowledgeId: doc.id }
+          // Reindexado real por documento. Un fallo (por ejemplo, el proveedor
+          // de embeddings caído) se cuenta como fallo con su motivo, en lugar
+          // de reportar éxito habiendo borrado los chunks.
+          const result = await ragService.reindexDocument(doc.id, (progress) => {
+            event.sender.send('wisdom:reindex-progress', {
+              documentId: doc.id,
+              title: doc.title,
+              document: docIndex,
+              totalDocuments: documentsToReindex.length,
+              ...progress
             })
-          }
-
-          // Update document to trigger reprocessing
-          await prismaClient.hydraulicKnowledge.update({
-            where: { id: doc.id },
-            data: {
-              updatedAt: new Date(),
-              version: doc.version + '.reindexed-' + Date.now()
-            }
           })
 
           results.successful++
+          results.indexedChunks += result.chunkCount
+          if (result.failedCount > 0) {
+            results.errors.push(
+              `${doc.title}: ${result.failedCount} de ${result.totalChunks} fragmentos sin embedding`
+            )
+          }
+          if (!result.milvusSynced) results.milvusFailures++
         } catch (error: any) {
           console.error(`Failed to reindex document ${doc.id}:`, error)
           results.failed++
@@ -1612,12 +1620,28 @@ export function registerVectorGraphHandlers(prisma?: PrismaClient) {
       if (embeddingCoverage < 80 || indexedPercentage < 80) status = 'degraded'
       if (embeddingCoverage < 50 || totalDocs === 0) status = 'critical'
 
+      // Estado real de Milvus. Antes se devolvía 'connected' escrito a mano, así
+      // que el panel decía "Database: connected" con el servidor vectorial caído
+      // y 0% indexado, que es lo que despistó al diagnosticar un caso real.
+      let vectorStatus = 'disconnected'
+      try {
+        const milvusService = (await import('../../backend/services/milvus.service')).MilvusService.getInstance()
+        await milvusService.ensureConnection()
+        vectorStatus = milvusService.isAvailable() ? 'connected' : 'disconnected'
+      } catch {
+        vectorStatus = 'disconnected'
+      }
+      if (vectorStatus !== 'connected') {
+        issues.push('Milvus (base vectorial) no está disponible: no se puede indexar ni buscar por similitud')
+        status = 'critical'
+      }
+
       const health = {
         status,
         timestamp: new Date().toISOString(),
         issues,
         metrics: {
-          databaseStatus: 'connected',
+          databaseStatus: vectorStatus,
           documents: {
             total: totalDocs,
             indexedPercentage: Math.round(indexedPercentage)

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -1,10 +1,17 @@
-import { ipcMain, BrowserWindow, app } from 'electron'
+import { ipcMain, BrowserWindow, app, dialog } from 'electron'
 import { spawn } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { startMilvusServer } from '../services/milvusProcess'
-import { resetPythonPathCache, savePythonPath } from '../../backend/services/hydraulic/pythonDetector'
+import {
+  resetPythonPathCache,
+  savePythonPath,
+  clearUserPythonPath,
+  getUserPythonPath,
+  getMissingWntrModules,
+  findPythonPath,
+} from '../../backend/services/hydraulic/pythonDetector'
 
 /**
  * Setup handler — instala/repara las dependencias Python que Boorie necesita
@@ -358,5 +365,72 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     }
 
     return { success: true, pythonPath: venvPython, optionalFailed: failedOptional }
+  })
+
+  // --- Selección manual del intérprete de Python ---------------------------
+  // Escape para quien ya tiene su propio entorno (conda, venv propio, ruta no
+  // estándar): la autodetección es una heurística y no puede cubrirlo todo.
+
+  function describePython(pythonPath: string) {
+    const missing = getMissingWntrModules(pythonPath)
+    return {
+      pythonPath,
+      usable: missing !== null,
+      wntrReady: missing !== null && missing.length === 0,
+      missingModules: missing ?? [],
+    }
+  }
+
+  ipcMain.handle('setup:get-python', async () => {
+    const configured = getUserPythonPath()
+    return {
+      success: true,
+      configured,
+      effective: describePython(findPythonPath()),
+    }
+  })
+
+  ipcMain.handle('setup:set-python', async (_event, rawPath: string) => {
+    const pythonPath = (rawPath || '').trim()
+    if (!pythonPath) return { success: false, error: 'empty-path' }
+
+    const missing = getMissingWntrModules(pythonPath)
+    if (missing === null) {
+      return {
+        success: false,
+        error: 'not-a-python',
+        message: 'Esa ruta no ejecuta Python. Indica el ejecutable completo (python.exe en Windows).',
+      }
+    }
+
+    savePythonPath(pythonPath, 'user')
+    resetPythonPathCache()
+    return {
+      success: true,
+      pythonPath,
+      wntrReady: missing.length === 0,
+      missingModules: missing,
+      message: missing.length === 0
+        ? 'Intérprete configurado. WNTR está disponible.'
+        : `Intérprete configurado, pero le faltan módulos: ${missing.join(', ')}.`,
+    }
+  })
+
+  ipcMain.handle('setup:clear-python', async () => {
+    clearUserPythonPath()
+    resetPythonPathCache()
+    return { success: true, effective: describePython(findPythonPath()) }
+  })
+
+  ipcMain.handle('setup:browse-python', async () => {
+    const window = getMainWindow()
+    const filters = process.platform === 'win32'
+      ? [{ name: 'Python', extensions: ['exe'] }]
+      : [{ name: 'Todos los archivos', extensions: ['*'] }]
+    const result = window
+      ? await dialog.showOpenDialog(window, { properties: ['openFile'], filters })
+      : await dialog.showOpenDialog({ properties: ['openFile'], filters })
+    if (result.canceled || result.filePaths.length === 0) return { success: false, canceled: true }
+    return { success: true, path: result.filePaths[0] }
   })
 }

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -91,8 +91,18 @@ interface SetupStatus {
   optionalMissing: string[]
   /** Motivo por el que cada paquete no carga; vacío si el venv no existe. */
   problems?: { name: string; error: string }[]
+  /** El venv está fuera de 3.10–3.13: pip nunca podrá completar Milvus ahí. */
+  venvPythonUnsupported?: boolean
+  /** Hay un intérprete del rango soportado con el que recrear el venv. */
+  canRecreateVenv?: boolean
   message?: string
 }
+
+/** Instrucción única para "instala un Python del rango soportado". */
+const INSTALL_PYTHON_HINT =
+  'Instala Python 3.13 desde python.org/downloads (marca "Add python.exe to PATH"), ' +
+  'reinicia Boorie y vuelve a pulsar "Instalar dependencias". La 3.14 todavía no sirve: ' +
+  'WNTR no publica paquete para ella.'
 
 function getVenvDir(userDataDir: string, repoRoot: string): string {
   // En dev, el repo tiene venv-wntr; reutilizamos.
@@ -369,11 +379,12 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
           ? `WNTR ya funciona con ${effectivePython}. Falta preparar el entorno de Milvus/RAG para poder indexar documentos.`
           : sys
             ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
-            : 'No se encontró un Python compatible (3.10 – 3.13). Descarga Python 3.13 de python.org/downloads, marca "Add Python to PATH" y reinicia Boorie. Ojo: 3.14 todavía no sirve, porque WNTR no publica paquete para esa versión.',
+            : `No se encontró un Python compatible (3.10 – 3.13). ${INSTALL_PYTHON_HINT}`,
       }
     }
 
     const problems = await checkPackagesInstalled(venvPython)
+    const venvVersion = await getPythonVersion(venvPython)
     const missing = missingNames(problems).filter((n) => !isOptionalPackage(n))
     const optionalMissing = missingNames(problems).filter((n) => isOptionalPackage(n))
     const venvReady = missing.length === 0
@@ -381,11 +392,37 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     // su ausencia sí debe seguir avisando: sin él no se indexa nada.
     const milvusMissing = missingNames(problems).filter((n) => MILVUS_PACKAGE_NAMES.includes(n))
 
+    // Un venv heredado fuera de 3.10–3.13 no puede completarse nunca: milvus-lite
+    // sólo publica ruedas Linux/macOS hasta la 2.5.x y la 3.x —la única instalable
+    // en Windows— exige Python >= 3.10. Sin decirlo, el asistente reaparecía en
+    // cada arranque pidiendo paquetes que pip no puede resolver, sin pista alguna
+    // de que el problema era la versión del intérprete (caso de un cliente con un
+    // venv de 3.9 creado por una versión anterior de Boorie).
+    if (venvVersion && !SUPPORTED_PYTHON.test(venvVersion) && (missing.length > 0 || milvusMissing.length > 0)) {
+      const sys = await findSystemPython()
+      return {
+        ready: false,
+        pythonPath: venvPython,
+        pythonVersion: venvVersion,
+        venvPath: venvDir,
+        missing: milvusMissing.length > 0 ? milvusMissing : missing,
+        optionalMissing,
+        problems,
+        venvPythonUnsupported: true,
+        canRecreateVenv: sys !== null,
+        message: sys
+          ? `El entorno de Boorie está sobre ${venvVersion}, y milvus-lite/WNTR necesitan Python 3.10 – 3.13. ` +
+            `Pulsa "Instalar dependencias": el entorno se recreará con ${sys.version} y el anterior se conservará por si acaso.`
+          : `El entorno de Boorie está sobre ${venvVersion} y no hay ningún Python 3.10 – 3.13 en este equipo, ` +
+            `así que pip no puede instalar milvus-lite (sus versiones para Windows exigen 3.10+). ${INSTALL_PYTHON_HINT}`,
+      }
+    }
+
     if ((venvReady || effectiveReady) && milvusMissing.length > 0) {
       return {
         ready: false,
         pythonPath: venvPython,   // los problemas listados vienen del venv
-        pythonVersion: await getPythonVersion(venvPython),
+        pythonVersion: venvVersion,
         venvPath: venvDir,
         missing: milvusMissing,
         optionalMissing: optionalMissing.filter((n) => !milvusMissing.includes(n)),
@@ -398,7 +435,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     return {
       ready: venvReady || effectiveReady,
       pythonPath: venvReady ? venvPython : (effectiveReady ? effectivePython : venvPython),
-      pythonVersion: await getPythonVersion(venvPython),
+      pythonVersion: venvVersion,
       venvPath: venvDir,
       missing: venvReady || effectiveReady ? [] : missing,
       optionalMissing,
@@ -425,7 +462,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       if (!sys) {
         emitProgress(window, {
           stage: 'error',
-          message: 'No se encontró un Python compatible (3.10 – 3.13) en el sistema. Descarga Python 3.13 de python.org/downloads, marca "Add Python to PATH" y reinicia Boorie. La 3.14 no sirve todavía: WNTR no publica paquete para ella.',
+          message: `No se encontró un Python compatible (3.10 – 3.13) en el sistema. ${INSTALL_PYTHON_HINT}`,
         })
         return { success: false, error: 'python-not-found' }
       }
@@ -477,9 +514,13 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
         }
         venvPython = getVenvPython(venvDir)
       } else {
+        // Se continúa (WNTR puede seguir funcionando en el venv viejo), pero hay
+        // que decir que Milvus/RAG no van a completarse aquí: pip no tiene
+        // candidato de milvus-lite para Windows por debajo de 3.10.
         emitProgress(window, {
           stage: 'warning',
-          message: `El entorno de Boorie usa ${existingVersion}, fuera del rango que WNTR soporta (3.10 – 3.13), y no hay otro intérprete instalado. Instala Python 3.13 desde python.org/downloads y reintenta.`,
+          message: `El entorno de Boorie usa ${existingVersion}, fuera del rango que WNTR y Milvus soportan ` +
+            `(3.10 – 3.13), y no hay otro intérprete instalado: el indexado RAG seguirá sin funcionar. ${INSTALL_PYTHON_HINT}`,
         })
       }
     }

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -37,12 +37,19 @@ import {
 // Python 3.9 pip no encuentra candidato y el setup abortaba justo después de
 // instalar wntr, dejando el entorno marcado como "no listo" para siempre.
 // Sin Milvus el RAG degrada, pero WNTR debe seguir funcionando.
+// `wntr` va PRIMERO a propósito: declara numpy>=2.2.6, pandas>=2.0, scipy,
+// networkx y matplotlib, así que dejar que pip resuelva su árbol de una vez
+// evita el escenario que rompió a un tester — instalar antes `numpy>=1.20`
+// dejaba numpy 1.x, pip daba el wntr por instalado y luego `import wntr`
+// fallaba. matplotlib está en la lista porque wntr lo importa al cargarse:
+// sin verificarlo, un fallo suyo se manifestaba como "wntr no instalado".
 const REQUIRED_PACKAGES: { name: string; pip: string; importName: string; optional?: boolean }[] = [
+  { name: 'wntr',                           pip: 'wntr>=0.5.0',                            importName: 'wntr' },
   { name: 'numpy',                          pip: 'numpy>=1.20',                            importName: 'numpy' },
   { name: 'scipy',                          pip: 'scipy>=1.7',                             importName: 'scipy' },
   { name: 'pandas',                         pip: 'pandas>=1.3',                            importName: 'pandas' },
   { name: 'networkx',                       pip: 'networkx>=2.6',                          importName: 'networkx' },
-  { name: 'wntr',                           pip: 'wntr>=0.5.0',                            importName: 'wntr' },
+  { name: 'matplotlib',                     pip: 'matplotlib>=3.4',                        importName: 'matplotlib' },
   { name: 'milvus-lite',                    pip: 'milvus-lite>=2.5.1',                     importName: 'milvus_lite', optional: true },
   { name: 'langchain-ollama',               pip: 'langchain-ollama>=0.2.0',                importName: 'langchain_ollama' },
   { name: 'langchain-nvidia-ai-endpoints',  pip: 'langchain-nvidia-ai-endpoints>=0.3.0',   importName: 'langchain_nvidia_ai_endpoints' },
@@ -60,6 +67,8 @@ interface SetupStatus {
   venvPath: string
   missing: string[]
   optionalMissing: string[]
+  /** Motivo por el que cada paquete no carga; vacío si el venv no existe. */
+  problems?: { name: string; error: string }[]
   message?: string
 }
 
@@ -163,19 +172,66 @@ function emitProgress(window: BrowserWindow | null, payload: any) {
   } catch { /* ignore */ }
 }
 
-async function checkPackagesInstalled(pythonPath: string): Promise<string[]> {
-  const missing: string[] = []
+interface PackageProblem {
+  name: string
+  /** Última línea significativa del traceback: por qué falla el import. */
+  error: string
+}
+
+/**
+ * Comprueba qué paquetes no cargan y **conserva el motivo**. Antes se
+ * descartaba el stderr, así que un `import wntr` que fallaba por matplotlib o
+ * por una DLL de Windows se reportaba como un opaco "verification-failed" y no
+ * había forma de diagnosticarlo desde el equipo del usuario.
+ */
+async function checkPackagesInstalled(pythonPath: string): Promise<PackageProblem[]> {
+  const problems: PackageProblem[] = []
   for (const pkg of REQUIRED_PACKAGES) {
-    const ok = await new Promise<boolean>((resolve) => {
+    const result = await new Promise<{ ok: boolean; stderr: string }>((resolve) => {
       const p = spawn(pythonPath, ['-c', `import ${pkg.importName}`], {
-        stdio: ['ignore', 'ignore', 'ignore'],
+        stdio: ['ignore', 'ignore', 'pipe'],
+        windowsHide: true,
       })
-      p.on('close', (code) => resolve(code === 0))
-      p.on('error', () => resolve(false))
+      let stderr = ''
+      p.stderr?.on('data', (d) => (stderr += d.toString()))
+      p.on('close', (code) => resolve({ ok: code === 0, stderr }))
+      p.on('error', (err) => resolve({ ok: false, stderr: err.message }))
     })
-    if (!ok) missing.push(pkg.name)
+    if (!result.ok) {
+      const lines = result.stderr.trim().split('\n').filter((l) => l.trim().length > 0)
+      const relevant = lines.reverse().find((l) => /Error|Exception/.test(l)) || lines[0] || 'import failed'
+      problems.push({ name: pkg.name, error: relevant.trim() })
+      appendSetupLog(`[check] ${pkg.name}: ${relevant.trim()}\n${result.stderr}`)
+    }
   }
-  return missing
+  return problems
+}
+
+function missingNames(problems: PackageProblem[]): string[] {
+  return problems.map((p) => p.name)
+}
+
+/** Versión del intérprete, para saber si un venv reutilizado es demasiado viejo. */
+async function getPythonVersion(pythonPath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const p = spawn(pythonPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true })
+    let out = ''
+    p.stdout.on('data', (d) => (out += d.toString()))
+    p.stderr.on('data', (d) => (out += d.toString()))
+    p.on('close', (code) => resolve(code === 0 ? out.trim() : null))
+    p.on('error', () => resolve(null))
+  })
+}
+
+/** Fichero de log del setup, para que un incidente se pueda diagnosticar. */
+let setupLogFile: string | null = null
+
+function appendSetupLog(text: string): void {
+  if (!setupLogFile) return
+  try {
+    fs.mkdirSync(path.dirname(setupLogFile), { recursive: true })
+    fs.appendFileSync(setupLogFile, `${text}\n`, 'utf-8')
+  } catch { /* el log no debe romper el setup */ }
 }
 
 async function createVenv(systemPython: SystemPython, venvDir: string, window: BrowserWindow | null): Promise<boolean> {
@@ -212,54 +268,81 @@ async function pipInstall(
     })
     p.stdout.on('data', (d) => {
       const line = d.toString().trim()
-      if (line) emitProgress(window, { stage: 'install', log: line })
+      if (line) {
+        emitProgress(window, { stage: 'install', log: line })
+        appendSetupLog(`[pip ${spec}] ${line}`)
+      }
     })
     p.stderr.on('data', (d) => {
       const line = d.toString().trim()
-      if (line) emitProgress(window, { stage: 'install', log: line })
+      if (line) {
+        emitProgress(window, { stage: 'install', log: line })
+        appendSetupLog(`[pip ${spec}] ${line}`)
+      }
     })
-    p.on('close', (code) => resolve(code === 0))
+    p.on('close', (code) => {
+      appendSetupLog(`[pip ${spec}] exit=${code}`)
+      resolve(code === 0)
+    })
     p.on('error', () => resolve(false))
   })
 }
 
 export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null, userDataDir: string, repoRoot: string) {
+  setupLogFile = path.join(userDataDir, 'logs', 'setup-python.log')
+
   ipcMain.handle('setup:status', async (): Promise<SetupStatus> => {
     const venvDir = getVenvDir(userDataDir, repoRoot)
     const venvPython = getVenvPython(venvDir)
     const venvExists = fs.existsSync(venvPython)
 
+    // El intérprete que WNTR usará de verdad puede ser el del sistema: si ya
+    // tiene el stack completo, el asistente no tiene nada que hacer y no debe
+    // aparecer. Antes sólo se medía el venv, así que el wizard insistía aunque
+    // el usuario tuviera su propia instalación funcionando.
+    const effectivePython = findPythonPath()
+    const effectiveMissing = getMissingWntrModules(effectivePython)
+    const effectiveReady = effectiveMissing !== null && effectiveMissing.length === 0
+
     if (!venvExists) {
       const sys = await findSystemPython()
       const allNames = REQUIRED_PACKAGES.map((p) => p.name)
       return {
-        ready: false,
-        pythonPath: sys?.path ?? null,
+        ready: effectiveReady,
+        pythonPath: effectiveReady ? effectivePython : (sys?.path ?? null),
         pythonVersion: sys?.version ?? null,
         venvPath: venvDir,
-        missing: allNames.filter((n) => !isOptionalPackage(n)),
+        missing: effectiveReady ? [] : allNames.filter((n) => !isOptionalPackage(n)),
         optionalMissing: allNames.filter((n) => isOptionalPackage(n)),
-        message: sys
-          ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
-          : 'Python 3.10 o superior no encontrado. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
+        message: effectiveReady
+          ? `WNTR está disponible en ${effectivePython}. No hace falta preparar nada.`
+          : sys
+            ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
+            : 'Python 3.10 o superior no encontrado. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
       }
     }
 
-    const allMissing = await checkPackagesInstalled(venvPython)
-    const missing = allMissing.filter((n) => !isOptionalPackage(n))
-    const optionalMissing = allMissing.filter((n) => isOptionalPackage(n))
+    const problems = await checkPackagesInstalled(venvPython)
+    const missing = missingNames(problems).filter((n) => !isOptionalPackage(n))
+    const optionalMissing = missingNames(problems).filter((n) => isOptionalPackage(n))
+    const venvReady = missing.length === 0
+
     return {
-      ready: missing.length === 0,
-      pythonPath: venvPython,
-      pythonVersion: 'venv',
+      ready: venvReady || effectiveReady,
+      pythonPath: venvReady ? venvPython : (effectiveReady ? effectivePython : venvPython),
+      pythonVersion: await getPythonVersion(venvPython),
       venvPath: venvDir,
-      missing,
+      missing: venvReady || effectiveReady ? [] : missing,
       optionalMissing,
-      message: missing.length === 0
+      problems,
+      message: venvReady
         ? (optionalMissing.length === 0
           ? 'Todo listo.'
           : `Todo listo (guardrails opcional no disponible: ${optionalMissing.join(', ')}).`)
-        : `Faltan ${missing.length} paquete${missing.length === 1 ? '' : 's'} Python.`,
+        : effectiveReady
+          ? `WNTR está disponible en ${effectivePython}. El entorno propio de Boorie está incompleto (${missing.join(', ')}), pero no es necesario.`
+          : `Faltan ${missing.length} paquete${missing.length === 1 ? '' : 's'} Python: ` +
+            problems.filter((p) => !isOptionalPackage(p.name)).map((p) => `${p.name} (${p.error})`).join('; '),
     }
   })
 
@@ -286,6 +369,38 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       venvPython = getVenvPython(venvDir)
     }
 
+    // Un venv heredado de versiones anteriores puede estar hecho con Python
+    // 3.9 (lo aceptábamos entonces). Ahí pip no puede resolver el árbol de
+    // wntr 1.5 (numpy>=2.2.6 exige 3.10) e "instala" versiones incompatibles
+    // que luego no importan. Lo apartamos y creamos uno nuevo.
+    const existingVersion = await getPythonVersion(venvPython)
+    if (existingVersion && !SUPPORTED_PYTHON.test(existingVersion)) {
+      const sys = await findSystemPython()
+      if (sys) {
+        const archived = `${venvDir}-old-${Date.now()}`
+        emitProgress(window, {
+          stage: 'venv',
+          message: `El entorno de Boorie usa ${existingVersion}; se recreará con ${sys.version}. El anterior se conserva en ${archived}.`,
+        })
+        appendSetupLog(`[recreate] ${existingVersion} -> ${sys.version}; archivado en ${archived}`)
+        try {
+          fs.renameSync(venvDir, archived)
+        } catch (error) {
+          appendSetupLog(`[recreate] no se pudo apartar el venv: ${String(error)}`)
+        }
+        if (!(await createVenv(sys, venvDir, window))) {
+          emitProgress(window, { stage: 'error', message: 'No se pudo recrear el entorno Python.' })
+          return { success: false, error: 'venv-recreation-failed' }
+        }
+        venvPython = getVenvPython(venvDir)
+      } else {
+        emitProgress(window, {
+          stage: 'warning',
+          message: `El entorno de Boorie usa ${existingVersion}, pero WNTR necesita Python 3.10 o superior y no hay ninguno instalado. Instálalo desde python.org y reintenta.`,
+        })
+      }
+    }
+
     // El venv ya existe (o se acaba de crear): fijamos PYTHON_PATH ya mismo
     // para que WNTR/Milvus puedan usarlo aunque un paquete opcional falle
     // más abajo y el setup termine en estado parcial.
@@ -310,7 +425,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     // Step 3 — install required packages. Un paquete opcional (nemoguardrails)
     // que falle se registra y se salta, pero no aborta el setup: Milvus/WNTR
     // no dependen de él y deben quedar operativos igualmente (issue #21).
-    const missing = await checkPackagesInstalled(venvPython)
+    const missing = missingNames(await checkPackagesInstalled(venvPython))
     const total = missing.length
     let i = 0
     const failedOptional: string[] = []
@@ -337,13 +452,29 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     }
 
     // Step 4 — verify (solo paquetes core; los opcionales fallidos ya se reportaron arriba)
-    const stillMissing = (await checkPackagesInstalled(venvPython)).filter((n) => !isOptionalPackage(n))
-    if (stillMissing.length > 0) {
+    const stillFailing = (await checkPackagesInstalled(venvPython)).filter((p) => !isOptionalPackage(p.name))
+    if (stillFailing.length > 0) {
+      // pip puede terminar con éxito y el import fallar igualmente (una DLL de
+      // Windows que no carga, una dependencia incompatible…). Reportamos el
+      // motivo real en lugar de un "verification-failed" que no dice nada.
+      const detail = stillFailing.map((p) => `${p.name}: ${p.error}`).join('\n')
+      const venvVersion = await getPythonVersion(venvPython)
+      appendSetupLog(`[verify] venv=${venvPython} (${venvVersion ?? 'versión desconocida'})\n${detail}`)
       emitProgress(window, {
         stage: 'error',
-        message: `Tras la instalación, siguen faltando: ${stillMissing.join(', ')}.`,
+        message: `pip terminó, pero estos paquetes siguen sin cargar:\n${detail}\n\n` +
+          `Intérprete: ${venvPython} (${venvVersion ?? 'versión desconocida'})\n` +
+          `Detalle completo en: ${setupLogFile}`,
       })
-      return { success: false, error: 'verification-failed', missing: stillMissing }
+      return {
+        success: false,
+        error: 'verification-failed',
+        missing: missingNames(stillFailing),
+        problems: stillFailing,
+        pythonPath: venvPython,
+        pythonVersion: venvVersion,
+        logFile: setupLogFile,
+      }
     }
 
     emitProgress(window, {

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { startMilvusServer } from '../services/milvusProcess'
-import { resetPythonPathCache } from '../../backend/services/hydraulic/pythonDetector'
+import { resetPythonPathCache, savePythonPath } from '../../backend/services/hydraulic/pythonDetector'
 
 /**
  * Setup handler — instala/repara las dependencias Python que Boorie necesita
@@ -25,13 +25,18 @@ import { resetPythonPathCache } from '../../backend/services/hydraulic/pythonDet
 // el resto del setup: Milvus/WNTR/RAG dependen solo de los paquetes "core".
 // nemoguardrails es opcional (moderación) y no debe poder dejar Milvus
 // inutilizable si su instalación falla — ver issue #21/#19.
+// milvus-lite también es opcional: las ruedas 2.5.x sólo existen para Linux y
+// macOS y la 3.x (pura Python) exige Python >= 3.10, así que en Windows con
+// Python 3.9 pip no encuentra candidato y el setup abortaba justo después de
+// instalar wntr, dejando el entorno marcado como "no listo" para siempre.
+// Sin Milvus el RAG degrada, pero WNTR debe seguir funcionando.
 const REQUIRED_PACKAGES: { name: string; pip: string; importName: string; optional?: boolean }[] = [
   { name: 'numpy',                          pip: 'numpy>=1.20',                            importName: 'numpy' },
   { name: 'scipy',                          pip: 'scipy>=1.7',                             importName: 'scipy' },
   { name: 'pandas',                         pip: 'pandas>=1.3',                            importName: 'pandas' },
   { name: 'networkx',                       pip: 'networkx>=2.6',                          importName: 'networkx' },
   { name: 'wntr',                           pip: 'wntr>=0.5.0',                            importName: 'wntr' },
-  { name: 'milvus-lite',                    pip: 'milvus-lite>=2.5.1',                     importName: 'milvus_lite' },
+  { name: 'milvus-lite',                    pip: 'milvus-lite>=2.5.1',                     importName: 'milvus_lite', optional: true },
   { name: 'langchain-ollama',               pip: 'langchain-ollama>=0.2.0',                importName: 'langchain_ollama' },
   { name: 'langchain-nvidia-ai-endpoints',  pip: 'langchain-nvidia-ai-endpoints>=0.3.0',   importName: 'langchain_nvidia_ai_endpoints' },
   { name: 'nemoguardrails',                 pip: 'nemoguardrails>=0.10.0',                 importName: 'nemoguardrails', optional: true },
@@ -69,41 +74,71 @@ function getVenvPython(venvDir: string): string {
   return process.platform === 'win32' ? winPath : unixPath
 }
 
-async function findSystemPython(): Promise<{ path: string; version: string } | null> {
-  const candidates: string[] = []
+interface SystemPython {
+  path: string
+  /** Argumentos previos a `-m` (el lanzador `py` de Windows necesita `-3`). */
+  args: string[]
+  version: string
+}
+
+// Milvus Lite y varias dependencias del stack RAG exigen Python >= 3.10.
+// Aceptar 3.9 hacía que el setup creara un venv en el que pip no podía
+// resolver milvus-lite y terminaba abortando.
+const SUPPORTED_PYTHON = /Python 3\.(1\d|[2-9]\d)(\.|\s|$)/
+
+async function findSystemPython(): Promise<SystemPython | null> {
+  const candidates: { cmd: string; args: string[] }[] = []
 
   if (process.platform === 'win32') {
-    candidates.push('python', 'python3', 'py')
-    const userPython = path.join(
-      os.homedir(),
-      'AppData', 'Local', 'Programs', 'Python', 'Python311', 'python.exe'
-    )
-    candidates.push(userPython)
+    const versions = ['313', '312', '311', '310']
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+
+    candidates.push({ cmd: 'python', args: [] })
+    candidates.push({ cmd: 'python3', args: [] })
+    // Lanzador oficial: resuelve la versión más reciente instalada
+    candidates.push({ cmd: 'py', args: ['-3'] })
+    // Rutas por defecto del instalador de python.org (por usuario y global)
+    for (const v of versions) {
+      candidates.push({
+        cmd: path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Python', `Python${v}`, 'python.exe'),
+        args: [],
+      })
+      candidates.push({ cmd: path.join(programFiles, `Python${v}`, 'python.exe'), args: [] })
+      candidates.push({ cmd: path.join('C:\\', `Python${v}`, 'python.exe'), args: [] })
+    }
   } else {
-    candidates.push(
+    for (const p of [
+      '/opt/homebrew/bin/python3.13',
+      '/opt/homebrew/bin/python3.12',
       '/opt/homebrew/bin/python3.11',
       '/opt/homebrew/bin/python3.10',
       '/opt/homebrew/bin/python3',
+      '/usr/local/bin/python3.12',
       '/usr/local/bin/python3.11',
       '/usr/local/bin/python3.10',
       '/usr/local/bin/python3',
       '/usr/bin/python3',
       'python3',
-    )
+    ]) {
+      candidates.push({ cmd: p, args: [] })
+    }
   }
 
   for (const candidate of candidates) {
     try {
       const version = await new Promise<string | null>((resolve) => {
-        const p = spawn(candidate, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] })
+        const p = spawn(candidate.cmd, [...candidate.args, '--version'], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        })
         let out = ''
         p.stdout.on('data', (d) => (out += d.toString()))
         p.stderr.on('data', (d) => (out += d.toString()))
         p.on('close', (code) => resolve(code === 0 ? out.trim() : null))
         p.on('error', () => resolve(null))
       })
-      if (version && /Python 3\.(9|10|11|12|13)/.test(version)) {
-        return { path: candidate, version }
+      if (version && SUPPORTED_PYTHON.test(version)) {
+        return { path: candidate.cmd, args: candidate.args, version }
       }
     } catch {
       // try next
@@ -136,10 +171,13 @@ async function checkPackagesInstalled(pythonPath: string): Promise<string[]> {
   return missing
 }
 
-async function createVenv(systemPython: string, venvDir: string, window: BrowserWindow | null): Promise<boolean> {
+async function createVenv(systemPython: SystemPython, venvDir: string, window: BrowserWindow | null): Promise<boolean> {
   emitProgress(window, { stage: 'venv', message: 'Creando entorno Python (venv-wntr)…' })
   return new Promise((resolve) => {
-    const p = spawn(systemPython, ['-m', 'venv', venvDir], { stdio: ['ignore', 'pipe', 'pipe'] })
+    const p = spawn(systemPython.path, [...systemPython.args, '-m', 'venv', venvDir], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
     p.stdout.on('data', (d) => emitProgress(window, { stage: 'venv', log: d.toString() }))
     p.stderr.on('data', (d) => emitProgress(window, { stage: 'venv', log: d.toString() }))
     p.on('close', (code) => resolve(code === 0))
@@ -233,7 +271,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
         })
         return { success: false, error: 'python-not-found' }
       }
-      const ok = await createVenv(sys.path, venvDir, window)
+      const ok = await createVenv(sys, venvDir, window)
       if (!ok) {
         emitProgress(window, { stage: 'error', message: 'No se pudo crear el entorno Python.' })
         return { success: false, error: 'venv-creation-failed' }
@@ -245,6 +283,10 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     // para que WNTR/Milvus puedan usarlo aunque un paquete opcional falle
     // más abajo y el setup termine en estado parcial.
     process.env.PYTHON_PATH = venvPython
+    // …y lo persistimos en userData: PYTHON_PATH sólo vive en memoria, así que
+    // sin esto el siguiente arranque volvía a "Python/WNTR no instalado".
+    savePythonPath(venvPython)
+    resetPythonPathCache()
 
     // Step 2 — upgrade pip
     emitProgress(window, { stage: 'pip', message: 'Actualizando pip…' })

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -234,10 +234,15 @@ function appendSetupLog(text: string): void {
   } catch { /* el log no debe romper el setup */ }
 }
 
-async function createVenv(systemPython: SystemPython, venvDir: string, window: BrowserWindow | null): Promise<boolean> {
+async function createVenv(
+  systemPython: SystemPython,
+  venvDir: string,
+  window: BrowserWindow | null,
+  extraArgs: string[] = [],
+): Promise<boolean> {
   emitProgress(window, { stage: 'venv', message: 'Creando entorno Python (venv-wntr)…' })
   return new Promise((resolve) => {
-    const p = spawn(systemPython.path, [...systemPython.args, '-m', 'venv', venvDir], {
+    const p = spawn(systemPython.path, [...systemPython.args, '-m', 'venv', ...extraArgs, venvDir], {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     })
@@ -383,14 +388,29 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
           message: `El entorno de Boorie usa ${existingVersion}; se recreará con ${sys.version}. El anterior se conserva en ${archived}.`,
         })
         appendSetupLog(`[recreate] ${existingVersion} -> ${sys.version}; archivado en ${archived}`)
+
+        // Si no se puede apartar (antivirus, un python del venv aún vivo…) hay
+        // que vaciarlo con `--clear`: crear encima dejaría el site-packages de
+        // 3.9 con un intérprete nuevo, que es peor que no tocar nada.
+        let archivedOk = true
         try {
           fs.renameSync(venvDir, archived)
         } catch (error) {
-          appendSetupLog(`[recreate] no se pudo apartar el venv: ${String(error)}`)
+          archivedOk = false
+          appendSetupLog(`[recreate] no se pudo apartar el venv, se recreará con --clear: ${String(error)}`)
+          emitProgress(window, {
+            stage: 'venv',
+            message: 'No se pudo conservar el entorno anterior; se vaciará y recreará.',
+          })
         }
-        if (!(await createVenv(sys, venvDir, window))) {
-          emitProgress(window, { stage: 'error', message: 'No se pudo recrear el entorno Python.' })
-          return { success: false, error: 'venv-recreation-failed' }
+
+        if (!(await createVenv(sys, venvDir, window, archivedOk ? [] : ['--clear']))) {
+          emitProgress(window, {
+            stage: 'error',
+            message: 'No se pudo recrear el entorno Python. Cierra Boorie, borra la carpeta ' +
+              `${venvDir} y vuelve a intentarlo.`,
+          })
+          return { success: false, error: 'venv-recreation-failed', venvPath: venvDir }
         }
         venvPython = getVenvPython(venvDir)
       } else {

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -20,7 +20,7 @@ import {
  * Settings → Guardrails si algo se rompe.
  *
  * Estrategia:
- *   1. Detecta un Python 3.10+ del sistema.
+ *   1. Detecta un Python del sistema en el rango soportado (3.10 – 3.13).
  *   2. Crea (o reutiliza) `venv-wntr/` en la carpeta de userData (writable
  *      en producción) o en el repo en dev.
  *   3. Hace `pip install` de los paquetes necesarios uno por uno con
@@ -43,7 +43,14 @@ import {
 // dejaba numpy 1.x, pip daba el wntr por instalado y luego `import wntr`
 // fallaba. matplotlib está en la lista porque wntr lo importa al cargarse:
 // sin verificarlo, un fallo suyo se manifestaba como "wntr no instalado".
-const REQUIRED_PACKAGES: { name: string; pip: string; importName: string; optional?: boolean }[] = [
+const REQUIRED_PACKAGES: {
+  name: string
+  pip: string
+  importName: string
+  optional?: boolean
+  /** Paquetes del mismo grupo se instalan en una única orden de pip. */
+  group?: string
+}[] = [
   { name: 'wntr',                           pip: 'wntr>=0.5.0',                            importName: 'wntr' },
   { name: 'numpy',                          pip: 'numpy>=1.20',                            importName: 'numpy' },
   { name: 'scipy',                          pip: 'scipy>=1.7',                             importName: 'scipy' },
@@ -56,8 +63,15 @@ const REQUIRED_PACKAGES: { name: string; pip: string; importName: string; option
   // él, `import milvus_lite` funciona y el servidor muere al arrancar: el RAG
   // se queda con 0 chunks y el panel informa "100% documents not indexed".
   { name: 'pymilvus',                       pip: 'pymilvus>=2.4',                          importName: 'pymilvus', optional: true },
-  { name: 'langchain-ollama',               pip: 'langchain-ollama>=0.2.0',                importName: 'langchain_ollama' },
-  { name: 'langchain-nvidia-ai-endpoints',  pip: 'langchain-nvidia-ai-endpoints>=0.3.0',   importName: 'langchain_nvidia_ai_endpoints' },
+  // Se instalan juntos y son opcionales. Juntos porque langchain-ollama exige
+  // langchain-core>=1.2.21 y langchain-nvidia-ai-endpoints >=1.4.7:
+  // instalándolos uno a uno pip deja un langchain_core que no satisface a
+  // ambos y el import falla con "cannot import name 'content'" / "'ModelProfile'".
+  // Opcionales porque sólo alimentan guardrails y el proveedor NVIDIA: ni WNTR
+  // ni el indexado de Milvus dependen de ellos, y su fallo no debe dejar el
+  // asistente en estado de error permanente.
+  { name: 'langchain-ollama',               pip: 'langchain-ollama>=0.2.0',                importName: 'langchain_ollama', optional: true, group: 'langchain' },
+  { name: 'langchain-nvidia-ai-endpoints',  pip: 'langchain-nvidia-ai-endpoints>=0.3.0',   importName: 'langchain_nvidia_ai_endpoints', optional: true, group: 'langchain' },
   { name: 'nemoguardrails',                 pip: 'nemoguardrails>=0.10.0',                 importName: 'nemoguardrails', optional: true },
 ]
 
@@ -105,23 +119,29 @@ interface SystemPython {
   version: string
 }
 
-// Milvus Lite y varias dependencias del stack RAG exigen Python >= 3.10.
-// Aceptar 3.9 hacía que el setup creara un venv en el que pip no podía
-// resolver milvus-lite y terminaba abortando.
-const SUPPORTED_PYTHON = /Python 3\.(1\d|[2-9]\d)(\.|\s|$)/
+// Rango soportado: 3.10 – 3.13.
+//   - Por abajo: Milvus Lite y el stack RAG exigen >= 3.10, y en 3.9 pip no
+//     podía resolver milvus-lite.
+//   - Por arriba: wntr 1.5 no publica rueda para cp314 en Windows (sí para
+//     cp313) y nemoguardrails declara python <3.14. Un venv sobre 3.14 deja
+//     WNTR ininstalable, que es lo que le ocurrió a un cliente con Anaconda
+//     3.14.6: pip "terminaba" y el import seguía fallando.
+const SUPPORTED_PYTHON = /Python 3\.(1[0-3])(\.|\s|$)/
 
 async function findSystemPython(): Promise<SystemPython | null> {
   const candidates: { cmd: string; args: string[] }[] = []
+
+  // Override explícito: si el usuario fijó PYTHON_PATH, manda.
+  if (process.env.PYTHON_PATH) candidates.push({ cmd: process.env.PYTHON_PATH, args: [] })
 
   if (process.platform === 'win32') {
     const versions = ['313', '312', '311', '310']
     const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
 
-    candidates.push({ cmd: 'python', args: [] })
-    candidates.push({ cmd: 'python3', args: [] })
-    // Lanzador oficial: resuelve la versión más reciente instalada
-    candidates.push({ cmd: 'py', args: ['-3'] })
-    // Rutas por defecto del instalador de python.org (por usuario y global)
+    // Primero versiones concretas soportadas y sólo al final los comandos
+    // genéricos: en un equipo con Anaconda, `python` resuelve a la versión que
+    // tenga instalada (3.14 en el caso que investigamos) y se llevaba la
+    // elección aunque hubiera un 3.13 perfectamente válido al lado.
     for (const v of versions) {
       candidates.push({
         cmd: path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Python', `Python${v}`, 'python.exe'),
@@ -129,17 +149,28 @@ async function findSystemPython(): Promise<SystemPython | null> {
       })
       candidates.push({ cmd: path.join(programFiles, `Python${v}`, 'python.exe'), args: [] })
       candidates.push({ cmd: path.join('C:\\', `Python${v}`, 'python.exe'), args: [] })
+      // Lanzador oficial con versión explícita
+      candidates.push({ cmd: 'py', args: [`-3.${v.slice(1)}`] })
     }
+    candidates.push({ cmd: 'python', args: [] })
+    candidates.push({ cmd: 'python3', args: [] })
+    candidates.push({ cmd: 'py', args: ['-3'] })
   } else {
+    // Igual que en Windows: versiones concretas primero, genéricos al final,
+    // para que un python3 que apunte a 3.14 no se lleve la elección.
     for (const p of [
       '/opt/homebrew/bin/python3.13',
       '/opt/homebrew/bin/python3.12',
       '/opt/homebrew/bin/python3.11',
       '/opt/homebrew/bin/python3.10',
-      '/opt/homebrew/bin/python3',
+      '/usr/local/bin/python3.13',
       '/usr/local/bin/python3.12',
       '/usr/local/bin/python3.11',
       '/usr/local/bin/python3.10',
+      '/usr/bin/python3.13',
+      '/usr/bin/python3.12',
+      '/usr/bin/python3.11',
+      '/opt/homebrew/bin/python3',
       '/usr/local/bin/python3',
       '/usr/bin/python3',
       'python3',
@@ -263,11 +294,12 @@ async function createVenv(
 
 async function pipInstall(
   pythonPath: string,
-  spec: string,
+  specs: string[],
   window: BrowserWindow | null,
   current: number,
   total: number,
 ): Promise<boolean> {
+  const spec = specs.join(' ')
   emitProgress(window, {
     stage: 'install',
     current,
@@ -276,8 +308,11 @@ async function pipInstall(
     message: `Instalando ${spec} (${current}/${total})…`,
   })
   return new Promise((resolve) => {
-    const p = spawn(pythonPath, ['-m', 'pip', 'install', '--upgrade', spec], {
+    // Varios specs en una sola invocación: pip resuelve sus restricciones
+    // conjuntamente en lugar de dejar versiones incompatibles entre sí.
+    const p = spawn(pythonPath, ['-m', 'pip', 'install', '--upgrade', ...specs], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     })
     p.stdout.on('data', (d) => {
       const line = d.toString().trim()
@@ -334,7 +369,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
           ? `WNTR ya funciona con ${effectivePython}. Falta preparar el entorno de Milvus/RAG para poder indexar documentos.`
           : sys
             ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
-            : 'Python 3.10 o superior no encontrado. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
+            : 'No se encontró un Python compatible (3.10 – 3.13). Descarga Python 3.13 de python.org/downloads, marca "Add Python to PATH" y reinicia Boorie. Ojo: 3.14 todavía no sirve, porque WNTR no publica paquete para esa versión.',
       }
     }
 
@@ -349,7 +384,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     if ((venvReady || effectiveReady) && milvusMissing.length > 0) {
       return {
         ready: false,
-        pythonPath: venvReady ? venvPython : effectivePython,
+        pythonPath: venvPython,   // los problemas listados vienen del venv
         pythonVersion: await getPythonVersion(venvPython),
         venvPath: venvDir,
         missing: milvusMissing,
@@ -390,7 +425,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       if (!sys) {
         emitProgress(window, {
           stage: 'error',
-          message: 'No se encontró Python 3.10 o superior en el sistema. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
+          message: 'No se encontró un Python compatible (3.10 – 3.13) en el sistema. Descarga Python 3.13 de python.org/downloads, marca "Add Python to PATH" y reinicia Boorie. La 3.14 no sirve todavía: WNTR no publica paquete para ella.',
         })
         return { success: false, error: 'python-not-found' }
       }
@@ -402,10 +437,10 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       venvPython = getVenvPython(venvDir)
     }
 
-    // Un venv heredado de versiones anteriores puede estar hecho con Python
-    // 3.9 (lo aceptábamos entonces). Ahí pip no puede resolver el árbol de
-    // wntr 1.5 (numpy>=2.2.6 exige 3.10) e "instala" versiones incompatibles
-    // que luego no importan. Lo apartamos y creamos uno nuevo.
+    // Un venv heredado puede estar fuera del rango soportado: hecho con 3.9
+    // (lo aceptábamos antes) o con 3.14 (donde wntr no tiene rueda para
+    // Windows). En ambos casos pip "instala" y el import falla después, así que
+    // lo apartamos y creamos uno nuevo con un intérprete del rango 3.10–3.13.
     const existingVersion = await getPythonVersion(venvPython)
     if (existingVersion && !SUPPORTED_PYTHON.test(existingVersion)) {
       const sys = await findSystemPython()
@@ -444,7 +479,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       } else {
         emitProgress(window, {
           stage: 'warning',
-          message: `El entorno de Boorie usa ${existingVersion}, pero WNTR necesita Python 3.10 o superior y no hay ninguno instalado. Instálalo desde python.org y reintenta.`,
+          message: `El entorno de Boorie usa ${existingVersion}, fuera del rango que WNTR soporta (3.10 – 3.13), y no hay otro intérprete instalado. Instala Python 3.13 desde python.org/downloads y reintenta.`,
         })
       }
     }
@@ -477,11 +512,31 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     const total = missing.length
     let i = 0
     const failedOptional: string[] = []
+    const doneGroups = new Set<string>()
     for (const name of missing) {
       i += 1
       const pkg = REQUIRED_PACKAGES.find((p) => p.name === name)
       if (!pkg) continue
-      const ok = await pipInstall(venvPython, pkg.pip, window, i, total)
+
+      // Los paquetes de un grupo van en una sola orden de pip para que el
+      // resolutor vea todas sus restricciones a la vez.
+      if (pkg.group) {
+        if (doneGroups.has(pkg.group)) continue
+        doneGroups.add(pkg.group)
+        const specs = REQUIRED_PACKAGES.filter((p) => p.group === pkg.group && missing.includes(p.name))
+        const okGroup = await pipInstall(venvPython, specs.map((p) => p.pip), window, i, total)
+        if (!okGroup) {
+          failedOptional.push(...specs.filter((p) => p.optional).map((p) => p.name))
+          emitProgress(window, {
+            stage: 'warning',
+            message: `No se pudo instalar el grupo ${pkg.group} (${specs.map((p) => p.name).join(', ')}). ` +
+              'Se continúa: WNTR y el indexado de Milvus no dependen de él.',
+          })
+        }
+        continue
+      }
+
+      const ok = await pipInstall(venvPython, [pkg.pip], window, i, total)
       if (!ok) {
         if (pkg.optional) {
           failedOptional.push(pkg.name)

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -13,7 +13,7 @@ import { resetPythonPathCache, savePythonPath } from '../../backend/services/hyd
  * Settings → Guardrails si algo se rompe.
  *
  * Estrategia:
- *   1. Detecta un Python 3.9+ del sistema.
+ *   1. Detecta un Python 3.10+ del sistema.
  *   2. Crea (o reutiliza) `venv-wntr/` en la carpeta de userData (writable
  *      en producción) o en el repo en dev.
  *   3. Hace `pip install` de los paquetes necesarios uno por uno con
@@ -234,7 +234,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
         optionalMissing: allNames.filter((n) => isOptionalPackage(n)),
         message: sys
           ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
-          : 'Python 3.9+ no encontrado. Instálalo desde python.org y reinicia Boorie.',
+          : 'Python 3.10 o superior no encontrado. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
       }
     }
 
@@ -267,7 +267,7 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       if (!sys) {
         emitProgress(window, {
           stage: 'error',
-          message: 'No se encontró Python 3.9+ en el sistema. Instálalo desde python.org y reinicia Boorie.',
+          message: 'No se encontró Python 3.10 o superior en el sistema. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
         })
         return { success: false, error: 'python-not-found' }
       }

--- a/electron/handlers/setup.handler.ts
+++ b/electron/handlers/setup.handler.ts
@@ -51,10 +51,18 @@ const REQUIRED_PACKAGES: { name: string; pip: string; importName: string; option
   { name: 'networkx',                       pip: 'networkx>=2.6',                          importName: 'networkx' },
   { name: 'matplotlib',                     pip: 'matplotlib>=3.4',                        importName: 'matplotlib' },
   { name: 'milvus-lite',                    pip: 'milvus-lite>=2.5.1',                     importName: 'milvus_lite', optional: true },
+  // milvus-lite 3.x NO declara pymilvus entre sus dependencias, pero su
+  // adaptador gRPC hace `from pymilvus.grpc_gen import milvus_pb2_grpc`. Sin
+  // él, `import milvus_lite` funciona y el servidor muere al arrancar: el RAG
+  // se queda con 0 chunks y el panel informa "100% documents not indexed".
+  { name: 'pymilvus',                       pip: 'pymilvus>=2.4',                          importName: 'pymilvus', optional: true },
   { name: 'langchain-ollama',               pip: 'langchain-ollama>=0.2.0',                importName: 'langchain_ollama' },
   { name: 'langchain-nvidia-ai-endpoints',  pip: 'langchain-nvidia-ai-endpoints>=0.3.0',   importName: 'langchain_nvidia_ai_endpoints' },
   { name: 'nemoguardrails',                 pip: 'nemoguardrails>=0.10.0',                 importName: 'nemoguardrails', optional: true },
 ]
+
+/** Paquetes sin los que Milvus Lite no puede servir y el RAG no indexa. */
+const MILVUS_PACKAGE_NAMES = ['milvus-lite', 'pymilvus']
 
 function isOptionalPackage(name: string): boolean {
   return REQUIRED_PACKAGES.find((p) => p.name === name)?.optional === true
@@ -313,14 +321,17 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
       const sys = await findSystemPython()
       const allNames = REQUIRED_PACKAGES.map((p) => p.name)
       return {
-        ready: effectiveReady,
+        // Sin venv no hay Milvus, y sin Milvus el RAG queda sin indexar. Se
+        // avisa aunque WNTR ya funcione: la degradación silenciosa del RAG es
+        // justo el fallo que reportó un cliente ("100% documents not indexed").
+        ready: false,
         pythonPath: effectiveReady ? effectivePython : (sys?.path ?? null),
         pythonVersion: sys?.version ?? null,
         venvPath: venvDir,
-        missing: effectiveReady ? [] : allNames.filter((n) => !isOptionalPackage(n)),
+        missing: allNames.filter((n) => !isOptionalPackage(n)),
         optionalMissing: allNames.filter((n) => isOptionalPackage(n)),
         message: effectiveReady
-          ? `WNTR está disponible en ${effectivePython}. No hace falta preparar nada.`
+          ? `WNTR ya funciona con ${effectivePython}. Falta preparar el entorno de Milvus/RAG para poder indexar documentos.`
           : sys
             ? 'venv no creado todavía. Boorie puede crearlo automáticamente.'
             : 'Python 3.10 o superior no encontrado. Instálalo desde python.org (marcando "Add Python to PATH") y reinicia Boorie.',
@@ -331,6 +342,23 @@ export function registerSetupHandlers(getMainWindow: () => BrowserWindow | null,
     const missing = missingNames(problems).filter((n) => !isOptionalPackage(n))
     const optionalMissing = missingNames(problems).filter((n) => isOptionalPackage(n))
     const venvReady = missing.length === 0
+    // Milvus es "opcional" para no bloquear WNTR si su instalación falla, pero
+    // su ausencia sí debe seguir avisando: sin él no se indexa nada.
+    const milvusMissing = missingNames(problems).filter((n) => MILVUS_PACKAGE_NAMES.includes(n))
+
+    if ((venvReady || effectiveReady) && milvusMissing.length > 0) {
+      return {
+        ready: false,
+        pythonPath: venvReady ? venvPython : effectivePython,
+        pythonVersion: await getPythonVersion(venvPython),
+        venvPath: venvDir,
+        missing: milvusMissing,
+        optionalMissing: optionalMissing.filter((n) => !milvusMissing.includes(n)),
+        problems: problems.filter((p) => milvusMissing.includes(p.name)),
+        message: `WNTR funciona, pero falta ${milvusMissing.join(' y ')} para el indexado RAG: ` +
+          'sin ellos Milvus no arranca y los documentos quedan sin indexar.',
+      }
+    }
 
     return {
       ready: venvReady || effectiveReady,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -686,7 +686,7 @@ if (!ENABLE_HARDWARE_ACCELERATION) {
 import { ServiceContainer } from '../backend/services'
 import { HandlersManager } from './handlers'
 import { appLogger } from '../backend/utils/logger'
-import { findPythonPath } from '../backend/services/hydraulic/pythonDetector'
+import { findPythonForMilvus } from '../backend/services/hydraulic/pythonDetector'
 import { startMilvusServer, stopMilvusServer } from './services/milvusProcess'
 
 log.transports.file.level = 'info'
@@ -959,7 +959,9 @@ async function initializeApplication(): Promise<void> {
     // process outside of the dev-only dev-runner.js, so Milvus was never
     // running in the installed app (root cause of issues #19/#20/#21).
     try {
-      startMilvusServer(findPythonPath(), milvusDataDir)
+      // Milvus necesita el venv gestionado (el que tiene milvus_lite), no el
+      // Python del sistema que WNTR puede estar usando.
+      startMilvusServer(findPythonForMilvus(), milvusDataDir)
     } catch (error) {
       appLogger.warn('Failed to start embedded Milvus Lite server', error as Error)
     }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -275,6 +275,11 @@ const electronAPI = {
     update: (documentId: string, updates: any) => ipcRenderer.invoke('wisdom:update', documentId, updates),
 
     reindex: (documentId: string) => ipcRenderer.invoke('wisdom:reindex', documentId),
+    onReindexProgress: (callback: (data: any) => void) => {
+      const wrapped = (_e: any, data: any) => callback(data)
+      ipcRenderer.on('wisdom:reindex-progress', wrapped)
+      return () => ipcRenderer.removeListener('wisdom:reindex-progress', wrapped)
+    },
 
     getEmbeddingProviders: () => ipcRenderer.invoke('wisdom:getEmbeddingProviders'),
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -367,6 +367,10 @@ const electronAPI = {
   setup: {
     status: () => ipcRenderer.invoke('setup:status'),
     install: () => ipcRenderer.invoke('setup:install'),
+    getPython: () => ipcRenderer.invoke('setup:get-python'),
+    setPython: (pythonPath: string) => ipcRenderer.invoke('setup:set-python', pythonPath),
+    clearPython: () => ipcRenderer.invoke('setup:clear-python'),
+    browsePython: () => ipcRenderer.invoke('setup:browse-python'),
     onProgress: (callback: (data: any) => void) => {
       const wrapped = (_e: any, data: any) => callback(data)
       ipcRenderer.on('setup:progress', wrapped)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.5",
+  "version": "1.5.1-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.5.1-rc.5",
+      "version": "1.5.1-rc.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.3",
+  "version": "1.5.1-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.5.1-rc.3",
+      "version": "1.5.1-rc.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.1",
+  "version": "1.5.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.5.1-rc.1",
+      "version": "1.5.1-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.2",
+  "version": "1.5.1-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.5.1-rc.2",
+      "version": "1.5.1-rc.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.4",
+  "version": "1.5.1-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.5.1-rc.4",
+      "version": "1.5.1-rc.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boorie",
-  "version": "1.4.2",
+  "version": "1.5.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boorie",
-      "version": "1.4.2",
+      "version": "1.5.1-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.0",
+  "version": "1.5.1-rc.1",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.2",
+  "version": "1.5.1-rc.3",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.6",
+  "version": "1.5.1-rc.7",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.5",
+  "version": "1.5.1-rc.6",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.4",
+  "version": "1.5.1-rc.5",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.8",
+  "version": "1.5.1-rc.9",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.1",
+  "version": "1.5.1-rc.2",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.7",
+  "version": "1.5.1-rc.8",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boorie",
-  "version": "1.5.1-rc.3",
+  "version": "1.5.1-rc.4",
   "description": "Boorie - Advanced AI Desktop Client with comprehensive productivity features",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/scripts/start_milvus.py
+++ b/scripts/start_milvus.py
@@ -2,10 +2,16 @@
 """
 Boorie embedded Milvus Lite — la base vectorial está dentro de la app.
 
-Sin Docker. Arranca milvus-lite en gRPC TCP en el primer puerto libre a
-partir de 19530, persiste a `data/boorie-milvus/boorie.db` y escribe el
-puerto efectivo en `data/boorie-milvus/port` para que el cliente
-TypeScript (`backend/services/milvus.service.ts`) sepa dónde conectar.
+Sin Docker. Arranca milvus-lite en gRPC TCP, persiste a
+`data/boorie-milvus/boorie.db` y escribe el puerto efectivo en
+`data/boorie-milvus/port` para que el cliente TypeScript
+(`backend/services/milvus.service.ts`) sepa dónde conectar.
+
+milvus-lite >=3 corre el servidor gRPC in-process (hilos, sin subproceso
+C++ de ~200MB) y elige él mismo un puerto libre: `start_and_get_uri()`
+devuelve `http://127.0.0.1:{puerto}`. No podemos imponer el puerto, así
+que publicamos el que nos devuelve. Requiere `pymilvus` instalado —
+milvus_lite.adapter.grpc importa `pymilvus.grpc_gen`.
 
 Esta misma instancia es la BD vectorial compartida para:
   - RAG (colección hydraulic_knowledge)
@@ -17,29 +23,21 @@ from __future__ import annotations
 
 import os
 import signal
-import socket
 import sys
 import time
 from pathlib import Path
-
-
-def find_free_port(start: int = 19530, end: int = 19550) -> int:
-    for port in range(start, end + 1):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError(f"No free port in range {start}-{end}")
+from urllib.parse import urlparse
 
 
 def main() -> int:
     try:
-        from milvus_lite.server_manager import Server
+        from milvus_lite.server_manager import server_manager_instance
     except Exception as e:
-        print(f"[milvus] milvus-lite no instalado: {e}", flush=True)
-        print("[milvus] ejecuta:  ./venv-wntr/bin/pip install milvus-lite", flush=True)
+        print(f"[milvus] milvus-lite no importable: {e}", flush=True)
+        print(
+            "[milvus] ejecuta:  ./venv-wntr/bin/pip install 'milvus-lite>=3' pymilvus",
+            flush=True,
+        )
         # Quedamos en idle — la app cae a fail-soft (search devuelve [] sin spam).
         try:
             while True:
@@ -61,19 +59,23 @@ def main() -> int:
     db_file = db_dir / "boorie.db"
     port_file = db_dir / "port"
 
-    port = find_free_port(19530, 19550)
-    address = f"127.0.0.1:{port}"
-
     print(f"[milvus] DB:      {db_file}", flush=True)
-    print(f"[milvus] Address: {address}", flush=True)
 
-    server = Server(db_file=str(db_file), address=address)
-    if not server.init():
-        print("[milvus] Server.init() falló", flush=True)
+    # milvus-lite elige el puerto; nos devuelve http://127.0.0.1:{puerto}.
+    try:
+        uri = server_manager_instance.start_and_get_uri(str(db_file))
+    except Exception as e:  # noqa: BLE001 — cualquier fallo debe ser fail-soft
+        print(f"[milvus] start_and_get_uri() lanzó: {e}", flush=True)
+        uri = None
+    if not uri:
+        print("[milvus] no se pudo arrancar el servidor Milvus Lite", flush=True)
         return 1
-    if not server.start():
-        print("[milvus] Server.start() falló", flush=True)
+
+    port = urlparse(uri).port
+    if not port:
+        print(f"[milvus] URI sin puerto reconocible: {uri}", flush=True)
         return 1
+    address = f"127.0.0.1:{port}"
 
     # Publicar el puerto efectivo para que MilvusService lo lea.
     port_file.write_text(str(port), encoding="utf-8")
@@ -99,7 +101,8 @@ def main() -> int:
         except Exception:
             pass
         try:
-            server._p and server._p.terminate()  # type: ignore[attr-defined]
+            # El servidor vive en hilos de este proceso: release_all() los para.
+            server_manager_instance.release_all()
         except Exception:
             pass
 

--- a/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
+++ b/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
@@ -67,13 +67,15 @@ interface WNTRAdvancedMapViewerProps {
   simulationResults?: SimulationResults | null;
   onDataLoaded?: (data: NetworkData) => void;
   onSimulationCompleted?: (results: SimulationResults) => void;
+  highlightedNodes?: string[];
 }
 
 export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
   networkData: externalNetworkData,
   simulationResults: externalSimulationResults,
   onDataLoaded: _onDataLoaded,
-  onSimulationCompleted: _onSimulationCompleted
+  onSimulationCompleted: _onSimulationCompleted,
+  highlightedNodes
 }) => {
   const [networkData, setNetworkData] = useState<NetworkData | null>(externalNetworkData || null);
   const [simulationResults, setSimulationResults] = useState<SimulationResults | null>(externalSimulationResults || null);
@@ -206,6 +208,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
             networkData={networkData}
             simulationResults={simulationResults}
             activeTimeStep={visualizationSettings.timeStep}
+            highlightedNodes={highlightedNodes}
           />
 
           {/* Overlay info - Empty for now as requested */}

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -16,7 +16,7 @@ import {
   RefreshCw, AlertCircle,
   Activity, Database,
   Target, FolderOpen, ChevronDown,
-  Scissors, Zap, ShieldAlert, AlertTriangle, Download
+  Scissors, Zap, ShieldAlert, AlertTriangle, Download, Clock
 } from 'lucide-react';
 import {
   Chart as ChartJS,
@@ -87,6 +87,15 @@ interface SimulationResults {
   }
 }
 
+
+/** Las rutinas de resiliencia lanzan una simulación WNTR completa: en una red de
+ *  ~90 nudos rondan el minuto, y sin avisar parece que la aplicación se colgó. */
+const AvisoDuracion: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <p className="text-[11px] text-muted-foreground flex items-start gap-1.5">
+    <Clock className="h-3 w-3 mt-px shrink-0" />
+    <span>{children}</span>
+  </p>
+);
 
 export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   projectId: _projectId,
@@ -584,6 +593,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
       if (res.success) {
         setFailureResult(res.data);
+        // Todos los afectados se resaltan de una vez: son el resultado de la
+        // simulación, no algo que el usuario deba ir marcando nudo a nudo.
+        setHighlightedComponents((res.data.affected_nodes ?? []).map((n: any) => n.id));
         if (currentProject) {
           const currentNetwork = currentProject.networks.find(n => n.name === networkData.name);
           const networkId = currentNetwork?.id || 'unknown';
@@ -646,7 +658,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       ['Índice de Todini', b.todini_index.toFixed(4), a ? a.todini_index.toFixed(4) : '', d ? d.todini_index.toFixed(4) : ''],
       ['Entropía de red', b.network_entropy.toFixed(4), a ? a.network_entropy.toFixed(4) : '', d ? d.network_entropy.toFixed(4) : ''],
       ['Redundancia hidráulica', b.hydraulic_redundancy.toFixed(4), a ? a.hydraulic_redundancy.toFixed(4) : '', d ? d.hydraulic_redundancy.toFixed(4) : ''],
-      ['Serviceability (presión)', b.serviceability.pressure_serviceability.toFixed(4), a ? a.serviceability.pressure_serviceability.toFixed(4) : '', d ? d.pressure_serviceability.toFixed(4) : '']
+      ['Nivel de servicio por presión', b.serviceability.pressure_serviceability.toFixed(4), a ? a.serviceability.pressure_serviceability.toFixed(4) : '', d ? d.pressure_serviceability.toFixed(4) : '']
     ];
     const csv = rows.map(r => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -680,6 +692,26 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       setIsGeneratingFragility(false);
     }
   }, [networkData, fragilityMaterial, fragilityMaxIntensity]);
+
+  const handleExportFragilityCSV = useCallback(() => {
+    if (!fragilityResult) return;
+    const rows = [
+      ['PGV (cm/s)', 'Prob. falla de tubería', 'Tuberías afectadas esperadas'],
+      ...fragilityResult.intensities.map((pgv: number, i: number) => [
+        pgv.toFixed(2),
+        fragilityResult.pipe_failure_probability[i]?.toFixed(6) ?? '',
+        fragilityResult.expected_failed_pipes[i]?.toFixed(2) ?? ''
+      ])
+    ];
+    const csv = rows.map(r => r.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `curva_fragilidad_${fragilityMaterial}_${networkData?.name || 'red'}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [fragilityResult, fragilityMaterial, networkData]);
 
 
   // Dashboard Layout Render
@@ -1177,6 +1209,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     <p className="text-[11px] text-muted-foreground">
                       Simplifica la red fusionando/eliminando tuberías bajo un diámetro umbral. Se guarda como un proyecto nuevo, sin modificar el original.
                     </p>
+                    <AvisoDuracion>En redes grandes el proceso puede tardar cerca de un minuto.</AvisoDuracion>
                     <div className="bg-background p-2 rounded border">
                       <div className="text-[10px] text-muted-foreground mb-1">Umbral de diámetro (mm)</div>
                       <input
@@ -1190,7 +1223,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                       {isSkeletonizing ? (
                         <><RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" /> Esqueletizando...</>
                       ) : (
-                        <><Scissors className="h-3.5 w-3.5 mr-2" /> Vista Previa</>
+                        <><Scissors className="h-3.5 w-3.5 mr-2" /> Ejecutar Esqueletización / Vista Previa</>
                       )}
                     </Button>
 
@@ -1235,6 +1268,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     <p className="text-[11px] text-muted-foreground">
                       Simula la falla de uno o más componentes (tubería, bomba, válvula) y estima el impacto sobre el servicio.
                     </p>
+                    <AvisoDuracion>
+                      Ejecuta una simulación hidráulica completa: en redes grandes puede tardar un minuto o más.
+                    </AvisoDuracion>
                     <div className="bg-background p-2 rounded border">
                       <div className="text-[10px] text-muted-foreground mb-1">IDs de componentes (separados por coma)</div>
                       <input
@@ -1305,7 +1341,25 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                             <span>Nudos afectados:</span>
                             <span className="font-mono">{failureResult.affected_node_count} / {failureResult.total_junction_count}</span>
                           </div>
-                          <div className="text-[10px] text-muted-foreground">Click en un nudo para resaltarlo en el mapa</div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-[10px] text-muted-foreground">
+                              Resaltados en el mapa. Click en un nudo para quitarlo o volver a ponerlo.
+                            </span>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-6 px-2 text-[10px] shrink-0"
+                              onClick={() => {
+                                const all = failureResult.affected_nodes.map((n: any) => n.id);
+                                const todosPuestos = all.every((id: string) => highlightedComponents.includes(id));
+                                setHighlightedComponents(todosPuestos ? [] : all);
+                              }}
+                            >
+                              {failureResult.affected_nodes.every((n: any) => highlightedComponents.includes(n.id))
+                                ? 'Quitar resaltado'
+                                : 'Resaltar todos'}
+                            </Button>
+                          </div>
                           <div className="flex flex-wrap gap-1">
                             {failureResult.affected_nodes.slice(0, 8).map((n: any) => (
                               <Badge
@@ -1332,6 +1386,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     <p className="text-[11px] text-muted-foreground">
                       Índice de Todini, entropía de red y redundancia hidráulica. Compara antes/después del escenario de interrupción simulado arriba.
                     </p>
+                    <AvisoDuracion>
+                      Con la comparación activada se simula dos veces la red, así que tarda aproximadamente el doble.
+                    </AvisoDuracion>
                     <label className="flex items-center gap-2 text-xs">
                       <input
                         type="checkbox"
@@ -1393,7 +1450,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                                   after: resilienceIndicatorsResult.after?.hydraulic_redundancy?.toFixed(4),
                                 },
                                 {
-                                  label: 'Serviceability (presión)',
+                                  label: 'Nivel de servicio por presión',
                                   delta: resilienceIndicatorsResult.delta?.pressure_serviceability,
                                   before: `${(resilienceIndicatorsResult.before.serviceability.pressure_serviceability * 100).toFixed(1)}%`,
                                   after: resilienceIndicatorsResult.after
@@ -1413,7 +1470,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                               ))}
                             </tbody>
                           </table>
-                          <Button size="sm" variant="outline" className="w-full mt-2" onClick={handleExportResilienceCSV}>
+                          <Button size="sm" className="w-full mt-2" onClick={handleExportResilienceCSV}>
                             <Download className="h-3 w-3 mr-2" /> Exportar CSV
                           </Button>
                         </CardContent>
@@ -1430,6 +1487,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                       Probabilidad de falla de tubería vs. intensidad sísmica (PGV). Modelo genérico ALA (2001) por material —{' '}
                       <strong>requiere validación de un experto APyS antes de usarse en decisiones reales.</strong>
                     </p>
+                    <AvisoDuracion>
+                      Evalúa la curva sobre todas las tuberías: en redes grandes puede tardar cerca de un minuto.
+                    </AvisoDuracion>
                     <div className="grid grid-cols-2 gap-2">
                       <div className="bg-background p-2 rounded border">
                         <div className="text-[10px] text-muted-foreground mb-1">Material predominante</div>
@@ -1508,6 +1568,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                             </span>
                           </div>
                           <div className="text-[10px] text-muted-foreground italic">{fragilityResult.methodology}</div>
+                          <Button size="sm" className="w-full mt-2" onClick={handleExportFragilityCSV}>
+                            <Download className="h-3 w-3 mr-2" /> Exportar CSV
+                          </Button>
                         </CardContent>
                       </Card>
                     )}
@@ -1544,6 +1607,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
           <WNTRAdvancedMapViewer
             networkData={networkData}
             simulationResults={simulationResults?.hydraulic?.data}
+            highlightedNodes={highlightedComponents}
             onDataLoaded={setNetworkData}
             onSimulationCompleted={(res: any) => setSimulationResults(prev => ({ ...prev, hydraulic: { success: true, data: res } }))}
           />

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -1358,34 +1358,61 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     {resilienceIndicatorsResult && (
                       <Card>
                         <CardContent className="p-3 text-xs space-y-2">
-                          {[
-                            { label: 'Índice de Todini', key: 'todini_index' },
-                            { label: 'Entropía de red', key: 'network_entropy' },
-                            { label: 'Redundancia hidráulica', key: 'hydraulic_redundancy' },
-                          ].map(({ label, key }) => (
-                            <div key={key} className="flex justify-between">
-                              <span>{label}:</span>
-                              <span className="font-mono">
-                                {resilienceIndicatorsResult.before[key]?.toFixed(4)}
-                                {resilienceIndicatorsResult.after && (
-                                  <span className={resilienceIndicatorsResult.delta[key] < 0 ? 'text-red-500' : 'text-green-600'}>
-                                    {' → '}{resilienceIndicatorsResult.after[key]?.toFixed(4)}
-                                  </span>
+                          <table className="w-full">
+                            <thead>
+                              <tr className="text-[10px] uppercase tracking-wide text-muted-foreground border-b border-border">
+                                <th className="text-left font-medium pb-1">Indicador</th>
+                                {resilienceIndicatorsResult.after ? (
+                                  <>
+                                    <th className="text-right font-medium pb-1">Antes</th>
+                                    <th className="text-right font-medium pb-1">Después</th>
+                                  </>
+                                ) : (
+                                  <th className="text-right font-medium pb-1">Valor Actual</th>
                                 )}
-                              </span>
-                            </div>
-                          ))}
-                          <div className="flex justify-between">
-                            <span>Serviceability (presión):</span>
-                            <span className="font-mono">
-                              {(resilienceIndicatorsResult.before.serviceability.pressure_serviceability * 100).toFixed(1)}%
-                              {resilienceIndicatorsResult.after && (
-                                <span className={resilienceIndicatorsResult.delta.pressure_serviceability < 0 ? 'text-red-500' : 'text-green-600'}>
-                                  {' → '}{(resilienceIndicatorsResult.after.serviceability.pressure_serviceability * 100).toFixed(1)}%
-                                </span>
-                              )}
-                            </span>
-                          </div>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {[
+                                {
+                                  label: 'Índice de Todini',
+                                  delta: resilienceIndicatorsResult.delta?.todini_index,
+                                  before: resilienceIndicatorsResult.before.todini_index?.toFixed(4),
+                                  after: resilienceIndicatorsResult.after?.todini_index?.toFixed(4),
+                                },
+                                {
+                                  label: 'Entropía de red',
+                                  delta: resilienceIndicatorsResult.delta?.network_entropy,
+                                  before: resilienceIndicatorsResult.before.network_entropy?.toFixed(4),
+                                  after: resilienceIndicatorsResult.after?.network_entropy?.toFixed(4),
+                                },
+                                {
+                                  label: 'Redundancia hidráulica',
+                                  delta: resilienceIndicatorsResult.delta?.hydraulic_redundancy,
+                                  before: resilienceIndicatorsResult.before.hydraulic_redundancy?.toFixed(4),
+                                  after: resilienceIndicatorsResult.after?.hydraulic_redundancy?.toFixed(4),
+                                },
+                                {
+                                  label: 'Serviceability (presión)',
+                                  delta: resilienceIndicatorsResult.delta?.pressure_serviceability,
+                                  before: `${(resilienceIndicatorsResult.before.serviceability.pressure_serviceability * 100).toFixed(1)}%`,
+                                  after: resilienceIndicatorsResult.after
+                                    ? `${(resilienceIndicatorsResult.after.serviceability.pressure_serviceability * 100).toFixed(1)}%`
+                                    : undefined,
+                                },
+                              ].map(({ label, before, after, delta }) => (
+                                <tr key={label} className="border-b border-border/40 last:border-0">
+                                  <td className="py-1 pr-2">{label}</td>
+                                  <td className="py-1 text-right font-mono">{before}</td>
+                                  {resilienceIndicatorsResult.after && (
+                                    <td className={`py-1 pl-2 text-right font-mono ${delta < 0 ? 'text-red-500' : 'text-green-600'}`}>
+                                      {after}
+                                    </td>
+                                  )}
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
                           <Button size="sm" variant="outline" className="w-full mt-2" onClick={handleExportResilienceCSV}>
                             <Download className="h-3 w-3 mr-2" /> Exportar CSV
                           </Button>

--- a/src/components/hydraulic/WNTRMapViewer.tsx
+++ b/src/components/hydraulic/WNTRMapViewer.tsx
@@ -82,12 +82,29 @@ interface WNTRMapViewerProps {
   networkData?: NetworkData | null
   simulationResults?: SimulationResults | null
   activeTimeStep?: number
+  /** IDs de nudos a destacar sobre el resto (p. ej. los afectados por una interrupción). */
+  highlightedNodes?: string[]
 }
+
+// `in` sobre una lista literal: si está vacía la expresión es siempre falsa, así
+// que sirve igual para "sin nada resaltado" sin ramas especiales.
+const isHighlighted = (ids?: string[]) =>
+  ['in', ['get', 'id'], ['literal', ids ?? []]] as unknown as mapboxgl.ExpressionSpecification
+
+const highlightRadius = (ids: string[] | undefined, nodeSize: number) =>
+  ['case', isHighlighted(ids), nodeSize * 2, nodeSize] as unknown as mapboxgl.ExpressionSpecification
+
+const highlightStrokeWidth = (ids?: string[]) =>
+  ['case', isHighlighted(ids), 3, 1] as unknown as mapboxgl.ExpressionSpecification
+
+const highlightStrokeColor = (ids?: string[]) =>
+  ['case', isHighlighted(ids), '#FACC15', '#ffffff'] as unknown as mapboxgl.ExpressionSpecification
 
 export function WNTRMapViewer({
   networkData: propNetworkData,
   simulationResults: propSimulationResults,
-  activeTimeStep: propActiveTimeStep
+  activeTimeStep: propActiveTimeStep,
+  highlightedNodes
 }: WNTRMapViewerProps) {
   // Priority: token pasted in Settings → General (persisted, works in the
   // packaged app) over the VITE_MAPBOX_ACCESS_TOKEN build-time env var.
@@ -828,6 +845,13 @@ export function WNTRMapViewer({
     }
   }, [detectCoordinateSystem])
 
+  // En una ref, no en las dependencias de addNetworkToMap: si entrara ahí, cada
+  // cambio de selección recrearía capas y fuentes (y con ellas el encuadre). La
+  // ref permite que una reconstrucción por otro motivo pinte el resaltado
+  // vigente en lugar del que hubiera cuando se creó el callback.
+  const highlightedNodesRef = useRef<string[] | undefined>(highlightedNodes)
+  useEffect(() => { highlightedNodesRef.current = highlightedNodes }, [highlightedNodes])
+
   // Add network overlay to map
   const addNetworkToMap = useCallback(() => {
     if (!map.current || !networkData) return
@@ -1028,10 +1052,16 @@ export function WNTRMapViewer({
         type: 'circle',
         source: 'network-nodes',
         paint: {
-          'circle-radius': mapSettings.nodeSize,
+          // El nudo resaltado gana tamaño y un halo ámbar: el color base ya lo
+          // usa la capa de presiones, así que distinguirlo sólo por color no
+          // serviría cuando la simulación pinta los nudos de rojo o naranja.
+          // La lista va en el paint, no en las propiedades de cada feature, para
+          // que resaltar no obligue a reconstruir la fuente (y con ella el
+          // encuadre del mapa) cada vez que cambia la selección.
+          'circle-radius': highlightRadius(highlightedNodesRef.current, mapSettings.nodeSize),
           'circle-color': ['get', 'color'],
-          'circle-stroke-width': 1,
-          'circle-stroke-color': '#ffffff'
+          'circle-stroke-width': highlightStrokeWidth(highlightedNodesRef.current),
+          'circle-stroke-color': highlightStrokeColor(highlightedNodesRef.current)
         }
       });
     }
@@ -1120,6 +1150,15 @@ export function WNTRMapViewer({
     }
 
   }, [networkData, simulationResults, mapSettings, convertToGeoCoordinates])
+
+  // Resaltar es sólo cambiar el paint de la capa ya montada: nada de rehacer
+  // fuentes ni volver a encuadrar.
+  useEffect(() => {
+    if (!map.current?.getLayer('network-nodes')) return
+    map.current.setPaintProperty('network-nodes', 'circle-radius', highlightRadius(highlightedNodes, mapSettings.nodeSize))
+    map.current.setPaintProperty('network-nodes', 'circle-stroke-width', highlightStrokeWidth(highlightedNodes))
+    map.current.setPaintProperty('network-nodes', 'circle-stroke-color', highlightStrokeColor(highlightedNodes))
+  }, [highlightedNodes, mapSettings.nodeSize, networkData])
 
   // Update network overlay when data or settings change
   useEffect(() => {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { AIConfigurationPanel } from './AIConfigurationPanel'
 import { SystemPromptPanel } from './SystemPromptPanel'
-import { GeneralTab, AccountsTab } from './tabs'
+import { GeneralTab, AccountsTab, AboutTab } from './tabs'
 import { MilvusInspector } from './MilvusInspector'
 import { GuardrailsPanel } from './GuardrailsPanel'
 import { cn } from '@/utils/cn'
@@ -90,6 +90,16 @@ export function SettingsPanel() {
               >
                 Guardrails
               </Tabs.Trigger>
+              <Tabs.Trigger
+                value="about"
+                className={cn(
+                  "px-4 py-2 rounded-md text-sm font-medium transition-all",
+                  "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+                  "data-[state=inactive]:text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {t('settings.about.title')}
+              </Tabs.Trigger>
             </Tabs.List>
 
             {/* Tab Content */}
@@ -115,6 +125,10 @@ export function SettingsPanel() {
 
             <Tabs.Content value="guardrails" className="flex-1 overflow-hidden">
               <GuardrailsPanel />
+            </Tabs.Content>
+
+            <Tabs.Content value="about" className="flex-1 overflow-hidden">
+              <AboutTab />
             </Tabs.Content>
           </Tabs.Root>
         </div>

--- a/src/components/settings/tabs/AboutTab.test.tsx
+++ b/src/components/settings/tabs/AboutTab.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { AboutTab } from './AboutTab'
+
+// El componente importa CHANGELOG.md con `?raw`; se sustituye por un contenido
+// controlado para que el test no dependa del changelog real del repositorio (la
+// coherencia de ése ya la cubre changelog.test.ts).
+vi.mock('../../../../CHANGELOG.md?raw', () => ({
+  default: `
+## [9.9.9] - 2026-08-08
+
+Resumen de la versión más reciente.
+
+- Detalle destacado
+
+## [9.9.8] - 2026-07-01
+
+Resumen de la versión anterior.
+`,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string) => k,
+    i18n: { language: 'es' },
+  }),
+}))
+
+/** Sustituye el IPC de versión por uno controlado y devuelve el espía. */
+function mockVersion(resultado: Promise<string>) {
+  const getAppVersion = vi.fn().mockReturnValue(resultado)
+  Object.defineProperty(window, 'electronAPI', { value: { getAppVersion }, writable: true })
+  return getAppVersion
+}
+
+describe('AboutTab', () => {
+  beforeEach(() => {
+    vi.stubGlobal('__BUILD_DATE__', '2026-08-08T10:00:00.000Z')
+    mockVersion(Promise.resolve('9.9.9'))
+  })
+
+  it('muestra la versión que informa la aplicación, no una constante', async () => {
+    render(<AboutTab />)
+    await waitFor(() => expect(screen.getByText('9.9.9')).toBeTruthy())
+    expect(window.electronAPI.getAppVersion).toHaveBeenCalled()
+  })
+
+  it('lista el historial en el orden del changelog, con la más reciente primero', async () => {
+    render(<AboutTab />)
+    const versiones = (await screen.findAllByText(/^v9\.9\.\d$/)).map((e) => e.textContent)
+    expect(versiones).toEqual(['v9.9.9', 'v9.9.8'])
+  })
+
+  it('muestra resumen y detalles de cada entrada', async () => {
+    render(<AboutTab />)
+    expect(await screen.findByText('Resumen de la versión más reciente.')).toBeTruthy()
+    expect(screen.getByText('Detalle destacado')).toBeTruthy()
+  })
+
+  it('marca la versión instalada como candidata cuando lleva sufijo', async () => {
+    mockVersion(Promise.resolve('9.9.9-rc.2'))
+    render(<AboutTab />)
+    await waitFor(() => expect(screen.getByText('9.9.9-rc.2')).toBeTruthy())
+    expect(screen.getByText('settings.about.channelPrerelease')).toBeTruthy()
+  })
+
+  it('avisa cuando el historial no cubre la versión instalada', async () => {
+    mockVersion(Promise.resolve('7.0.0'))
+    render(<AboutTab />)
+    expect(await screen.findByText('settings.about.outOfSync')).toBeTruthy()
+  })
+
+  it('no revienta si la versión no se puede obtener', async () => {
+    mockVersion(Promise.reject(new Error('sin IPC')))
+    render(<AboutTab />)
+    expect(await screen.findByText('v9.9.9')).toBeTruthy()
+  })
+})

--- a/src/components/settings/tabs/AboutTab.tsx
+++ b/src/components/settings/tabs/AboutTab.tsx
@@ -1,0 +1,129 @@
+import { useTranslation } from 'react-i18next'
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, ExternalLink } from 'lucide-react'
+import changelogRaw from '../../../../CHANGELOG.md?raw'
+import { parseChangelog, isChangelogInSync } from '../../../utils/changelog'
+
+const NOTAS_GITHUB = 'https://github.com/Boorie-AI/boorie_cliente/blob/main/CHANGELOG.md'
+
+/** Una versión con sufijo (1.5.1-rc.9) es una candidata, no una liberación estable. */
+const esPrerelease = (v: string) => v.includes('-')
+
+export function AboutTab() {
+  const { t, i18n } = useTranslation()
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Misma fuente que consume electron-builder para nombrar el instalador, así
+    // que lo que se muestra no puede desincronizarse del artefacto entregado.
+    window.electronAPI?.getAppVersion?.()
+      .then((v: string) => setVersion(v))
+      .catch(() => setVersion(null))
+  }, [])
+
+  const entries = useMemo(() => parseChangelog(changelogRaw), [])
+  const sincronizado = version ? isChangelogInSync(entries, version) : true
+
+  const fechaLarga = (iso: string) =>
+    new Date(iso).toLocaleDateString(i18n.language, { day: 'numeric', month: 'short', year: 'numeric' })
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-center gap-4">
+          <div className="h-14 w-14 shrink-0 rounded-xl bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center text-2xl font-extrabold text-amber-950">
+            B
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="text-lg font-semibold text-foreground">{t('settings.about.appName')}</h3>
+              <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                {t('settings.about.currentVersion')}
+              </span>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-9 gap-y-3">
+              <div>
+                <div className="text-xs text-muted-foreground">{t('settings.about.version')}</div>
+                <div className="font-mono text-sm font-semibold text-foreground">
+                  {version ?? t('settings.about.loading')}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">{t('settings.about.buildDate')}</div>
+                <div className="text-sm font-semibold text-foreground">{fechaLarga(__BUILD_DATE__)}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">{t('settings.about.channel')}</div>
+                <div className="text-sm font-semibold text-foreground">
+                  {version && esPrerelease(version)
+                    ? t('settings.about.channelPrerelease')
+                    : t('settings.about.channelStable')}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-6">
+        <h3 className="text-base font-semibold text-foreground">{t('settings.about.historyTitle')}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">{t('settings.about.historyDesc')}</p>
+
+        {/* Un fallo de formato en el CHANGELOG no debe pasar desapercibido. */}
+        {!sincronizado && (
+          <div className="mt-4 flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3 text-xs text-yellow-700 dark:text-yellow-400">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{t('settings.about.outOfSync')}</span>
+          </div>
+        )}
+
+        {entries.length === 0 ? (
+          <p className="mt-4 text-sm text-muted-foreground">{t('settings.about.historyEmpty')}</p>
+        ) : (
+          <ol className="mt-4">
+            {entries.map((e, i) => (
+              <li
+                key={e.version}
+                className="flex gap-4 border-t border-border/60 py-4 first:border-t-0 first:pt-1"
+              >
+                <span className="flex w-3 shrink-0 justify-center pt-1.5">
+                  <span
+                    className={`h-2.5 w-2.5 rounded-full ${
+                      i === 0 ? 'bg-green-500 ring-4 ring-green-500/20' : 'bg-muted-foreground/50'
+                    }`}
+                  />
+                </span>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2.5">
+                    <span className="text-sm font-bold text-foreground">v{e.version}</span>
+                    {e.date && <span className="text-xs text-muted-foreground">{fechaLarga(e.date)}</span>}
+                  </div>
+                  {e.summary && (
+                    <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{e.summary}</p>
+                  )}
+                  {e.details.length > 0 && (
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-[13px] leading-relaxed text-muted-foreground">
+                      {e.details.map((d) => (
+                        <li key={d}>{d}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <a
+          href={NOTAS_GITHUB}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-5 inline-flex items-center gap-1.5 text-[13px] font-medium text-primary hover:underline"
+        >
+          {t('settings.about.releaseNotes')}
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/tabs/GeneralTab.tsx
+++ b/src/components/settings/tabs/GeneralTab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/stores/appStore'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 import { databaseService } from '@/services/database'
-import { Moon, Sun, RotateCcw, Languages, Eye, EyeOff, Map, Check } from 'lucide-react'
+import { Moon, Sun, RotateCcw, Languages, Eye, EyeOff, Map, Check, Terminal } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import * as Switch from '@radix-ui/react-switch'
 import * as Select from '@radix-ui/react-select'
@@ -26,12 +26,71 @@ export function GeneralTab() {
   const [showMapboxToken, setShowMapboxToken] = useState(false)
   const [mapboxSaved, setMapboxSaved] = useState(false)
 
+  const [pythonPath, setPythonPath] = useState('')
+  const [pythonDetected, setPythonDetected] = useState('')
+  const [pythonMessage, setPythonMessage] = useState('')
+  const [pythonOk, setPythonOk] = useState(false)
+  const [pythonChecking, setPythonChecking] = useState(false)
+  const isWindows = navigator.userAgent.includes('Windows')
+  const setupApi = (window as any).electronAPI?.setup
+
+  const refreshPythonStatus = async () => {
+    if (!setupApi?.getPython) return
+    const info = await setupApi.getPython()
+    if (!info?.success) return
+    setPythonDetected(info.effective?.pythonPath ?? '')
+    setPythonPath(info.configured ?? '')
+    if (info.effective && !info.effective.wntrReady) {
+      setPythonOk(false)
+      setPythonMessage(
+        info.effective.usable
+          ? `El intérprete en uso no tiene: ${info.effective.missingModules.join(', ')}.`
+          : 'No hay un intérprete de Python utilizable.'
+      )
+    } else {
+      setPythonOk(true)
+      setPythonMessage('')
+    }
+  }
+
   useEffect(() => {
     loadPreferences()
     databaseService.getSetting(MAPBOX_TOKEN_SETTING_KEY).then((value) => {
       if (value) setMapboxToken(value)
     })
+    refreshPythonStatus()
   }, [loadPreferences])
+
+  const handleBrowsePython = async () => {
+    const result = await setupApi?.browsePython()
+    if (result?.success && result.path) setPythonPath(result.path)
+  }
+
+  const handleSavePythonPath = async () => {
+    if (!setupApi?.setPython) return
+    setPythonChecking(true)
+    try {
+      const result = await setupApi.setPython(pythonPath)
+      await refreshPythonStatus()
+      // Después del refresco, para que el mensaje de confirmación no se pise
+      setPythonOk(Boolean(result?.success && result?.wntrReady))
+      setPythonMessage(result?.message ?? result?.error ?? '')
+    } finally {
+      setPythonChecking(false)
+    }
+  }
+
+  const handleClearPythonPath = async () => {
+    if (!setupApi?.clearPython) return
+    setPythonChecking(true)
+    try {
+      await setupApi.clearPython()
+      setPythonPath('')
+      await refreshPythonStatus()
+    } finally {
+      setPythonChecking(false)
+    }
+  }
 
   const handleSaveMapboxToken = async () => {
     const ok = await databaseService.setSetting(MAPBOX_TOKEN_SETTING_KEY, mapboxToken.trim(), 'map')
@@ -270,6 +329,77 @@ export function GeneralTab() {
               >
                 {mapboxSaved ? <Check size={16} /> : null}
                 {mapboxSaved ? 'Guardado' : 'Guardar'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Python / WNTR interpreter */}
+        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+          <div className="flex items-center gap-2 mb-4">
+            <Terminal size={20} className="text-muted-foreground" />
+            <h2 className="text-xl font-semibold text-card-foreground">Python (WNTR)</h2>
+          </div>
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium text-card-foreground">Ruta del intérprete</label>
+              <p className="text-sm text-muted-foreground">
+                Boorie detecta Python automáticamente y prioriza el de tu sistema. Indica aquí la ruta
+                sólo si tienes WNTR en un entorno que no encuentra (conda, un venv propio o una
+                instalación fuera de las rutas habituales).
+              </p>
+            </div>
+            <div className="flex space-x-2">
+              <input
+                type="text"
+                value={pythonPath}
+                onChange={(e) => setPythonPath(e.target.value)}
+                placeholder={pythonDetected || (isWindows ? 'C:\\Python312\\python.exe' : '/usr/bin/python3')}
+                className="flex-1 min-w-0 px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none text-sm font-mono"
+              />
+              <button
+                type="button"
+                onClick={handleBrowsePython}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-accent text-accent-foreground hover:bg-accent/80 transition-colors"
+              >
+                Examinar…
+              </button>
+              <button
+                type="button"
+                onClick={handleSavePythonPath}
+                disabled={pythonChecking}
+                className={cn(
+                  'px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5',
+                  'bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50'
+                )}
+              >
+                {pythonChecking ? 'Comprobando…' : 'Guardar'}
+              </button>
+            </div>
+            {pythonMessage && (
+              <div
+                className={cn(
+                  'rounded-lg border p-3 text-sm flex gap-2 items-start',
+                  pythonOk
+                    ? 'border-green-600/30 bg-green-600/5 text-green-700 dark:text-green-400'
+                    : 'border-yellow-500/30 bg-yellow-500/5 text-yellow-700 dark:text-yellow-400'
+                )}
+              >
+                {pythonOk ? <Check size={16} className="mt-0.5 flex-shrink-0" /> : null}
+                <span className="whitespace-pre-wrap">{pythonMessage}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>
+                En uso ahora:{' '}
+                <span className="font-mono">{pythonDetected || 'detectando…'}</span>
+              </span>
+              <button
+                type="button"
+                onClick={handleClearPythonPath}
+                className="underline hover:text-foreground"
+              >
+                Volver a la detección automática
               </button>
             </div>
           </div>

--- a/src/components/settings/tabs/index.ts
+++ b/src/components/settings/tabs/index.ts
@@ -1,2 +1,3 @@
 export { GeneralTab } from './GeneralTab'
 export { AccountsTab } from './AccountsTab'
+export { AboutTab } from './AboutTab'

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -157,7 +157,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                 <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 text-sm text-yellow-700 dark:text-yellow-400 flex gap-3 items-start">
                   <AlertTriangle className="w-5 h-5 flex-shrink-0" />
                   <div>
-                    No se encontró Python 3.10 o superior en tu sistema. Instálalo desde{' '}
+                    No se encontró un Python compatible (3.10 – 3.13) en tu sistema. Instala la 3.13 desde{' '}
                     <a className="underline" href="https://www.python.org/downloads/" target="_blank" rel="noopener noreferrer">
                       python.org/downloads
                     </a>{' '}

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -10,6 +10,8 @@ interface SetupStatus {
   missing: string[]
   optionalMissing: string[]
   problems?: { name: string; error: string }[]
+  venvPythonUnsupported?: boolean
+  canRecreateVenv?: boolean
   message?: string
 }
 
@@ -33,6 +35,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [installing, setInstalling] = useState(false)
   const [progress, setProgress] = useState<ProgressEvent | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [warnings, setWarnings] = useState<string[]>([])
   const logRef = useRef<HTMLDivElement>(null)
   const [logLines, setLogLines] = useState<string[]>([])
   const api = (window as any).electronAPI?.setup
@@ -54,6 +57,13 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
       if (p.stage === 'error') {
         setErrorMsg(p.message ?? 'Error en el setup.')
       }
+      // Los avisos ('warning') explican por qué algo quedará deshabilitado —
+      // p.ej. un venv sobre Python 3.9 donde Milvus no puede instalarse. Antes
+      // se emitían y no se pintaban en ningún sitio, así que el usuario veía el
+      // asistente reaparecer sin ninguna explicación.
+      if (p.stage === 'warning' && p.message) {
+        setWarnings((prev) => (prev.includes(p.message!) ? prev : [...prev, p.message!]))
+      }
     })
 
     return off
@@ -67,6 +77,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const startInstall = async () => {
     setInstalling(true)
     setErrorMsg(null)
+    setWarnings([])
     setLogLines([])
     try {
       const result = await api.install()
@@ -153,15 +164,22 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                   )}
                 </div>
               )}
-              {!status.pythonPath && (
+              {/* El diagnóstico del backend (qué falta y por qué) es lo único
+                  que dice al usuario qué tiene que hacer; antes se descartaba. */}
+              {status.message && (
+                <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-foreground/80">
+                  {status.message}
+                </div>
+              )}
+              {(!status.pythonPath || (status.venvPythonUnsupported && !status.canRecreateVenv)) && (
                 <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 text-sm text-yellow-700 dark:text-yellow-400 flex gap-3 items-start">
                   <AlertTriangle className="w-5 h-5 flex-shrink-0" />
                   <div>
                     No se encontró un Python compatible (3.10 – 3.13) en tu sistema. Instala la 3.13 desde{' '}
                     <a className="underline" href="https://www.python.org/downloads/" target="_blank" rel="noopener noreferrer">
                       python.org/downloads
-                    </a>{' '}
-                    y reinicia Boorie.
+                    </a>
+                    , marca <span className="font-mono">Add python.exe to PATH</span> y reinicia Boorie.
                   </div>
                 </div>
               )}
@@ -213,6 +231,17 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                   </div>
                 </div>
               )}
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 text-sm text-yellow-700 dark:text-yellow-400 space-y-2">
+              {warnings.map((w, i) => (
+                <div key={i} className="flex gap-3 items-start">
+                  <AlertTriangle className="w-5 h-5 flex-shrink-0" />
+                  <div>{w}</div>
+                </div>
+              ))}
             </div>
           )}
 

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -9,6 +9,7 @@ interface SetupStatus {
   venvPath: string
   missing: string[]
   optionalMissing: string[]
+  problems?: { name: string; error: string }[]
   message?: string
 }
 
@@ -78,7 +79,9 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
           setTimeout(onComplete, 800)
         }
       } else {
-        setErrorMsg(result?.error || 'Setup falló.')
+        // El evento de progreso 'error' ya trae el motivo real (qué import
+        // falla y por qué). No lo pisamos con el código genérico.
+        setErrorMsg((prev) => prev || result?.error || 'Setup falló.')
       }
     } catch (e: any) {
       setErrorMsg(e?.message ?? 'Setup falló.')
@@ -132,6 +135,22 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                       </span>
                     ))}
                   </div>
+                  {/* El motivo del fallo, no sólo el nombre: un paquete puede
+                      estar instalado y no cargar (DLL, versión incompatible). */}
+                  {status.problems && status.problems.length > 0 && (
+                    <div className="pt-2 space-y-1 text-[11px] font-mono text-muted-foreground">
+                      {status.problems.map((p) => (
+                        <div key={p.name} className="break-all">
+                          {p.name}: {p.error}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {status.pythonVersion && (
+                    <div className="pt-1 text-[11px] text-muted-foreground">
+                      Intérprete: <span className="font-mono">{status.pythonPath}</span> ({status.pythonVersion})
+                    </div>
+                  )}
                 </div>
               )}
               {!status.pythonPath && (

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -138,7 +138,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                 <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 text-sm text-yellow-700 dark:text-yellow-400 flex gap-3 items-start">
                   <AlertTriangle className="w-5 h-5 flex-shrink-0" />
                   <div>
-                    No se encontró Python 3.9+ en tu sistema. Instálalo desde{' '}
+                    No se encontró Python 3.10 o superior en tu sistema. Instálalo desde{' '}
                     <a className="underline" href="https://www.python.org/downloads/" target="_blank" rel="noopener noreferrer">
                       python.org/downloads
                     </a>{' '}

--- a/src/components/wisdom/UnifiedWisdomPanel.tsx
+++ b/src/components/wisdom/UnifiedWisdomPanel.tsx
@@ -705,7 +705,9 @@ export function UnifiedWisdomPanel() {
         if (result.success) {
           logger.debug('✅ Document reindexed successfully')
           await loadWisdomDocuments() // Refresh the list
-          showNotification('Document reindexed successfully!', 'success')
+          // El mensaje trae el número de fragmentos indexados: sin ese dato, un
+          // "reindexado con éxito" podía significar cero chunks creados.
+          showNotification(result.message || 'Document reindexed successfully!', 'success')
         } else {
           logger.error('❌ Reindexing failed:', result.message)
           showNotification(`Reindexing failed: ${result.message}`, 'error')

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -62,7 +62,24 @@
     "settingsStorage": "Emmagatzematge de configuració:",
     "backupFrequency": "Freqüència de còpia de seguretat:",
     "aiConfiguration": "Configuració d'IA",
-    "accounts": "Comptes"
+    "accounts": "Comptes",
+    "about": {
+      "title": "Quant a",
+      "appName": "Boorie Client",
+      "currentVersion": "Versió actual",
+      "version": "Versió",
+      "buildDate": "Data de compilació",
+      "channel": "Canal",
+      "channelStable": "Estable",
+      "channelPrerelease": "Candidata de llançament",
+      "historyTitle": "Historial de versions",
+      "historyDesc": "Versions publicades de Boorie Client, de la més recent a la més antiga.",
+      "historyEmpty": "No s’ha pogut llegir l’historial de versions.",
+      "outOfSync": "L’historial no inclou cap entrada per a la versió instal·lada.",
+      "releaseNotes": "Veure les notes de versió completes a GitHub",
+      "loading": "Carregant…",
+      "unknown": "Desconeguda"
+    }
   },
   "ai": {
     "localModels": "Models Locals (Ollama)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,7 +62,24 @@
     "settingsStorage": "Settings storage:",
     "backupFrequency": "Backup frequency:",
     "aiConfiguration": "AI Configuration",
-    "accounts": "Accounts"
+    "accounts": "Accounts",
+    "about": {
+      "title": "About",
+      "appName": "Boorie Client",
+      "currentVersion": "Current version",
+      "version": "Version",
+      "buildDate": "Build date",
+      "channel": "Channel",
+      "channelStable": "Stable",
+      "channelPrerelease": "Release candidate",
+      "historyTitle": "Version history",
+      "historyDesc": "Released versions of Boorie Client, newest first.",
+      "historyEmpty": "The version history could not be read.",
+      "outOfSync": "The history has no entry for the installed version.",
+      "releaseNotes": "See full release notes on GitHub",
+      "loading": "Loading…",
+      "unknown": "Unknown"
+    }
   },
   "ai": {
     "localModels": "Local Models (Ollama)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -62,7 +62,24 @@
     "settingsStorage": "Almacenamiento de configuración:",
     "backupFrequency": "Frecuencia de respaldo:",
     "aiConfiguration": "Configuración de IA",
-    "accounts": "Cuentas"
+    "accounts": "Cuentas",
+    "about": {
+      "title": "Acerca de",
+      "appName": "Boorie Cliente",
+      "currentVersion": "Versión actual",
+      "version": "Versión",
+      "buildDate": "Fecha de compilación",
+      "channel": "Canal",
+      "channelStable": "Estable",
+      "channelPrerelease": "Candidata de liberación",
+      "historyTitle": "Historial de versiones",
+      "historyDesc": "Versiones liberadas de Boorie Cliente, de la más reciente a la más antigua.",
+      "historyEmpty": "No se pudo leer el historial de versiones.",
+      "outOfSync": "El historial no incluye una entrada para la versión instalada.",
+      "releaseNotes": "Ver notas de versión completas en GitHub",
+      "loading": "Cargando…",
+      "unknown": "Desconocida"
+    }
   },
   "ai": {
     "localModels": "Modelos Locales (Ollama)",

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -35,6 +35,17 @@ declare module '*.webp' {
   export default content;
 }
 
+// CHANGELOG.md se importa como texto y se resuelve en tiempo de compilación, para
+// que su contenido viaje dentro del bundle en vez de leerse del disco en runtime.
+// Ver docs/ACERCA_DE_HISTORIAL_VERSIONES.md.
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}
+
+/** Fecha de compilación (ISO), inyectada por `define` en vite.config.ts. */
+declare const __BUILD_DATE__: string;
+
 interface Window {
   electronAPI: {
     minimizeWindow: () => Promise<void>;

--- a/src/utils/changelog.test.ts
+++ b/src/utils/changelog.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { parseChangelog, isChangelogInSync } from './changelog'
+
+describe('parseChangelog', () => {
+  it('extrae versión, fecha, resumen y detalles', () => {
+    const [e] = parseChangelog(`
+## [1.5.1] - 2026-08-08
+
+Resumen de la versión.
+
+- Primer detalle
+- Segundo detalle
+`)
+    expect(e.version).toBe('1.5.1')
+    expect(e.date).toBe('2026-08-08')
+    expect(e.summary).toBe('Resumen de la versión.')
+    expect(e.details).toEqual(['Primer detalle', 'Segundo detalle'])
+  })
+
+  it('conserva el orden del fichero', () => {
+    const v = parseChangelog(`
+## [2.0.0] - 2026-01-01
+Nueva.
+
+## [1.0.0] - 2025-01-01
+Vieja.
+`).map((e) => e.version)
+    expect(v).toEqual(['2.0.0', '1.0.0'])
+  })
+
+  // El fichero se escribe con las líneas partidas para que sea legible en el
+  // editor; sin unir las continuaciones, el detalle se truncaba en la interfaz.
+  it('une las viñetas partidas en varias líneas', () => {
+    const [e] = parseChangelog(`
+## [1.0.0] - 2025-01-01
+Resumen.
+
+- Una viñeta larga que continúa
+  en la línea siguiente y termina aquí.
+- Otra viñeta corta
+`)
+    expect(e.details).toEqual([
+      'Una viñeta larga que continúa en la línea siguiente y termina aquí.',
+      'Otra viñeta corta',
+    ])
+  })
+
+  it('una línea en blanco cierra la viñeta: lo que sigue no se le pega', () => {
+    const [e] = parseChangelog(`
+## [1.0.0] - 2025-01-01
+Resumen.
+
+- La viñeta
+
+Nota de cierre suelta.
+`)
+    expect(e.details).toEqual(['La viñeta'])
+  })
+
+  it('acepta cabeceras sin corchetes y sin fecha', () => {
+    const e = parseChangelog('## 1.4.0\nSin fecha ni corchetes.')
+    expect(e).toHaveLength(1)
+    expect(e[0].version).toBe('1.4.0')
+    expect(e[0].date).toBeNull()
+  })
+
+  it('admite versiones con sufijo de pre-release', () => {
+    expect(parseChangelog('## [1.5.1-rc.9] - 2026-08-08\nCandidata.')[0].version)
+      .toBe('1.5.1-rc.9')
+  })
+
+  // Lo que sigue es el motivo de tener parser propio: el fichero se edita a mano.
+  it('devuelve lista vacía con entrada vacía o sin cabeceras', () => {
+    expect(parseChangelog('')).toEqual([])
+    expect(parseChangelog('# Changelog\n\nTexto suelto sin ninguna versión.')).toEqual([])
+  })
+
+  it('ignora una versión declarada sin contenido en vez de mostrarla vacía', () => {
+    const e = parseChangelog('## [1.0.1] - 2026-01-01\n\n## [1.0.0] - 2025-01-01\nCon cuerpo.')
+    expect(e.map((x) => x.version)).toEqual(['1.0.0'])
+  })
+
+  it('no arrastra a la entrada el texto que va tras una cabecera de otro nivel', () => {
+    const [e] = parseChangelog(`
+## [1.0.0] - 2025-01-01
+Resumen.
+- Detalle
+
+# Otra sección
+- Esto no pertenece a la versión
+`)
+    expect(e.details).toEqual(['Detalle'])
+  })
+
+  it('no confunde texto posterior a las viñetas con el resumen', () => {
+    const [e] = parseChangelog(`
+## [1.0.0] - 2025-01-01
+El resumen.
+- Detalle
+
+Nota de cierre que no es resumen.
+`)
+    expect(e.summary).toBe('El resumen.')
+  })
+
+  it('descarta cabeceras que no son una versión semántica', () => {
+    expect(parseChangelog('## Unreleased\nAlgo.\n## [1.0.0] - 2025-01-01\nOtro.')
+      .map((e) => e.version)).toEqual(['1.0.0'])
+  })
+})
+
+describe('isChangelogInSync', () => {
+  const entries = parseChangelog('## [1.5.1] - 2026-08-08\nResumen.')
+
+  it('acepta la coincidencia exacta', () => {
+    expect(isChangelogInSync(entries, '1.5.1')).toBe(true)
+  })
+
+  it('acepta una release candidate de la versión documentada', () => {
+    expect(isChangelogInSync(entries, '1.5.1-rc.9')).toBe(true)
+  })
+
+  it('rechaza una versión distinta', () => {
+    expect(isChangelogInSync(entries, '1.5.2')).toBe(false)
+  })
+
+  it('rechaza los casos degenerados', () => {
+    expect(isChangelogInSync([], '1.5.1')).toBe(false)
+    expect(isChangelogInSync(entries, '')).toBe(false)
+  })
+})
+
+// Guarda de coherencia: es la comprobación que faltó en el rc.7, donde lo declarado
+// y lo empaquetado no coincidían.
+describe('CHANGELOG.md del repositorio', () => {
+  const raiz = resolve(__dirname, '../..')
+  const entries = parseChangelog(readFileSync(resolve(raiz, 'CHANGELOG.md'), 'utf-8'))
+
+  it('se parsea y tiene entradas', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it('su entrada superior coincide con la versión de package.json', () => {
+    const { version } = JSON.parse(readFileSync(resolve(raiz, 'package.json'), 'utf-8'))
+    expect(isChangelogInSync(entries, version)).toBe(true)
+  })
+
+  it('todas las entradas traen fecha y resumen', () => {
+    for (const e of entries) {
+      expect(e.date, `la versión ${e.version} no tiene fecha`).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(e.summary, `la versión ${e.version} no tiene resumen`).not.toBe('')
+    }
+  })
+})

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -1,0 +1,96 @@
+/**
+ * Parser del CHANGELOG.md, que es la fuente única del historial de versiones.
+ *
+ * El fichero se edita a mano en cada release, así que el parser tiene que tolerar
+ * formato imperfecto sin vaciar la sección: lo que no encaja se ignora y el resto
+ * se muestra. Ver docs/ACERCA_DE_HISTORIAL_VERSIONES.md.
+ */
+
+export interface ChangelogEntry {
+  /** Versión sin la `v`, tal como aparece en package.json (p. ej. "1.5.1"). */
+  version: string
+  /** ISO corta (YYYY-MM-DD) o null si la cabecera no la traía. */
+  date: string | null
+  /** Párrafo de resumen, pensado para el usuario final. */
+  summary: string
+  /** Viñetas de detalle, en el orden del fichero. */
+  details: string[]
+}
+
+// ## [1.5.1] - 2026-08-08   |   ## [1.5.1]   |   ## 1.5.1 - 2026-08-08
+const HEADING = /^##\s+\[?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)\]?\s*(?:[-–]\s*(\d{4}-\d{2}-\d{2}))?\s*$/
+
+/**
+ * Extrae las entradas en el orden en que aparecen. No reordena: el fichero manda,
+ * porque una fecha ausente o mal escrita no debe mover una versión de sitio.
+ */
+export function parseChangelog(markdown: string): ChangelogEntry[] {
+  if (!markdown) return []
+
+  const entries: ChangelogEntry[] = []
+  let current: ChangelogEntry | null = null
+  let summaryLines: string[] = []
+  let enViñeta = false
+
+  const flush = () => {
+    if (!current) return
+    current.summary = summaryLines.join(' ').replace(/\s+/g, ' ').trim()
+    // Una entrada sin nada que contar no aporta y ensucia la línea de tiempo.
+    if (current.summary || current.details.length) entries.push(current)
+    current = null
+    summaryLines = []
+    enViñeta = false
+  }
+
+  for (const raw of markdown.split('\n')) {
+    const line = raw.trim()
+    const heading = HEADING.exec(line)
+
+    if (heading) {
+      flush()
+      current = { version: heading[1], date: heading[2] ?? null, summary: '', details: [] }
+      enViñeta = false
+      continue
+    }
+    if (!current) continue
+
+    // Una cabecera de otro nivel cierra la entrada: lo que sigue ya no le pertenece.
+    if (/^#{1,2}\s/.test(line)) {
+      flush()
+      continue
+    }
+    // Una línea en blanco cierra la viñeta: lo que venga después es otra cosa.
+    if (!line) {
+      enViñeta = false
+      continue
+    }
+
+    const bullet = /^[-*]\s+(.*)$/.exec(line)
+    if (bullet) {
+      current.details.push(bullet[1].trim())
+      enViñeta = true
+    } else if (!current.details.length) {
+      // El resumen es lo que va entre la cabecera y la primera viñeta; el texto
+      // posterior (notas de cierre) no se mezcla con él.
+      summaryLines.push(line)
+    } else if (enViñeta) {
+      // Continuación de la viñeta anterior: el fichero se escribe con las líneas
+      // partidas para que sea legible en el editor, y sin esto el texto se
+      // truncaría en la primera línea.
+      current.details[current.details.length - 1] += ' ' + line
+    }
+  }
+  flush()
+
+  return entries
+}
+
+/**
+ * La entrada superior debe describir la versión que se está ejecutando. Si no
+ * coinciden, el historial miente sobre lo que el usuario tiene instalado.
+ */
+export function isChangelogInSync(entries: ChangelogEntry[], appVersion: string): boolean {
+  if (!entries.length || !appVersion) return false
+  // La app puede correr como 1.5.1-rc.9 mientras el changelog documenta la 1.5.1.
+  return entries[0].version === appVersion.replace(/-.*$/, '')
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
   },
   define: {
     global: 'globalThis',
+    // No puede calcularse en runtime: `new Date()` daría la fecha en que el
+    // usuario abre la app, no la de la compilación.
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
   },
   server: {
     port: 3000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,22 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    watch: {
+      // Nada de esto es fuente del frontend, y vigilarlo agota
+      // fs.inotify.max_user_watches (65536 aquí): venv-wntr solo ya son
+      // ~21k archivos. Al pasarse, chokidar emite ENOSPC y Vite muere al
+      // arrancar, dejando un servidor huérfano sirviendo el puerto 3000.
+      ignored: [
+        '**/.git/**',
+        '**/node_modules/**',
+        '**/venv-wntr/**',
+        '**/dist/**',
+        '**/dist-electron/**',
+        '**/test-files/**',
+        '**/rag-knowledge/**',
+        '**/data/**',
+      ],
+    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
# Pull Request

## 📋 Description

Arranque de Boorie en Windows, indexado RAG y rutinas de resiliencia. 17 commits, 28 ficheros (+1803 / −374), validados por el cliente sobre instaladores sucesivos (rc.1 → rc.9).

Tres bloques:

**1. Arranque de Python/WNTR en Windows** — `electron/handlers/setup.handler.ts`, `SetupWizard.tsx`, `pythonDetector.ts`

- La ruta del venv creado por el asistente no se persistía: al reiniciar, WNTR volvía a reportarse como no instalado. Ahora vive en `python-path.json` y los servicios resuelven el intérprete vigente en cada ejecución en lugar de fijarlo en el constructor.
- El asistente decía `verification-failed` sin explicar nada. Ahora conserva y muestra el motivo de cada import fallido, con el detalle completo en `<userData>/logs/setup-python.log`.
- Rango soportado acotado a **Python 3.10–3.13**: wntr 1.5 no publica rueda cp314 para Windows y `nemoguardrails` declara `python <3.14`. Los mensajes decían «3.10 o superior», lo que llevaba al usuario a instalar justo la versión que no funciona.
- `findSystemPython` prioriza rutas con versión concreta sobre `python`/`py -3`: en equipos con Anaconda 3.14 se llevaba la elección aunque hubiera un 3.13 al lado.
- Un venv heredado fuera de rango se aparta (`venv-wntr-old-<ts>`) y se recrea; si el renombrado falla (antivirus, intérprete vivo) se recrea con `--clear` o se aborta indicando la carpeta a borrar, en vez de dejar un entorno mixto.
- `langchain-ollama` y `langchain-nvidia-ai-endpoints` se instalan en una sola orden de pip: uno a uno quedaba un `langchain_core` que no satisface a ambos.

**2. Milvus y RAG** — `start_milvus.py`, `ragService.ts`, `milvus.service.ts`, `document.handler.ts`

- Un cliente reportó «100% documents not indexed» con 51 documentos y 0 chunks. `milvus-lite` 3.x declara sólo faiss-cpu/grpcio/numpy/pyarrow, pero su adaptador gRPC importa `pymilvus`. Como `import milvus_lite` sí funcionaba, el asistente daba el entorno por bueno y la degradación era silenciosa.
- **`wisdom:reindex` destruía el indexado y reportaba éxito**: borraba los chunks sin que nadie los recreara. El troceado + embeddings pasa a `buildIndexedChunks`, compartida por la subida y el nuevo `reindexDocument(id)`. Los embeddings se generan **antes** de tocar la base, el reemplazo va en transacción y en Milvus se retiran los vectores viejos antes de insertar.
- `getRAGHealth` consulta Milvus de verdad en lugar de escribir `'connected'` a mano — decir «connected» con el servidor caído fue lo que despistó el diagnóstico original.
- Adaptación a la API de `milvus-lite >= 3` (`start_and_get_uri()` / `release_all()`).

**3. Rutinas de resiliencia (UI)** — `WNTRMainInterface.tsx`, `WNTRMapViewer.tsx`, `WNTRAdvancedMapViewer.tsx`

- Tabla de indicadores con cabeceras: `Indicador · Antes · Después` al comparar con la interrupción simulada, `Indicador · Valor Actual` cuando está desactivada.
- **Los nudos afectados por una interrupción ahora sí se resaltan en el mapa.** `highlightedComponents` existía pero no salía del componente: sólo cambiaba el color del badge, mientras la interfaz prometía «click en un nudo para resaltarlo en el mapa».
- Export CSV de la curva de fragilidad.
- «Serviceability (presión)» → «Nivel de servicio por presión»; botón de esqueletización renombrado a «Ejecutar Esqueletización / Vista Previa».
- Las cuatro rutinas avisan de su duración (40–60 s medidos en una red de 92 nudos).

**Infraestructura** — el watcher de Vite ignora `venv-wntr` y compañía: sus ~21.000 ficheros agotaban `fs.inotify.max_user_watches` y Vite moría con ENOSPC dejando el puerto 3000 huérfano.

## 🔗 Related Issues

Epic #26 (rutinas de resiliencia). Issues #22, #23, #25 cubiertos por el bloque 3.

## 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🔧 Maintenance (dependency updates, refactoring, etc.)
- [ ] 🌍 Internationalization

## 🌊 Hydraulic Engineering Impact
- [x] WNTR integration
- [ ] EPANET file handling
- [ ] Hydraulic calculations
- [x] Network visualization
- [ ] Project management
- [ ] Regulatory compliance

## 🧪 Testing
- [x] Tests pass locally — **28/28 en 5 ficheros** (`npm test`)
- [x] I have added tests that prove my fix is effective — `ragService.reindex.test.ts`, `pythonDetector.priority.test.ts`, `pythonDetector.integration.test.ts`
- [ ] I have tested on multiple platforms:
  - [ ] macOS
  - [x] Windows — vía instaladores rc.1–rc.9 validados por el cliente
  - [x] Linux — desarrollo

## 🔍 Testing Instructions

1. **Arranque en Windows limpio**: instalar el rc.9, dejar que el asistente cree el venv, cerrar y reabrir Boorie. WNTR debe seguir detectado (era la regresión original).
2. **Venv no soportado**: con un venv sobre Python 3.9, el asistente debe explicar que milvus-lite no tiene candidato para Windows por debajo de 3.10 y ofrecer recrearlo.
3. **Reindexado**: subir un documento al Wisdom Center, pulsar «reindexar» y comprobar que devuelve fragmentos indexados reales (antes borraba y reportaba éxito).
4. **Resaltado de nudos**: cargar Net3, pestaña de resiliencia, simular interrupción de la tubería `251`. Los nudos afectados deben quedar resaltados en el mapa **sin tocar nada más**.
5. **Exports**: generar la curva de fragilidad y exportar a CSV; ídem con los indicadores de resiliencia.

## 📸 Screenshots

Comparativa del resaltado (izquierda: tras simular; derecha: resaltado quitado) disponible a petición; verificado con `compare` de ImageMagick, 2405 píxeles de diferencia.

## 🌍 Internationalization
- [x] Changes include new user-facing text
- [ ] Text has been added to translation files
- [ ] All supported languages updated

> **Nota para el revisor:** el texto nuevo va en castellano y codificado en el componente, siguiendo la convención existente del panel WNTR, que no está internacionalizado. Si el equipo quiere llevarlo a `src/locales/`, conviene hacerlo para todo el panel de una vez y no sólo para estas cadenas.

## 📚 Documentation
- [ ] Documentation has been updated
- [x] Code comments added/updated — el «por qué» de las decisiones no obvias (rango 3.10–3.13, expresión `in` en el paint, ref en `addNetworkToMap`)

## ⚡ Performance
- [x] This change improves performance

Los embeddings se generan antes de tocar la base, evitando reindexados a medias. El resaltado se aplica en el *paint* de la capa en vez de reconstruir la fuente GeoJSON, así que cambiar la selección no rehace capas ni pierde el encuadre del mapa.

## 🔒 Security
- [x] No security impact

## 📦 Dependencies
- [x] Dependencies have been updated

`pymilvus` pasa a ser paquete verificado por el asistente (lo exige el adaptador gRPC de milvus-lite). `langchain-ollama` y `langchain-nvidia-ai-endpoints` pasan a opcionales y se resuelven en bloque. No hay altas en `package.json` más allá del bump de versión.

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings — `npm run typecheck` limpio; ESLint sin errores (los avisos son preexistentes)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published

## 🎯 Breaking Changes

Ninguno en la API, pero sí un **requisito de entorno**: Python pasa de «3.9 o superior» a **3.10–3.13**. Un usuario con un venv sobre 3.9 verá el asistente ofreciendo recrearlo; el venv anterior se conserva como `venv-wntr-old-<ts>`.

## 📝 Additional Notes

- Validado por el cliente sobre el instalador **v1.5.1-rc.9** (`sha256 561e3ed84c2a388c42bd7e41176f2282e770cf856224636cb3b72cc98e40b9e6`).
- El rc.7 fue retirado: se empaquetó con el cliente Prisma generado para PostgreSQL dentro de un paquete cuyo schema declara `sqlite`, y la app no abría. Corregido en rc.8; desde entonces se verifica el `provider` **dentro del `.exe`** antes de publicar.
- La rama arrastra 17 commits porque se fue entregando por instaladores sucesivos según el cliente reportaba. Para revisar, el orden por bloques de la descripción es más útil que el cronológico.