### PR TITLE
Proyecto activo global y escenarios de red (#31)

### DIFF
--- a/backend/services/hydraulic/networkRepository.ts
+++ b/backend/services/hydraulic/networkRepository.ts
@@ -39,6 +39,12 @@ export interface SavedNetwork {
   }
   coordinateSystem?: any
   version: string
+  /**
+   * false cuando la red se guardo sin el .inp original: se puede ver en el mapa
+   * pero no simular, porque WNTR necesita el fichero. Pasa con redes migradas
+   * desde el overlay de localStorage cuyo .inp ya no estaba en disco.
+   */
+  hasFileContent: boolean
   isActive: boolean
   lastLoaded?: Date
   createdAt: Date
@@ -50,6 +56,11 @@ export class NetworkRepositoryService {
 
   /**
    * Save a network to the repository
+   */
+  /**
+   * `fileContent` vacio se acepta a proposito: una red migrada cuyo .inp ya no
+   * existe se conserva con sus datos parseados y queda marcada como incompleta,
+   * en lugar de descartarse. Perder la red seria peor que no poder simularla.
    */
   async saveNetwork(
     projectId: string,
@@ -269,6 +280,7 @@ export class NetworkRepositoryService {
     summary: JSON.parse(network.summary),
     coordinateSystem: network.coordinateSystem ? JSON.parse(network.coordinateSystem) : undefined,
     version: network.version,
+    hasFileContent: !!network.fileContent,
     isActive: network.isActive,
     lastLoaded: network.lastLoaded,
     createdAt: network.createdAt,

--- a/backend/services/hydraulic/networkRepository.ts
+++ b/backend/services/hydraulic/networkRepository.ts
@@ -45,6 +45,10 @@ export interface SavedNetwork {
    * desde el overlay de localStorage cuyo .inp ya no estaba en disco.
    */
   hasFileContent: boolean
+  /** Red madre de la que deriva este escenario; ausente en la red original. */
+  parentId?: string
+  scenarioLabel?: string
+  resultsPath?: string
   isActive: boolean
   lastLoaded?: Date
   createdAt: Date
@@ -67,7 +71,12 @@ export class NetworkRepositoryService {
     networkData: NetworkData,
     fileContent: string,
     filename: string,
-    description?: string
+    description?: string,
+    /**
+     * Datos de escenario: cuando la red deriva de otra (esqueletizacion,
+     * interrupcion...), cuelga de ella en lugar de quedar como red suelta (#31).
+     */
+    scenario?: { parentId?: string; scenarioLabel?: string; resultsPath?: string }
   ): Promise<SavedNetwork> {
     // Check if network with same name exists in project
     const existing = await this.prisma.hydraulicNetwork.findFirst({
@@ -92,6 +101,9 @@ export class NetworkRepositoryService {
         networkData: JSON.stringify(networkData),
         coordinateSystem: networkData.coordinate_system ? JSON.stringify(networkData.coordinate_system) : null,
         summary: JSON.stringify(networkData.summary),
+        parentId: scenario?.parentId ?? null,
+        scenarioLabel: scenario?.scenarioLabel ?? null,
+        resultsPath: scenario?.resultsPath ?? null,
         version: '1.0'
       }
     })
@@ -281,6 +293,9 @@ export class NetworkRepositoryService {
     coordinateSystem: network.coordinateSystem ? JSON.parse(network.coordinateSystem) : undefined,
     version: network.version,
     hasFileContent: !!network.fileContent,
+    parentId: network.parentId ?? undefined,
+    scenarioLabel: network.scenarioLabel ?? undefined,
+    resultsPath: network.resultsPath ?? undefined,
     isActive: network.isActive,
     lastLoaded: network.lastLoaded,
     createdAt: network.createdAt,

--- a/docs/PROYECTO_ACTIVO_GLOBAL.md
+++ b/docs/PROYECTO_ACTIVO_GLOBAL.md
@@ -1,0 +1,122 @@
+# Proyecto activo global y escenarios de red
+
+Diseño y decisiones de la funcionalidad pedida en el [issue #31](https://github.com/Boorie-AI/boorie_cliente/issues/31), la tarea habilitadora nº 0 del informe de apreciaciones.
+
+## El problema
+
+No existía un proyecto activo global. `useProjectStore` estaba escrito y **ningún componente lo importaba**; en su lugar, cada vista guardaba el proyecto en su propio estado local y lo perdía al desmontarse. Por eso el chat no sabía en qué proyecto estaba el usuario y no había dónde exigir «al menos una red» de forma coherente.
+
+Además, redes y cálculos vivían en la clave `wntr_project_assets` de `localStorage`, no en las tablas `HydraulicNetwork` y `HydraulicCalculation`, invisibles para el resto de la aplicación.
+
+## Lo que se construye
+
+| Fase | Contenido |
+|---|---|
+| 1 | Proyecto activo global en `useProjectStore`, persistido y compartido por todas las vistas |
+| 2 | Aviso al abrir una conversación que pertenece a otro proyecto |
+| 3 | Redes y cálculos pasan a la base de datos, con migración del almacenamiento local |
+| 4 | Jerarquía madre/hija de escenarios en el esquema |
+| 5 | La esqueletización puede guardarse como escenario de la red madre |
+
+## Decisiones
+
+### 1. Se persiste sólo el id, y el proyecto se rehidrata de la base de datos
+
+`currentProjectId` es la única cosa que se guarda. El objeto completo se vuelve a pedir con `restoreActiveProject()`.
+
+Guardar el objeto serviría datos obsoletos si el proyecto cambió de nombre o de contenido entre sesiones. Y si se borró, el id se descarta en lugar de dejar la aplicación apuntando a algo que no existe.
+
+**El issue daba por hecho que esto ya funcionaba** («persistencia de `currentProjectId`, línea 265»). No funcionaba: el fichero sólo importaba `devtools`, nunca `persist`, así que ese `partialize` se pasaba como opción de devtools y se ignoraba en silencio. El código *parecía* persistir. El criterio de aceptación de restaurar el proyecto al reabrir habría fallado igual después de enchufar el store.
+
+### 2. La restauración se dispara desde la raíz, no desde el store
+
+`restoreActiveProject()` la llama `App.tsx`, y no `onRehydrateStorage`, porque necesita que `window.electronAPI` exista para releer de la base de datos.
+
+### 3. Seleccionar un proyecto ya no carga su red en el backend
+
+`syncAllSections` llamaba a `loadNetworkFromProject`, que carga un `.inp` en el backend de WNTR. Se ha quitado: **seleccionar proyecto fija contexto, cargar una red es una acción explícita**.
+
+Cargarla por detrás deja el backend simulando una red distinta de la que el usuario ve. Es la clase de desincronización que costó la retirada de la v1.5.1-rc.7 y el fallo del resaltado de nudos. Como el store no tenía ningún importador, el cambio no rompió nada.
+
+### 4. La discrepancia chat / proyecto se pregunta, no se resuelve sola
+
+Al abrir una conversación de otro proyecto, se pregunta. Conmutar por cuenta propia cambiaría el contexto de la red y del Wisdom Center sin que el usuario lo pida; no conmutar dejaría al LLM respondiendo con el contexto de otro proyecto. Las dos opciones son defendibles, así que decide quien está delante.
+
+**La detección vive en `chatStore.setActiveConversation`**, que es el punto único. Hay cinco sitios en la interfaz que abren conversaciones (`Sidebar` ×2, `ProjectConversationsList`, `ProjectDetailView`), y repartir la comprobación entre ellos es exactamente lo que produjo el problema que arregla este issue.
+
+### 5. La migración no puede perder datos
+
+Cuatro reglas, todas cubiertas con tests, porque aquí un error se ve como «he perdido mis redes»:
+
+1. **La clave original nunca se borra.** El control de si ya se migró vive en una clave marcadora aparte.
+2. **Una red sin su `.inp` no se descarta.** El overlay guardaba la ruta del fichero, no su contenido, y `fileContent` es obligatorio. Si el usuario movió o borró el `.inp`, la red se guarda con sus datos parseados y queda marcada como incompleta: se ve en el mapa pero no se puede simular. Perder la red sería peor que no poder simularla.
+3. **El marcador se escribe aunque haya fallos**, para no duplicar lo migrado en cada arranque. El detalle queda en el informe.
+4. **Si el overlay está corrupto, no se marca**, para no dar por migrado algo que no se pudo leer.
+
+Y una guarda contra ejecuciones concurrentes: el marcador se escribe al final, así que dos llamadas simultáneas verían ambas «sin migrar». Pasa de verdad — `React.StrictMode` invoca los efectos dos veces en desarrollo — y se detectó ejecutándolo: cuatro redes donde debían haber dos.
+
+### 6. Una red ya guardada no es un fallo
+
+El overlay acumulaba copias de la misma red, porque el código antiguo la reañadía en cada carga: 13 copias de `newport.inp` en un proyecto. El informe decía «14 redes no se pudieron guardar» cuando 13 ya estaban dentro.
+
+El duplicado se marca en el handler, con el código `P2002` de Prisma, en lugar de comparar cadenas de error en el renderer.
+
+### 7. El `.inp` se lee y se escribe en el proceso principal
+
+`network-repo:save` acepta una ruta y lee el fichero él mismo. Exponer un lector de ficheros genérico al renderer sería un agujero innecesario en una aplicación con aislamiento de contexto.
+
+> Nota: `readFile` está expuesto en `preload.ts` y **no tiene handler** en el proceso principal, así que llamarlo falla con «No handler registered for read-file». Conviene retirarlo antes de que alguien lo use.
+
+### 8. `network-repo:load` materializa el `.inp` en un temporal
+
+Devuelve los datos y la ruta de un fichero temporal con el contenido guardado, para poder cargarlo en el backend de WNTR con el canal que ya existe.
+
+El efecto secundario es una mejora: la fuente pasa a ser la base de datos, así que **una red guardada sigue abriéndose aunque el usuario haya movido o borrado el `.inp` original**. Antes eso la rompía.
+
+### 9. `onDelete: SetNull` en la jerarquía, no `Cascade`
+
+Borrar la red original no debe llevarse por delante los escenarios derivados, que pueden tener resultados que el usuario quiere conservar. Se quedan como raíz, y el listado los muestra como tales en vez de ocultarlos.
+
+### 10. Se mantiene «guardar como proyecto aparte»
+
+La esqueletización puede guardarse como escenario hijo (acción principal) o como proyecto independiente. Lo segundo es el comportamiento que el cliente validó en el rc.9, y hay análisis que se organizan así.
+
+### 11. La ruta de resultados la elige el usuario
+
+`resultsPath` toma la carpeta donde el usuario guardó el `.inp` del escenario. No la impone la aplicación.
+
+## Fallos latentes encontrados por el camino
+
+Ninguno estaba en el issue. Los cuatro se arreglan en esta rama:
+
+| Fallo | Consecuencia |
+|---|---|
+| `projectStore` no aplicaba `persist` | Nada se persistía, aunque el código lo aparentara |
+| `ChatArea` tenía su propio `selectedProjectId` | Se podía estar en un proyecto en WNTR y en otro en el chat, sin aviso |
+| El `.inp` se buscaba comparando nombres entre las redes guardadas | Con dos redes homónimas devolvía la equivocada; con una red sin guardar, el backend simulaba la anterior |
+| `hydraulic:save-calculation` exigía la forma de la calculadora de fórmulas | Cualquier otro llamante fallaba con «Cannot read properties of undefined (reading 'value')»; los 29 cálculos de la migración fallaban |
+
+También se cerraron los cuatro avisos de `react-hooks/exhaustive-deps` del componente. No son cosméticos: un closure obsoleto en los callbacks de análisis y simulación significa simular la red equivocada.
+
+## Verificación
+
+Todo lo relevante se comprobó ejecutando la aplicación, no sólo con tests:
+
+- El proyecto se comparte entre vistas y se restaura al reabrir.
+- El aviso de discrepancia muestra los dos nombres correctos y conmutar propaga a la vista WNTR.
+- Migración sobre datos reales (16 redes en 4 proyectos, 29 cálculos): **4 redes, 12 ya existentes, 0 incompletas, 0 fallidas, 29/29 cálculos**, con el overlay intacto.
+- La jerarquía se recorre en los dos sentidos, y al borrar la madre la hija sobrevive con `parentId` a `null`.
+- Esqueletizar y guardar como escenario crea la hija, y la lista muestra la madre con 7 nudos y debajo el escenario con 3.
+
+## Fuera de alcance
+
+| No se hace | Motivo |
+|---|---|
+| Interfaz para reubicar el `.inp` de una red incompleta | Se marca y se explica; reimportarla ya funciona |
+| Migrar el overlay de equipos distintos | La clave es local a cada instalación |
+| Unificar `ProjectData` (store) y `Project` (vista) | Son formas distintas por motivos reales: una viene de la base de datos, la otra compone la vista. Unificarlas es un refactor aparte |
+| Retirar `docs/wiki` o el `readFile` muerto del preload | Ajenos a este issue, anotados para no perderlos |
+
+## Nota para la revisión
+
+El issue describe el problema sólo en `WNTRMainInterface`. En realidad había **tres** sitios con estado de proyecto propio, y el chat no es que le faltara el dato: **tenía otro**. Y daba por funcionando una persistencia que no existía. Merece la pena tenerlo presente al valorar el alcance frente a lo pedido.

--- a/electron/handlers/hydraulic.handler.ts
+++ b/electron/handlers/hydraulic.handler.ts
@@ -251,7 +251,20 @@ export class HydraulicHandler {
       try {
         const projects = await this.services.database.prisma.hydraulicProject.findMany({
           orderBy: { updatedAt: 'desc' },
-          include: { _count: { select: { conversations: true } } }
+          // Los contadores vienen en la misma consulta: el panel de proyectos
+          // muestra redes/simulaciones/chats de cada tarjeta, y pedirlos proyecto
+          // a proyecto seria una consulta por tarjeta.
+          include: {
+            _count: {
+              select: {
+                conversations: true,
+                // deleteNetwork() es borrado logico (isActive: false); sin filtrar,
+                // la tarjeta contaria redes ya borradas.
+                networks: { where: { isActive: true } },
+                calculations: true
+              }
+            }
+          }
         })
 
         const projectList = projects.map(p => ({
@@ -263,7 +276,9 @@ export class HydraulicHandler {
           location: safeJsonParse(p.location, { country: '', region: '' }),
           createdAt: p.createdAt,
           updatedAt: p.updatedAt,
-          chatCount: p._count.conversations
+          chatCount: p._count.conversations,
+          networkCount: p._count.networks,
+          calculationCount: p._count.calculations
         }))
 
         return { success: true, data: projectList }

--- a/electron/handlers/hydraulic.handler.ts
+++ b/electron/handlers/hydraulic.handler.ts
@@ -319,14 +319,23 @@ export class HydraulicHandler {
             projectId,
             type: calculation.type,
             name: calculation.name,
-            inputs: JSON.stringify(calculation.inputs),
-            results: JSON.stringify({
-              value: calculation.result.value,
-              unit: calculation.result.unit,
-              steps: calculation.intermediateSteps
-            }),
-            formulas: JSON.stringify([calculation.formula]),
-            notes: calculation.recommendations?.join('\n')
+            inputs: JSON.stringify(calculation.inputs ?? {}),
+            // El handler estaba ajustado solo a la calculadora de formulas, que
+            // devuelve un unico valor con unidad. Una simulacion WNTR produce un
+            // objeto de resultados arbitrario, asi que si el llamante ya envia
+            // `results` se guarda tal cual, y solo si no lo hace se compone desde
+            // la forma de CalculationResult.
+            results: JSON.stringify(
+              (calculation as any).results ?? {
+                value: calculation.result?.value,
+                unit: calculation.result?.unit,
+                steps: calculation.intermediateSteps
+              }
+            ),
+            formulas: JSON.stringify(
+              (calculation as any).formulas ?? (calculation.formula ? [calculation.formula] : [])
+            ),
+            notes: (calculation as any).notes ?? calculation.recommendations?.join('\n')
           }
         })
         

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -29,6 +29,14 @@ export class NetworkRepositoryHandler {
       filePath?: string
       filename: string
       description?: string
+      /**
+       * Permite guardar sin el .inp, dejando la red marcada como incompleta. Solo
+       * lo usa la migracion del overlay heredado: si el fichero original ya no
+       * esta en disco, conservar la red con sus datos parseados es mejor que
+       * descartarla. Exigirlo de forma explicita evita que ocurra por descuido en
+       * el flujo normal de guardado.
+       */
+      allowMissingFile?: boolean
     }) => {
       try {
         appLogger.info('Saving network to repository', {
@@ -39,16 +47,23 @@ export class NetworkRepositoryHandler {
 
         let fileContent = data.fileContent
         if (!fileContent && data.filePath) {
-          fileContent = await readFile(data.filePath, 'utf-8')
+          try {
+            fileContent = await readFile(data.filePath, 'utf-8')
+          } catch (error) {
+            if (!data.allowMissingFile) throw error
+            appLogger.warn('El .inp ya no esta en disco; la red se guarda incompleta', {
+              filePath: data.filePath
+            })
+          }
         }
-        if (!fileContent) {
-          throw new Error('Falta el contenido del .inp: envía fileContent o filePath')
+        if (!fileContent && !data.allowMissingFile) {
+          throw new Error('Falta el contenido del .inp: envia fileContent o filePath')
         }
 
         const savedNetwork = await this.networkRepo.saveNetwork(
           data.projectId,
           data.networkData,
-          fileContent,
+          fileContent ?? '',
           data.filename,
           data.description
         )

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -78,10 +78,24 @@ export class NetworkRepositoryHandler {
           data: savedNetwork
         }
       } catch (error) {
-        appLogger.error('Failed to save network', error as Error)
+        // Una red ya guardada no es un error de verdad: la migracion del overlay
+        // heredado encuentra duplicados a puñados (el codigo antiguo reañadia la
+        // red en cada carga), y presentarlos como fallos alarma sin motivo. Se
+        // marca aqui, con el codigo de Prisma o el mensaje del servicio, para no
+        // tener que adivinarlo comparando cadenas en el renderer.
+        const mensaje = (error as Error).message
+        const duplicate =
+          (error as { code?: string }).code === 'P2002' ||
+          mensaje.includes('ya existe') ||
+          mensaje.includes('Unique constraint failed')
+
+        if (duplicate) appLogger.info('La red ya estaba guardada en el proyecto', { name: data.networkData?.name })
+        else appLogger.error('Failed to save network', error as Error)
+
         return {
           success: false,
-          error: (error as Error).message
+          duplicate,
+          error: mensaje
         }
       }
     })

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -37,6 +37,8 @@ export class NetworkRepositoryHandler {
        * el flujo normal de guardado.
        */
       allowMissingFile?: boolean
+      /** Si viene, la red se guarda como escenario colgando de `parentId`. */
+      scenario?: { parentId?: string; scenarioLabel?: string; resultsPath?: string }
     }) => {
       try {
         appLogger.info('Saving network to repository', {
@@ -65,7 +67,8 @@ export class NetworkRepositoryHandler {
           data.networkData,
           fileContent ?? '',
           data.filename,
-          data.description
+          data.description,
+          data.scenario
         )
 
         appLogger.success('Network saved successfully', {

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -1,4 +1,7 @@
 import { ipcMain } from 'electron'
+import { readFile, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { NetworkRepositoryService } from '../../backend/services/hydraulic/networkRepository'
 import type { PrismaClient } from '@prisma/client'
 import { appLogger } from '../../backend/utils/logger'
@@ -16,7 +19,14 @@ export class NetworkRepositoryHandler {
     ipcMain.handle('network-repo:save', async (_, data: {
       projectId: string
       networkData: any
-      fileContent: string
+      /** Contenido del .inp. Si no se envía, se lee de `filePath`. */
+      fileContent?: string
+      /**
+       * Ruta del .inp en disco. El renderer la tiene tras cargar la red, pero no
+       * puede leer ficheros: la lectura se hace aquí a propósito, para no exponer
+       * un lector genérico al proceso de renderizado.
+       */
+      filePath?: string
       filename: string
       description?: string
     }) => {
@@ -27,10 +37,18 @@ export class NetworkRepositoryHandler {
           filename: data.filename
         })
 
+        let fileContent = data.fileContent
+        if (!fileContent && data.filePath) {
+          fileContent = await readFile(data.filePath, 'utf-8')
+        }
+        if (!fileContent) {
+          throw new Error('Falta el contenido del .inp: envía fileContent o filePath')
+        }
+
         const savedNetwork = await this.networkRepo.saveNetwork(
           data.projectId,
           data.networkData,
-          data.fileContent,
+          fileContent,
           data.filename,
           data.description
         )
@@ -113,11 +131,20 @@ export class NetworkRepositoryHandler {
 
         const result = await this.networkRepo.loadNetwork(networkId)
 
-        appLogger.success('Network loaded successfully', { networkId })
+        // El .inp guardado se materializa en un temporal y se devuelve su ruta,
+        // para que el llamante pueda cargarlo en el backend de WNTR con el canal
+        // que ya existe. Así la red que se simula es la que se muestra, y la red
+        // guardada sigue abriéndose aunque el fichero original se haya movido o
+        // borrado: la fuente es la base de datos, no el disco del usuario.
+        const filePath = join(tmpdir(), `boorie-net-${networkId}.inp`)
+        await writeFile(filePath, result.fileContent, 'utf-8')
+
+        appLogger.success('Network loaded successfully', { networkId, filePath })
 
         return {
           success: true,
-          data: result.networkData
+          data: result.networkData,
+          filePath
         }
       } catch (error) {
         appLogger.error('Failed to load network', error as Error)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -163,6 +163,9 @@ const electronAPI = {
       filePath?: string
       filename: string
       description?: string
+      // Solo la migracion del overlay heredado: guarda la red sin .inp, marcada
+      // como incompleta, en vez de perderla.
+      allowMissingFile?: boolean
     }) => ipcRenderer.invoke('network-repo:save', data),
 
     update: (data: {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -166,6 +166,8 @@ const electronAPI = {
       // Solo la migracion del overlay heredado: guarda la red sin .inp, marcada
       // como incompleta, en vez de perderla.
       allowMissingFile?: boolean
+      // Guarda la red como escenario derivado de otra (#31).
+      scenario?: { parentId?: string; scenarioLabel?: string; resultsPath?: string }
     }) => ipcRenderer.invoke('network-repo:save', data),
 
     update: (data: {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -157,7 +157,10 @@ const electronAPI = {
     save: (data: {
       projectId: string
       networkData: any
-      fileContent: string
+      // Uno de los dos: el contenido del .inp, o su ruta para que el proceso
+      // principal lo lea (el renderer no tiene acceso a disco).
+      fileContent?: string
+      filePath?: string
       filename: string
       description?: string
     }) => ipcRenderer.invoke('network-repo:save', data),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -331,8 +331,25 @@ model HydraulicNetwork {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
+  // Jerarquia madre/hija de escenarios (#31). La red importada es la "madre" y
+  // cada escenario derivado (esqueletizacion, interrupcion de servicio...) es una
+  // "hija" que cuelga de ella, en lugar de un proyecto suelto sin trazabilidad.
+  //
+  // onDelete: SetNull y no Cascade a proposito: borrar la red original no debe
+  // llevarse por delante los escenarios derivados de ella, que pueden tener
+  // resultados que el usuario quiere conservar. Se quedan como raiz.
+  parentId          String?
+  parent            HydraulicNetwork?  @relation("EscenariosDeRed", fields: [parentId], references: [id], onDelete: SetNull)
+  scenarios         HydraulicNetwork[] @relation("EscenariosDeRed")
+
+  /// Etiqueta del escenario, p. ej. "esqueletizada 100 mm". Null en la red madre.
+  scenarioLabel     String?
+  /// Carpeta de resultados del escenario, validada por el usuario.
+  resultsPath       String?
+
   project           HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
+  @@index([parentId])
   @@unique([projectId, name])
   @@map("hydraulic_networks")
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,12 @@ import { ChatLayout } from '@/components/chat/ChatLayout'
 import { CustomTopBar } from '@/components/CustomTopBar'
 import { GlobalErrorTracker } from '@/components/GlobalErrorTracker'
 import { ProjectMismatchDialog } from '@/components/project/ProjectMismatchDialog'
+import { MigracionAvisoDialog } from '@/components/project/MigracionAvisoDialog'
 import { Onboarding } from '@/components/Onboarding'
 import { SetupWizard } from '@/components/setup/SetupWizard'
 import { useAppStore } from '@/stores/appStore'
 import { useProjectStore } from '@/stores/projectStore'
+import { migrateProjectAssets } from '@/services/migration/migrateProjectAssets'
 import { cn } from '@/utils/cn'
 import './i18n' // Initialize i18n
 
@@ -18,6 +20,7 @@ function App() {
   const [setupChecked, setSetupChecked] = useState(false)
   const [setupNeeded, setSetupNeeded] = useState(false)
   const [setupSkipped, setSetupSkipped] = useState(false)
+  const [informeMigracion, setInformeMigracion] = useState<Awaited<ReturnType<typeof migrateProjectAssets>> | null>(null)
 
   useEffect(() => {
     initializeApp()
@@ -29,6 +32,17 @@ function App() {
   useEffect(() => {
     restoreActiveProject()
   }, [restoreActiveProject])
+
+  // Las redes y calculos que vivian en localStorage pasan a la base de datos
+  // (#31). Se hace despues de restaurar el proyecto y una sola vez: el modulo
+  // lleva su propio marcador y nunca borra los datos originales.
+  useEffect(() => {
+    migrateProjectAssets()
+      .then(informe => {
+        if (informe.ejecutada) setInformeMigracion(informe)
+      })
+      .catch(error => console.error('Fallo la migracion del almacenamiento local:', error))
+  }, [])
 
   // First-run check: if Python deps are missing, show the SetupWizard.
   useEffect(() => {
@@ -85,6 +99,7 @@ function App() {
         <Onboarding />
         {/* Único en la raíz: cualquier vista puede abrir una conversación. */}
         <ProjectMismatchDialog />
+        <MigracionAvisoDialog informe={informeMigracion} onClose={() => setInformeMigracion(null)} />
         {setupChecked && setupNeeded && !setupSkipped && (
           <SetupWizard onComplete={() => { setSetupNeeded(false); setSetupSkipped(true) }} />
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,14 @@ import { GlobalErrorTracker } from '@/components/GlobalErrorTracker'
 import { Onboarding } from '@/components/Onboarding'
 import { SetupWizard } from '@/components/setup/SetupWizard'
 import { useAppStore } from '@/stores/appStore'
+import { useProjectStore } from '@/stores/projectStore'
 import { cn } from '@/utils/cn'
 import './i18n' // Initialize i18n
 
 function App() {
   const { t } = useTranslation()
   const { initializeApp, isInitialized, theme } = useAppStore()
+  const restoreActiveProject = useProjectStore(s => s.restoreActiveProject)
   const [setupChecked, setSetupChecked] = useState(false)
   const [setupNeeded, setSetupNeeded] = useState(false)
   const [setupSkipped, setSetupSkipped] = useState(false)
@@ -19,6 +21,13 @@ function App() {
   useEffect(() => {
     initializeApp()
   }, [initializeApp])
+
+  // El proyecto activo se restaura aquí, y no en el store, porque hace falta
+  // que window.electronAPI exista para releerlo de la base de datos. Si el
+  // proyecto se borró entre sesiones, el store descarta el id sin romper nada.
+  useEffect(() => {
+    restoreActiveProject()
+  }, [restoreActiveProject])
 
   // First-run check: if Python deps are missing, show the SetupWizard.
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ChatLayout } from '@/components/chat/ChatLayout'
 import { CustomTopBar } from '@/components/CustomTopBar'
 import { GlobalErrorTracker } from '@/components/GlobalErrorTracker'
+import { ProjectMismatchDialog } from '@/components/project/ProjectMismatchDialog'
 import { Onboarding } from '@/components/Onboarding'
 import { SetupWizard } from '@/components/setup/SetupWizard'
 import { useAppStore } from '@/stores/appStore'
@@ -82,6 +83,8 @@ function App() {
       <div className="flex-1 min-h-0 relative">
         <ChatLayout />
         <Onboarding />
+        {/* Único en la raíz: cualquier vista puede abrir una conversación. */}
+        <ProjectMismatchDialog />
         {setupChecked && setupNeeded && !setupSkipped && (
           <SetupWizard onComplete={() => { setSetupNeeded(false); setSetupSkipped(true) }} />
         )}

--- a/src/components/chat/ChatArea.tsx
+++ b/src/components/chat/ChatArea.tsx
@@ -1,5 +1,6 @@
-import { useRef, useEffect, useState } from 'react'
+import { useRef, useEffect } from 'react'
 import { useChatStore } from '@/stores/chatStore'
+import { useProjectStore } from '@/stores/projectStore'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
 import { ChatHeader } from './ChatHeader'
@@ -10,7 +11,16 @@ import boorieIconLight from '@/assets/boorie_icon_light.png'
 
 export function ChatArea() {
   const { activeConversationId, conversations, isLoading, streamingMessage } = useChatStore()
-  const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>()
+  // El proyecto del chat es el proyecto activo global (issue #31): antes el chat
+  // llevaba su propia selección, así que podía estar en un proyecto distinto del
+  // que mostraba la vista WNTR.
+  const selectedProjectId = useProjectStore(s => s.currentProjectId) ?? undefined
+  const selectProject = useProjectStore(s => s.selectProject)
+  const clearProject = useProjectStore(s => s.clearProject)
+  const onProjectSelect = (projectId: string | undefined) => {
+    if (projectId) selectProject(projectId)
+    else clearProject()
+  }
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   const activeConversation = conversations.find(c => c.id === activeConversationId)
@@ -47,7 +57,7 @@ export function ChatArea() {
             <div className="space-y-4 flex flex-col items-center">
               <ProjectSelector
                 selectedProjectId={selectedProjectId}
-                onProjectSelect={setSelectedProjectId}
+                onProjectSelect={onProjectSelect}
                 className="justify-center"
               />
 

--- a/src/components/chat/ProjectConversationsList.tsx
+++ b/src/components/chat/ProjectConversationsList.tsx
@@ -32,9 +32,14 @@ export function ProjectConversationsList({ projectId, currentConversationId }: P
   }, [])
   
   useEffect(() => {
-    if (projectId && projects.length > 0) {
-      const project = projects.find(p => p.id === projectId)
-      setSelectedProject(project || null)
+    // Sin el else, al volver a "General Conversations" (projectId undefined) se
+    // quedaba mostrando el nombre del proyecto anterior.
+    if (!projectId) {
+      setSelectedProject(null)
+      return
+    }
+    if (projects.length > 0) {
+      setSelectedProject(projects.find(p => p.id === projectId) || null)
     }
   }, [projectId, projects])
   

--- a/src/components/hydraulic/ProjectDashboard.tsx
+++ b/src/components/hydraulic/ProjectDashboard.tsx
@@ -252,12 +252,12 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
                                     <div className="grid grid-cols-3 gap-2 py-4 border-y border-slate-700/50">
                                         <div className="text-center">
                                             <div className="flex justify-center mb-1 text-blue-400"><Database className="h-4 w-4" /></div>
-                                            <div className="text-lg font-bold text-white">{project.networks.length}</div>
+                                            <div className="text-lg font-bold text-white">{project.networkCount}</div>
                                             <div className="text-[10px] uppercase tracking-wider text-slate-500">Redes</div>
                                         </div>
                                         <div className="text-center border-l border-slate-700/50">
                                             <div className="flex justify-center mb-1 text-green-400"><Activity className="h-4 w-4" /></div>
-                                            <div className="text-lg font-bold text-white">{project.calculations.length}</div>
+                                            <div className="text-lg font-bold text-white">{project.calculationCount}</div>
                                             <div className="text-[10px] uppercase tracking-wider text-slate-500">Sims</div>
                                         </div>
                                         <div className="text-center border-l border-slate-700/50">

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -201,7 +201,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     } catch (e) {
       logger.error('Failed to create project:', e);
     }
-  }, [toViewModel]);
+  }, [toViewModel, selectProjectGlobal]);
 
   const handleSelectProject = useCallback((project: Project) => {
     selectProjectGlobal(project.id);
@@ -222,7 +222,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     } catch (e) {
       logger.error('Failed to delete project:', e);
     }
-  }, [currentProject]);
+  }, [activeProjectId, clearProjectGlobal]);
 
   const handleSaveNetworkToProject = useCallback((data: NetworkData, filePath?: string) => {
     if (!currentProject) return;
@@ -263,6 +263,13 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
   // Core state
   const [networkData, setNetworkData] = useState<NetworkData | null>(null);
+  /**
+   * Ruta del .inp que el backend de WNTR tiene cargado. Antes se buscaba la red
+   * guardada por nombre para recuperarla, lo que falla con dos redes homonimas o
+   * con una red aun sin guardar. Recordar lo que se cargo es directo y no depende
+   * del catalogo.
+   */
+  const [loadedNetworkPath, setLoadedNetworkPath] = useState<string | null>(null);
   const [analysisResults, setAnalysisResults] = useState<AnalysisResults>({});
   // Core state - Updated to hold multiple simulation results
   interface ProjectSimulationResults {
@@ -334,6 +341,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
       if (result.success && result.data) {
         setNetworkData(result.data);
+        setLoadedNetworkPath(result.filePath ?? null);
 
         // Save to current project (include filePath for later re-loading)
         handleSaveNetworkToProject(result.data, result.filePath);
@@ -376,12 +384,10 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       setAnalysisProgress(0);
       setError(null);
 
-      // Ensure the INP file is loaded in the backend
-      // Find the filePath from saved networks, or skip if already loaded
-      const savedNet = currentProject?.networks.find(n => n.name === networkData.name);
-      if (savedNet?.filePath) {
-        logger.debug('Loading INP file before analysis:', savedNet.filePath);
-        const loadResult = await window.electronAPI.wntr.loadINPFromPath(savedNet.filePath);
+      // Se reasegura que el backend tenga cargado el .inp de la red que se ve.
+      if (loadedNetworkPath) {
+        logger.debug('Loading INP file before analysis:', loadedNetworkPath);
+        const loadResult = await window.electronAPI.wntr.loadINPFromPath(loadedNetworkPath);
         if (!loadResult.success) {
           throw new Error(`Failed to load INP file: ${loadResult.error}`);
         }
@@ -422,7 +428,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       setIsAnalyzing(false);
       // setAnalysisProgress(0); // Leave at 100 for visual confirmation
     }
-  }, [networkData, onAnalysisComplete]);
+  }, [networkData, loadedNetworkPath, onAnalysisComplete]);
 
 
 
@@ -438,11 +444,10 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       // Reset current results
       setSimulationResults({ hydraulic: null, quality: null, scenario: null });
 
-      // Ensure the INP file is loaded in the backend
-      const savedNet = currentProject?.networks.find(n => n.name === networkData.name);
-      if (savedNet?.filePath) {
-        logger.debug('Loading INP file before simulation:', savedNet.filePath);
-        const loadResult = await window.electronAPI.wntr.loadINPFromPath(savedNet.filePath);
+      // Se reasegura que el backend tenga cargado el .inp de la red que se ve.
+      if (loadedNetworkPath) {
+        logger.debug('Loading INP file before simulation:', loadedNetworkPath);
+        const loadResult = await window.electronAPI.wntr.loadINPFromPath(loadedNetworkPath);
         if (!loadResult.success) {
           throw new Error(`Failed to load INP file: ${loadResult.error}`);
         }
@@ -504,7 +509,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       setIsSimulating(false);
       // setSimulationProgress(0); // Leave at 100 to show success
     }
-  }, [networkData, onSimulationComplete, simulationDuration, simulationTimestep, currentProject, handleSaveCalculationToProject]);
+  }, [networkData, loadedNetworkPath, onSimulationComplete, simulationDuration, simulationTimestep, currentProject, handleSaveCalculationToProject]);
 
   // --- Resilience routines handlers (epic #26) ---
 
@@ -551,6 +556,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
       const loadRes = await window.electronAPI.wntr.loadINPFromPath(saveRes.filePath);
       if (loadRes.success && loadRes.data) {
+        setLoadedNetworkPath(saveRes.filePath);
         const networkAsset: NetworkAsset = {
           id: `net_${Date.now()}`,
           name: loadRes.data.name,
@@ -818,6 +824,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                           className="w-full justify-start text-xs"
                           onClick={async () => {
                             setNetworkData(net.data);
+                            setLoadedNetworkPath(net.filePath ?? null);
                             // Reload the .inp file in the backend so simulations/analyses work
                             if (net.filePath) {
                               try {

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -131,33 +131,26 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   // Lazy-initialized from localStorage so there's no load/save race on mount
   // (a load-then-save effect pair would briefly overwrite storage with the
   // initial empty state before the async load's setState landed).
-  const [projectAssets, setProjectAssets] = useState<Record<string, { networks: NetworkAsset[]; calculations: CalculationAsset[] }>>(() => {
-    try {
-      const saved = localStorage.getItem('wntr_project_assets');
-      return saved ? JSON.parse(saved) : {};
-    } catch (e) {
-      logger.error('Failed to load project assets:', e);
-      return {};
-    }
-  });
-
-  useEffect(() => {
-    localStorage.setItem('wntr_project_assets', JSON.stringify(projectAssets));
-  }, [projectAssets]);
+  // Las redes del proyecto activo salen de HydraulicNetwork. Antes vivian en la
+  // clave wntr_project_assets de localStorage, invisibles para el resto de la
+  // aplicacion y perdidas al cambiar de equipo (#31).
+  const [activeNetworks, setActiveNetworks] = useState<NetworkAsset[]>([]);
+  const storeCalculations = useProjectStore(s => s.currentProject?.calculations);
 
   const toViewModel = useCallback((p: any): Project => {
-    const assets = projectAssets[p.id] || { networks: [], calculations: [] };
     return {
       id: p.id,
       name: p.name,
       description: p.description,
       createdAt: p.createdAt ? new Date(p.createdAt).toISOString() : new Date().toISOString(),
       lastModified: p.updatedAt ? new Date(p.updatedAt).toISOString() : new Date().toISOString(),
-      networks: assets.networks,
-      calculations: assets.calculations,
+      networks: [],
+      calculations: [],
+      networkCount: p.networkCount ?? 0,
+      calculationCount: p.calculationCount ?? 0,
       chatCount: p.chatCount ?? 0
     };
-  }, [projectAssets]);
+  }, []);
 
   // Derivado, no duplicado: el catálogo aporta la identidad y el overlay las
   // redes y cálculos. Antes se mantenía una copia en estado local que había que
@@ -167,9 +160,41 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     if (!activeProjectId) return null;
     const base = projects.find(p => p.id === activeProjectId);
     if (!base) return null;
-    const assets = projectAssets[activeProjectId] || { networks: [], calculations: [] };
-    return { ...base, networks: assets.networks, calculations: assets.calculations };
-  }, [activeProjectId, projects, projectAssets]);
+    const calculations: CalculationAsset[] = (storeCalculations ?? []).map((c: any) => ({
+      id: c.id,
+      name: c.name,
+      date: c.createdAt ? new Date(c.createdAt).toISOString() : new Date().toISOString(),
+      status: 'completed',
+      networkId: '',
+      results: c.results
+    }));
+    return { ...base, networks: activeNetworks, calculations };
+  }, [activeProjectId, projects, activeNetworks, storeCalculations]);
+
+  const refreshCurrentProject = useCallback(() => {
+    if (activeProjectId) selectProjectGlobal(activeProjectId);
+  }, [activeProjectId, selectProjectGlobal]);
+
+  const refreshActiveNetworks = useCallback(async () => {
+    if (!activeProjectId) { setActiveNetworks([]); return; }
+    try {
+      const res = await window.electronAPI.networkRepository.getProjectNetworks(activeProjectId);
+      if (!res?.success) { logger.error('No se pudieron leer las redes del proyecto:', res?.error); return; }
+      setActiveNetworks((res.data ?? []).map((n: any): NetworkAsset => ({
+        id: n.id,
+        name: n.name,
+        uploadDate: n.createdAt ? new Date(n.createdAt).toISOString() : new Date().toISOString(),
+        nodeCount: (n.summary?.junctions ?? 0) + (n.summary?.tanks ?? 0) + (n.summary?.reservoirs ?? 0),
+        linkCount: n.summary?.pipes ?? 0,
+        // Sin `data`: se pide al abrirla, para no traer todas las redes a memoria.
+        incomplete: n.hasFileContent === false
+      })));
+    } catch (e) {
+      logger.error('Error leyendo las redes del proyecto:', e);
+    }
+  }, [activeProjectId]);
+
+  useEffect(() => { refreshActiveNetworks(); }, [refreshActiveNetworks]);
 
   const refreshProjects = useCallback(async () => {
     try {
@@ -210,12 +235,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   const handleDeleteProject = useCallback(async (projectId: string) => {
     try {
       await hydraulicService.deleteProject(projectId);
+      // Las redes y calculos del proyecto los borra la cascada de la base de
+      // datos (onDelete: Cascade), ya no hay que limpiar nada en local.
       setProjects(prev => prev.filter(p => p.id !== projectId));
-      setProjectAssets(prev => {
-        const next = { ...prev };
-        delete next[projectId];
-        return next;
-      });
       if (activeProjectId === projectId) {
         clearProjectGlobal();
       }
@@ -224,27 +246,33 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     }
   }, [activeProjectId, clearProjectGlobal]);
 
-  const handleSaveNetworkToProject = useCallback((data: NetworkData, filePath?: string) => {
-    if (!currentProject) return;
-
-    const networkAsset: NetworkAsset = {
-      id: `net_${Date.now()}`,
-      name: data.name,
-      filePath: filePath,
-      uploadDate: new Date().toISOString(),
-      nodeCount: data.summary?.junctions || 0,
-      linkCount: data.summary?.pipes || 0,
-      data: data
-    };
-
-    setProjectAssets(prev => {
-      const existing = prev[currentProject.id] || { networks: [], calculations: [] };
-      return { ...prev, [currentProject.id]: { ...existing, networks: [...existing.networks, networkAsset] } };
-    });
-  }, [currentProject]);
+  const handleSaveNetworkToProject = useCallback(async (data: NetworkData, filePath?: string) => {
+    if (!activeProjectId) return;
+    try {
+      // El proceso principal lee el .inp de `filePath`: el renderer no tiene
+      // acceso a disco, y el contenido hace falta para poder simular mas tarde
+      // aunque el usuario mueva el fichero original.
+      const res = await window.electronAPI.networkRepository.save({
+        projectId: activeProjectId,
+        networkData: data,
+        filePath,
+        filename: filePath?.split(/[\\/]/).pop() || `${data.name}.inp`
+      });
+      if (!res?.success) {
+        // Guardar dos veces la misma red no es un error que deba interrumpir:
+        // el repositorio rechaza nombres duplicados por proyecto.
+        logger.warn('No se guardo la red en el proyecto:', res?.error);
+        return;
+      }
+      await refreshActiveNetworks();
+      await refreshProjects();
+    } catch (e) {
+      logger.error('Error guardando la red en el proyecto:', e);
+    }
+  }, [activeProjectId, refreshActiveNetworks, refreshProjects]);
 
   const handleSaveCalculationToProject = useCallback((name: string, networkId: string, results: any) => {
-    if (!currentProject) return;
+    if (!activeProjectId) return;
 
     const calculation: CalculationAsset = {
       id: `calc_${Date.now()}`,
@@ -255,11 +283,22 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       results
     };
 
-    setProjectAssets(prev => {
-      const existing = prev[currentProject.id] || { networks: [], calculations: [] };
-      return { ...prev, [currentProject.id]: { ...existing, calculations: [...existing.calculations, calculation] } };
-    });
-  }, [currentProject]);
+    window.electronAPI.hydraulic
+      .saveCalculation(activeProjectId, {
+        type: 'wntr_simulation',
+        name: calculation.name,
+        inputs: { networkId },
+        results,
+        formulas: []
+      })
+      .then((res: any) => {
+        if (!res?.success) logger.warn('No se guardo el calculo en el proyecto:', res?.error);
+        // Recargar el proyecto trae la lista de calculos al dia, que es de donde
+        // la vista los lee ahora.
+        else refreshCurrentProject();
+      })
+      .catch((e: unknown) => logger.error('Error guardando el calculo:', e));
+  }, [activeProjectId, refreshCurrentProject]);
 
   // Core state
   const [networkData, setNetworkData] = useState<NetworkData | null>(null);
@@ -557,19 +596,13 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       const loadRes = await window.electronAPI.wntr.loadINPFromPath(saveRes.filePath);
       if (loadRes.success && loadRes.data) {
         setLoadedNetworkPath(saveRes.filePath);
-        const networkAsset: NetworkAsset = {
-          id: `net_${Date.now()}`,
-          name: loadRes.data.name,
+        await window.electronAPI.networkRepository.save({
+          projectId: newProject.id,
+          networkData: loadRes.data,
           filePath: saveRes.filePath,
-          uploadDate: new Date().toISOString(),
-          nodeCount: loadRes.data.summary?.junctions || 0,
-          linkCount: loadRes.data.summary?.pipes || 0,
-          data: loadRes.data
-        };
-        setProjectAssets(prev => ({
-          ...prev,
-          [newProject.id]: { networks: [networkAsset], calculations: [] }
-        }));
+          filename: saveRes.filePath.split(/[\\/]/).pop() || `${loadRes.data.name}.inp`,
+          description: `Esqueletizada desde "${currentProject.name}"`
+        });
       }
 
       await refreshProjects();
@@ -733,11 +766,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     if (!currentProject) {
       return (
         <ProjectDashboard
-          projects={projects.map(p => ({
-            ...p,
-            networks: projectAssets[p.id]?.networks ?? p.networks,
-            calculations: projectAssets[p.id]?.calculations ?? p.calculations
-          }))}
+          projects={projects}
           onSelectProject={handleSelectProject}
           onCreateProject={handleCreateProject}
           onDeleteProject={handleDeleteProject}
@@ -823,12 +852,20 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                           size="sm"
                           className="w-full justify-start text-xs"
                           onClick={async () => {
-                            setNetworkData(net.data);
-                            setLoadedNetworkPath(net.filePath ?? null);
-                            // Reload the .inp file in the backend so simulations/analyses work
-                            if (net.filePath) {
+                            // Datos y .inp desde la base de datos: la red se abre
+                            // aunque el fichero original ya no este en disco.
+                            const res = await window.electronAPI.networkRepository.load(net.id);
+                            if (!res?.success) {
+                              setError(res?.error || 'No se pudo abrir la red guardada');
+                              return;
+                            }
+                            setNetworkData(res.data);
+                            setLoadedNetworkPath(res.filePath ?? null);
+                            // El backend debe quedarse con la misma red que se
+                            // muestra, o las simulaciones correrian sobre otra.
+                            if (res.filePath) {
                               try {
-                                await window.electronAPI.wntr.loadINPFromPath(net.filePath);
+                                await window.electronAPI.wntr.loadINPFromPath(res.filePath);
                               } catch (err) {
                                 logger.warn('Could not reload INP file:', err);
                               }
@@ -837,6 +874,14 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                         >
                           <Database className="h-3 w-3 mr-2" />
                           {net.name}
+                          {net.incomplete && (
+                            <span
+                              className="ml-2 rounded bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-medium text-yellow-600 dark:text-yellow-500"
+                              title="Falta el fichero .inp original: la red se puede ver, pero no simular. Vuelve a importarla para recuperarla."
+                            >
+                              sin .inp
+                            </span>
+                          )}
                           <span className="ml-auto text-muted-foreground">
                             {net.nodeCount} nudos
                           </span>

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -180,15 +180,31 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     try {
       const res = await window.electronAPI.networkRepository.getProjectNetworks(activeProjectId);
       if (!res?.success) { logger.error('No se pudieron leer las redes del proyecto:', res?.error); return; }
-      setActiveNetworks((res.data ?? []).map((n: any): NetworkAsset => ({
+      const mapear = (n: any): NetworkAsset => ({
         id: n.id,
         name: n.name,
         uploadDate: n.createdAt ? new Date(n.createdAt).toISOString() : new Date().toISOString(),
         nodeCount: (n.summary?.junctions ?? 0) + (n.summary?.tanks ?? 0) + (n.summary?.reservoirs ?? 0),
         linkCount: n.summary?.pipes ?? 0,
         // Sin `data`: se pide al abrirla, para no traer todas las redes a memoria.
-        incomplete: n.hasFileContent === false
-      })));
+        incomplete: n.hasFileContent === false,
+        parentId: n.parentId,
+        scenarioLabel: n.scenarioLabel
+      });
+
+      // Cada escenario justo debajo de su madre: si no, la sangria de la lista no
+      // significaria nada porque el orden viene por fecha de modificacion.
+      const todas = (res.data ?? []).map(mapear);
+      const madres = todas.filter((n: NetworkAsset) => !n.parentId);
+      const ordenadas = madres.flatMap((m: NetworkAsset) => [
+        m,
+        ...todas.filter((n: NetworkAsset) => n.parentId === m.id)
+      ]);
+      // Un escenario cuya madre se borro queda como raiz: no debe desaparecer.
+      const huerfanos = todas.filter(
+        (n: NetworkAsset) => n.parentId && !madres.some((m: NetworkAsset) => m.id === n.parentId)
+      );
+      setActiveNetworks([...ordenadas, ...huerfanos]);
     } catch (e) {
       logger.error('Error leyendo las redes del proyecto:', e);
     }
@@ -574,6 +590,66 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     }
   }, [networkData, skeletonizeThresholdMm]);
 
+  /**
+   * Guarda la red esqueletizada como escenario que cuelga de la red actual, dentro
+   * del mismo proyecto (#31). Es lo que pedia el criterio de Luis Mora: la red
+   * importada es la carpeta madre y cada escenario una hija con su ruta de
+   * resultados, en lugar de un proyecto suelto sin trazabilidad.
+   */
+  const handleSaveSkeletonizedAsScenario = useCallback(async () => {
+    if (!skeletonizePreview || !activeProjectId || !networkData) return;
+    const madre = activeNetworks.find(n => n.name === networkData.name);
+    if (!madre) {
+      setSkeletonizeError('Guarda primero la red original en el proyecto para poder derivar escenarios de ella');
+      return;
+    }
+    try {
+      const etiqueta = `esqueletizada ${skeletonizeThresholdMm} mm`;
+      const saveRes = await window.electronAPI.wntr.saveINPFile(
+        skeletonizePreview.inp_content,
+        `${networkData.name}_${skeletonizeThresholdMm}mm.inp`
+      );
+      if (!saveRes.success || !saveRes.filePath) {
+        setSkeletonizeError(saveRes.error || 'Guardado cancelado');
+        return;
+      }
+
+      const loadRes = await window.electronAPI.wntr.loadINPFromPath(saveRes.filePath);
+      if (!loadRes.success || !loadRes.data) {
+        setSkeletonizeError(loadRes.error || 'No se pudo leer la red esqueletizada');
+        return;
+      }
+
+      const res = await window.electronAPI.networkRepository.save({
+        projectId: activeProjectId,
+        networkData: { ...loadRes.data, name: `${networkData.name} (${etiqueta})` },
+        filePath: saveRes.filePath,
+        filename: saveRes.filePath.split(/[\\/]/).pop() || 'escenario.inp',
+        description: `Escenario derivado de "${networkData.name}": umbral ${skeletonizeThresholdMm} mm, reduccion ${skeletonizePreview.reduction.pipes_pct}% tuberias / ${skeletonizePreview.reduction.junctions_pct}% nudos.`,
+        scenario: {
+          parentId: madre.id,
+          scenarioLabel: etiqueta,
+          // La carpeta donde el usuario guardo el .inp es la de resultados del
+          // escenario: la elige el, no la impone la aplicacion.
+          resultsPath: saveRes.filePath.replace(/[\\/][^\\/]+$/, '')
+        }
+      });
+
+      if (!res?.success) {
+        setSkeletonizeError(res?.duplicate
+          ? 'Ya existe un escenario con ese nombre en el proyecto'
+          : res?.error || 'No se pudo guardar el escenario');
+        return;
+      }
+
+      await refreshActiveNetworks();
+      await refreshProjects();
+      setSkeletonizePreview(null);
+    } catch (err) {
+      setSkeletonizeError(err instanceof Error ? err.message : 'Error guardando el escenario');
+    }
+  }, [skeletonizePreview, activeProjectId, networkData, activeNetworks, skeletonizeThresholdMm, refreshActiveNetworks, refreshProjects]);
+
   const handleSaveSkeletonizedNetwork = useCallback(async () => {
     if (!skeletonizePreview || !currentProject || !networkData) return;
     try {
@@ -850,7 +926,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                           key={net.id}
                           variant="outline"
                           size="sm"
-                          className="w-full justify-start text-xs"
+                          className={`w-full justify-start text-xs ${net.parentId ? 'ml-4 w-[calc(100%-1rem)]' : ''}`}
                           onClick={async () => {
                             // Datos y .inp desde la base de datos: la red se abre
                             // aunque el fichero original ya no este en disco.
@@ -874,6 +950,11 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                         >
                           <Database className="h-3 w-3 mr-2" />
                           {net.name}
+                          {net.scenarioLabel && (
+                            <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                              {net.scenarioLabel}
+                            </span>
+                          )}
                           {net.incomplete && (
                             <span
                               className="ml-2 rounded bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-medium text-yellow-600 dark:text-yellow-500"
@@ -1311,8 +1392,11 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                               </div>
                             </div>
                           </div>
+                          <Button size="sm" className="w-full" onClick={handleSaveSkeletonizedAsScenario}>
+                            Guardar como escenario de esta red
+                          </Button>
                           <Button size="sm" variant="outline" className="w-full" onClick={handleSaveSkeletonizedNetwork}>
-                            Guardar como nuevo proyecto
+                            Guardar como proyecto aparte
                           </Button>
                         </CardContent>
                       </Card>

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -1,6 +1,7 @@
 import { logger } from '@/utils/logger'
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { useClarity } from '@/components/ClarityProvider';
+import { useProjectStore } from '@/stores/projectStore';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -120,7 +121,13 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   // feature — see network-repo IPC channels), so this keeps existing
   // behavior working without regressing it.
   const [projects, setProjects] = useState<Project[]>([]);
-  const [currentProject, setCurrentProject] = useState<Project | null>(null);
+  // El proyecto activo vive en useProjectStore (issue #31): así el chat, el
+  // Wisdom Center y esta vista comparten contexto, y sobrevive a desmontar la
+  // vista o a cerrar la aplicación. Aquí sólo se guarda el id; el view-model se
+  // deriva más abajo del catálogo y del overlay.
+  const activeProjectId = useProjectStore(s => s.currentProjectId);
+  const selectProjectGlobal = useProjectStore(s => s.selectProject);
+  const clearProjectGlobal = useProjectStore(s => s.clearProject);
   // Lazy-initialized from localStorage so there's no load/save race on mount
   // (a load-then-save effect pair would briefly overwrite storage with the
   // initial empty state before the async load's setState landed).
@@ -152,6 +159,18 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     };
   }, [projectAssets]);
 
+  // Derivado, no duplicado: el catálogo aporta la identidad y el overlay las
+  // redes y cálculos. Antes se mantenía una copia en estado local que había que
+  // sincronizar a mano en cada cambio del overlay, y esa copia se perdía al
+  // desmontar la vista.
+  const currentProject = useMemo<Project | null>(() => {
+    if (!activeProjectId) return null;
+    const base = projects.find(p => p.id === activeProjectId);
+    if (!base) return null;
+    const assets = projectAssets[activeProjectId] || { networks: [], calculations: [] };
+    return { ...base, networks: assets.networks, calculations: assets.calculations };
+  }, [activeProjectId, projects, projectAssets]);
+
   const refreshProjects = useCallback(async () => {
     try {
       const list = await hydraulicService.listProjects();
@@ -178,15 +197,15 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       });
       const newProject = toViewModel(created);
       setProjects(prev => [newProject, ...prev]);
-      setCurrentProject(newProject);
+      await selectProjectGlobal(created.id);
     } catch (e) {
       logger.error('Failed to create project:', e);
     }
   }, [toViewModel]);
 
   const handleSelectProject = useCallback((project: Project) => {
-    setCurrentProject(project);
-  }, []);
+    selectProjectGlobal(project.id);
+  }, [selectProjectGlobal]);
 
   const handleDeleteProject = useCallback(async (projectId: string) => {
     try {
@@ -197,8 +216,8 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
         delete next[projectId];
         return next;
       });
-      if (currentProject?.id === projectId) {
-        setCurrentProject(null);
+      if (activeProjectId === projectId) {
+        clearProjectGlobal();
       }
     } catch (e) {
       logger.error('Failed to delete project:', e);
@@ -222,12 +241,6 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       const existing = prev[currentProject.id] || { networks: [], calculations: [] };
       return { ...prev, [currentProject.id]: { ...existing, networks: [...existing.networks, networkAsset] } };
     });
-
-    setCurrentProject(prev => prev ? {
-      ...prev,
-      networks: [...prev.networks, networkAsset],
-      lastModified: new Date().toISOString()
-    } : null);
   }, [currentProject]);
 
   const handleSaveCalculationToProject = useCallback((name: string, networkId: string, results: any) => {
@@ -246,12 +259,6 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
       const existing = prev[currentProject.id] || { networks: [], calculations: [] };
       return { ...prev, [currentProject.id]: { ...existing, calculations: [...existing.calculations, calculation] } };
     });
-
-    setCurrentProject(prev => prev ? {
-      ...prev,
-      calculations: [...prev.calculations, calculation],
-      lastModified: new Date().toISOString()
-    } : null);
   }, [currentProject]);
 
   // Core state
@@ -742,7 +749,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setCurrentProject(null)}
+                onClick={() => clearProjectGlobal()}
                 className="text-slate-400 hover:text-white"
               >
                 <ChevronDown className="h-4 w-4 mr-2 rotate-90" />

--- a/src/components/project/MigracionAvisoDialog.tsx
+++ b/src/components/project/MigracionAvisoDialog.tsx
@@ -1,0 +1,122 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { Database, AlertTriangle } from 'lucide-react'
+import type { InformeMigracion } from '@/services/migration/migrateProjectAssets'
+import { CLAVE_OVERLAY } from '@/services/migration/migrateProjectAssets'
+import { cn } from '@/utils/cn'
+
+/**
+ * Resumen de la migración del almacenamiento local a la base de datos (#31).
+ *
+ * Se informa a propósito en lugar de migrar en silencio: el usuario tiene que
+ * poder saber qué se movió y, sobre todo, qué quedó a medias. El texto va en
+ * castellano y sin pasar por i18next porque es un aviso puntual de una unica
+ * version: internacionalizarlo obligaria a mantener tres traducciones de algo que
+ * deja de mostrarse en cuanto se ejecuta.
+ */
+export function MigracionAvisoDialog({
+  informe,
+  onClose
+}: {
+  informe: InformeMigracion | null
+  onClose: () => void
+}) {
+  if (!informe) return null
+
+  const hayProblemas = informe.redesIncompletas.length > 0 || informe.redesFallidas.length > 0
+
+  return (
+    <Dialog.Root open onOpenChange={abierto => { if (!abierto) onClose() }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 animate-in fade-in-0" />
+        <Dialog.Content
+          className={cn(
+            'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+            'w-[480px] max-w-[92vw] max-h-[85vh] overflow-y-auto',
+            'bg-card rounded-lg shadow-lg border border-border',
+            'animate-in fade-in-0 zoom-in-95 duration-200'
+          )}
+        >
+          <div className="p-6">
+            <div className="flex gap-3">
+              <Database className="h-5 w-5 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <Dialog.Title className="text-base font-semibold text-foreground">
+                  Tus redes y cálculos se han guardado en el proyecto
+                </Dialog.Title>
+                <Dialog.Description className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  Hasta ahora vivían solo en este equipo. Ahora forman parte del proyecto, así que el
+                  chat y el resto de la aplicación pueden usarlos.
+                </Dialog.Description>
+              </div>
+            </div>
+
+            <div className="mt-4 flex gap-8 rounded-lg border border-border bg-muted/30 p-4">
+              <div>
+                <div className="text-xs text-muted-foreground">Redes</div>
+                <div className="font-mono text-lg font-semibold text-foreground">{informe.redesMigradas}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Cálculos</div>
+                <div className="font-mono text-lg font-semibold text-foreground">{informe.calculosMigrados}</div>
+              </div>
+            </div>
+
+            {informe.redesIncompletas.length > 0 && (
+              <div className="mt-4 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3 text-xs text-yellow-700 dark:text-yellow-400">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  <div>
+                    <p className="font-medium">
+                      {informe.redesIncompletas.length === 1
+                        ? 'Una red se guardó sin su archivo .inp'
+                        : `${informe.redesIncompletas.length} redes se guardaron sin su archivo .inp`}
+                    </p>
+                    <p className="mt-1 leading-relaxed">
+                      El archivo original ya no está donde estaba, así que puedes verlas pero no
+                      simularlas. Vuelve a importarlas cuando quieras recuperarlas:
+                    </p>
+                    <ul className="mt-2 list-disc space-y-0.5 pl-4 font-mono">
+                      {informe.redesIncompletas.map(r => (
+                        <li key={`${r.proyecto}-${r.red}`}>{r.red}{r.ruta ? ` — ${r.ruta}` : ''}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {informe.redesFallidas.length > 0 && (
+              <div className="mt-3 rounded-lg border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-700 dark:text-red-400">
+                <p className="font-medium">
+                  {informe.redesFallidas.length === 1 ? 'Una red no se pudo guardar' : `${informe.redesFallidas.length} redes no se pudieron guardar`}
+                </p>
+                <ul className="mt-2 list-disc space-y-0.5 pl-4">
+                  {informe.redesFallidas.map(r => (
+                    <li key={`${r.proyecto}-${r.red}`}><span className="font-mono">{r.red}</span>: {r.error}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {hayProblemas && (
+              <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
+                Nada se ha borrado: los datos originales siguen guardados en este equipo, bajo la
+                clave <span className="font-mono">{CLAVE_OVERLAY}</span>.
+              </p>
+            )}
+
+            <button
+              onClick={onClose}
+              className={cn(
+                'mt-5 w-full rounded-md px-4 py-2 text-sm font-medium',
+                'bg-primary text-primary-foreground hover:bg-primary/90'
+              )}
+            >
+              Entendido
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/components/project/MigracionAvisoDialog.tsx
+++ b/src/components/project/MigracionAvisoDialog.tsx
@@ -61,6 +61,14 @@ export function MigracionAvisoDialog({
               </div>
             </div>
 
+            {informe.redesYaExistentes.length > 0 && (
+              <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+                {informe.redesYaExistentes.length === 1
+                  ? 'Una red estaba repetida y ya se encontraba guardada, así que no se ha duplicado.'
+                  : `${informe.redesYaExistentes.length} redes estaban repetidas y ya se encontraban guardadas, así que no se han duplicado.`}
+              </p>
+            )}
+
             {informe.redesIncompletas.length > 0 && (
               <div className="mt-4 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3 text-xs text-yellow-700 dark:text-yellow-400">
                 <div className="flex items-start gap-2">

--- a/src/components/project/ProjectMismatchDialog.tsx
+++ b/src/components/project/ProjectMismatchDialog.tsx
@@ -1,0 +1,77 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { useTranslation } from 'react-i18next'
+import { FolderOpen, AlertTriangle } from 'lucide-react'
+import { useProjectStore } from '@/stores/projectStore'
+import { cn } from '@/utils/cn'
+
+/**
+ * Se monta una sola vez en la raíz. Aparece cuando se abre una conversación que
+ * pertenece a un proyecto distinto del activo (#31).
+ *
+ * No se resuelve en silencio a propósito: conmutar por su cuenta cambiaría el
+ * contexto de la red y del Wisdom Center sin que el usuario lo pida, y no
+ * conmutar dejaría al LLM respondiendo con el contexto de otro proyecto. Las dos
+ * opciones son defendibles, así que decide quien está delante.
+ */
+export function ProjectMismatchDialog() {
+  const { t } = useTranslation()
+  const mismatch = useProjectStore(s => s.projectMismatch)
+  const resolve = useProjectStore(s => s.resolveProjectMismatch)
+
+  return (
+    <Dialog.Root open={!!mismatch} onOpenChange={abierto => { if (!abierto) resolve('keep') }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 animate-in fade-in-0" />
+        <Dialog.Content
+          className={cn(
+            'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+            'w-[440px] max-w-[92vw] bg-card rounded-lg shadow-lg border border-border',
+            'animate-in fade-in-0 zoom-in-95 duration-200'
+          )}
+        >
+          <div className="p-6">
+            <div className="flex gap-3">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-yellow-500" />
+              <div className="min-w-0">
+                <Dialog.Title className="text-base font-semibold text-foreground">
+                  {t('project.mismatch.title')}
+                </Dialog.Title>
+                <Dialog.Description className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {/* Sin proyecto activo el texto normal dejaría un hueco vacío. */}
+                  {t(mismatch?.activeProjectName ? 'project.mismatch.body' : 'project.mismatch.bodyNoActive', {
+                    conversationProject: mismatch?.conversationProjectName ?? '',
+                    activeProject: mismatch?.activeProjectName ?? ''
+                  })}
+                </Dialog.Description>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-2">
+              <button
+                onClick={() => resolve('switch')}
+                className={cn(
+                  'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2',
+                  'bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90'
+                )}
+              >
+                <FolderOpen className="h-4 w-4" />
+                {t('project.mismatch.switch', { project: mismatch?.conversationProjectName ?? '' })}
+              </button>
+              {mismatch?.activeProjectName && (
+                <button
+                  onClick={() => resolve('keep')}
+                  className={cn(
+                    'rounded-md border border-border px-4 py-2 text-sm font-medium',
+                    'text-foreground hover:bg-muted'
+                  )}
+                >
+                  {t('project.mismatch.keep', { project: mismatch.activeProjectName })}
+                </button>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -208,5 +208,14 @@
       "title": "Eines d'Enginyeria",
       "desc": "Accedeix a calculadores hidràuliques integrades i anàlisi de xarxes amb WNTR de forma directa."
     }
+  },
+  "project": {
+    "mismatch": {
+      "title": "Aquesta conversa pertany a un altre projecte",
+      "body": "La conversa que has obert pertany a «{{conversationProject}}», però el teu projecte actiu és «{{activeProject}}». Si no el canvies, l'assistent respondrà amb el context de «{{activeProject}}».",
+      "switch": "Canviar a «{{project}}»",
+      "keep": "Continuar a «{{project}}»",
+      "bodyNoActive": "La conversa que has obert pertany a «{{conversationProject}}» i ara mateix no hi ha cap projecte actiu."
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -208,5 +208,14 @@
       "title": "Engineering Tools",
       "desc": "Access integrated hydraulic calculators and network analysis with WNTR directly."
     }
+  },
+  "project": {
+    "mismatch": {
+      "title": "This conversation belongs to another project",
+      "body": "The conversation you opened belongs to “{{conversationProject}}”, but your active project is “{{activeProject}}”. If you don't switch, the assistant will answer using the context of “{{activeProject}}”.",
+      "switch": "Switch to “{{project}}”",
+      "keep": "Stay in “{{project}}”",
+      "bodyNoActive": "The conversation you opened belongs to “{{conversationProject}}” and there is no active project right now."
+    }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -208,5 +208,14 @@
       "title": "Herramientas de Ingeniería",
       "desc": "Accede a calculadoras hidráulicas integradas y análisis de redes con WNTR de forma directa."
     }
+  },
+  "project": {
+    "mismatch": {
+      "title": "Esta conversación pertenece a otro proyecto",
+      "body": "La conversación que has abierto pertenece a «{{conversationProject}}», pero tu proyecto activo es «{{activeProject}}». Si no cambias, el asistente responderá con el contexto de «{{activeProject}}».",
+      "switch": "Cambiar a «{{project}}»",
+      "keep": "Seguir en «{{project}}»",
+      "bodyNoActive": "La conversación que has abierto pertenece a «{{conversationProject}}» y ahora mismo no hay ningún proyecto activo."
+    }
   }
 }

--- a/src/services/migration/migrateProjectAssets.test.ts
+++ b/src/services/migration/migrateProjectAssets.test.ts
@@ -84,6 +84,24 @@ describe('migrateProjectAssets', () => {
     ])
   })
 
+  // El overlay heredado acumulaba copias de la misma red, asi que aqui hay muchas:
+  // contarlas como fallos diria "14 redes no se pudieron guardar" cuando 13 ya
+  // estaban dentro.
+  it('cuenta las redes ya existentes aparte, no como fallos', async () => {
+    save
+      .mockResolvedValueOnce({ success: true, data: { id: 'n1', hasFileContent: true } })
+      .mockResolvedValueOnce({ success: false, duplicate: true, error: 'ya existe' })
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      p1: { networks: [red('A', '/r/A.inp'), red('A-copia', '/r/A.inp')] },
+    }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.redesMigradas).toBe(1)
+    expect(r.redesYaExistentes).toEqual([{ proyecto: 'p1', red: 'A-copia' }])
+    expect(r.redesFallidas).toEqual([])
+  })
+
   it('registra las redes que fallan sin abortar el resto', async () => {
     save
       .mockResolvedValueOnce({ success: false, error: 'nombre duplicado' })

--- a/src/services/migration/migrateProjectAssets.test.ts
+++ b/src/services/migration/migrateProjectAssets.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { migrateProjectAssets, CLAVE_OVERLAY, CLAVE_MARCADOR } from './migrateProjectAssets'
+
+const save = vi.fn()
+const saveCalculation = vi.fn()
+const getProject = vi.fn()
+
+const red = (name: string, filePath?: string) => ({
+  id: `net_${name}`, name, filePath,
+  uploadDate: '2026-07-01T00:00:00.000Z', nodeCount: 5, linkCount: 6, data: { name, summary: {} },
+})
+
+const calculo = (name: string) => ({
+  id: `calc_${name}`, name, date: '2026-07-01T00:00:00.000Z',
+  status: 'completed', networkId: 'net_x', results: { ok: true },
+})
+
+describe('migrateProjectAssets', () => {
+  beforeEach(() => {
+    save.mockReset(); saveCalculation.mockReset(); getProject.mockReset()
+    localStorage.clear()
+    Object.defineProperty(window, 'electronAPI', {
+      value: { networkRepository: { save }, hydraulic: { saveCalculation, getProject } },
+      writable: true,
+    })
+    getProject.mockResolvedValue({ success: true, data: { id: 'p1' } })
+    save.mockResolvedValue({ success: true, data: { id: 'n1', hasFileContent: true } })
+    saveCalculation.mockResolvedValue({ success: true })
+  })
+
+  it('no hace nada si no hay overlay', async () => {
+    const r = await migrateProjectAssets()
+    expect(r.ejecutada).toBe(false)
+    expect(r.motivo).toBe('sin-datos')
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('migra redes y cálculos de cada proyecto', async () => {
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      p1: { networks: [red('A', '/ruta/A.inp'), red('B', '/ruta/B.inp')], calculations: [calculo('c1')] },
+    }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.ejecutada).toBe(true)
+    expect(r.redesMigradas).toBe(2)
+    expect(r.calculosMigrados).toBe(1)
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'p1', filePath: '/ruta/A.inp', filename: 'A.inp', allowMissingFile: true,
+    }))
+  })
+
+  // La regla que no se negocia: los datos originales se quedan donde están.
+  it('NUNCA borra la clave original', async () => {
+    const contenido = JSON.stringify({ p1: { networks: [red('A', '/ruta/A.inp')] } })
+    localStorage.setItem(CLAVE_OVERLAY, contenido)
+
+    await migrateProjectAssets()
+
+    expect(localStorage.getItem(CLAVE_OVERLAY)).toBe(contenido)
+  })
+
+  it('no vuelve a migrar si ya existe el marcador', async () => {
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({ p1: { networks: [red('A', '/r/A.inp')] } }))
+    localStorage.setItem(CLAVE_MARCADOR, JSON.stringify({ at: 'antes' }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.motivo).toBe('ya-migrada')
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('marca como incompleta la red cuyo .inp ya no existe, pero la migra', async () => {
+    save.mockResolvedValue({ success: true, data: { id: 'n1', hasFileContent: false } })
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      p1: { networks: [red('Perdida', '/ruta/borrada.inp')] },
+    }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.redesMigradas).toBe(1)
+    expect(r.redesIncompletas).toEqual([
+      { proyecto: 'p1', red: 'Perdida', ruta: '/ruta/borrada.inp' },
+    ])
+  })
+
+  it('registra las redes que fallan sin abortar el resto', async () => {
+    save
+      .mockResolvedValueOnce({ success: false, error: 'nombre duplicado' })
+      .mockResolvedValueOnce({ success: true, data: { id: 'n2', hasFileContent: true } })
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      p1: { networks: [red('A', '/r/A.inp'), red('B', '/r/B.inp')] },
+    }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.redesMigradas).toBe(1)
+    expect(r.redesFallidas).toEqual([{ proyecto: 'p1', red: 'A', error: 'nombre duplicado' }])
+  })
+
+  // Un proyecto borrado no puede recibir sus redes: la clave ajena lo rechazaría.
+  it('salta los proyectos que ya no existen y deja sus datos en el respaldo', async () => {
+    getProject.mockImplementation((id: string) =>
+      Promise.resolve(id === 'vivo' ? { success: true, data: { id } } : { success: false }))
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      vivo: { networks: [red('A', '/r/A.inp')] },
+      borrado: { networks: [red('B', '/r/B.inp')] },
+    }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.redesMigradas).toBe(1)
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem(CLAVE_OVERLAY)).toContain('borrado')
+  })
+
+  it('marca aunque el overlay esté vacío, para no comprobarlo en cada arranque', async () => {
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({ p1: { networks: [], calculations: [] } }))
+
+    const r = await migrateProjectAssets()
+
+    expect(r.ejecutada).toBe(false)
+    expect(localStorage.getItem(CLAVE_MARCADOR)).toBeTruthy()
+  })
+
+  it('no revienta ni marca si el overlay no es JSON válido', async () => {
+    localStorage.setItem(CLAVE_OVERLAY, '{esto no es json')
+
+    const r = await migrateProjectAssets()
+
+    expect(r.ejecutada).toBe(false)
+    expect(localStorage.getItem(CLAVE_MARCADOR)).toBeNull()
+    expect(localStorage.getItem(CLAVE_OVERLAY)).toBe('{esto no es json')
+  })
+
+  // Reintentar en cada arranque duplicaría lo ya migrado.
+  it('marca aunque haya fallos, dejando el detalle en el informe', async () => {
+    save.mockResolvedValue({ success: false, error: 'boom' })
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({ p1: { networks: [red('A', '/r/A.inp')] } }))
+
+    await migrateProjectAssets()
+
+    const marcador = JSON.parse(localStorage.getItem(CLAVE_MARCADOR) || '{}')
+    expect(marcador.informe.redesFallidas).toHaveLength(1)
+  })
+})

--- a/src/services/migration/migrateProjectAssets.test.ts
+++ b/src/services/migration/migrateProjectAssets.test.ts
@@ -123,6 +123,21 @@ describe('migrateProjectAssets', () => {
     expect(localStorage.getItem(CLAVE_MARCADOR)).toBeTruthy()
   })
 
+  // React.StrictMode invoca los efectos dos veces en desarrollo: sin guarda, dos
+  // llamadas simultaneas duplicaban el volcado, porque el marcador solo se escribe
+  // al terminar.
+  it('dos llamadas simultáneas comparten una sola ejecución', async () => {
+    localStorage.setItem(CLAVE_OVERLAY, JSON.stringify({
+      p1: { networks: [red('A', '/r/A.inp'), red('B', '/r/B.inp')] },
+    }))
+
+    const [r1, r2] = await Promise.all([migrateProjectAssets(), migrateProjectAssets()])
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(r1).toBe(r2)
+    expect(r1.redesMigradas).toBe(2)
+  })
+
   it('no revienta ni marca si el overlay no es JSON válido', async () => {
     localStorage.setItem(CLAVE_OVERLAY, '{esto no es json')
 

--- a/src/services/migration/migrateProjectAssets.ts
+++ b/src/services/migration/migrateProjectAssets.ts
@@ -1,0 +1,172 @@
+import { logger } from '@/utils/logger'
+
+/**
+ * Migración del overlay heredado de localStorage a la base de datos (#31).
+ *
+ * Hasta la v1.5.1 las redes y los cálculos de cada proyecto vivían en la clave
+ * `wntr_project_assets` del navegador, no en las tablas HydraulicNetwork y
+ * HydraulicCalculation. Este módulo los vuelca una sola vez.
+ *
+ * Tres reglas que no se negocian, porque aquí un error se ve como «he perdido mis
+ * redes»:
+ *
+ * 1. **La clave original no se borra nunca.** El control de si ya se migró vive en
+ *    una clave marcadora aparte. Si algo sale mal, los datos siguen donde estaban.
+ * 2. **Una red sin su .inp no se descarta.** El overlay guarda la ruta del fichero,
+ *    no su contenido; si el usuario lo movió o lo borró, la red se guarda con sus
+ *    datos parseados y queda marcada como incompleta: se ve en el mapa pero no se
+ *    puede simular. Perder la red sería peor que no poder simularla.
+ * 3. **El resultado se informa.** Migrar en silencio impide saber qué quedó a medias.
+ */
+
+export const CLAVE_OVERLAY = 'wntr_project_assets'
+export const CLAVE_MARCADOR = 'wntr_project_assets_migrated'
+
+interface RedHeredada {
+  id: string
+  name: string
+  filePath?: string
+  uploadDate: string
+  nodeCount: number
+  linkCount: number
+  data: any
+}
+
+interface CalculoHeredado {
+  id: string
+  name: string
+  date: string
+  status: string
+  networkId: string
+  results?: any
+}
+
+type Overlay = Record<string, { networks?: RedHeredada[]; calculations?: CalculoHeredado[] }>
+
+export interface InformeMigracion {
+  ejecutada: boolean
+  /** Motivo por el que no se ejecutó, si aplica. */
+  motivo?: 'sin-datos' | 'ya-migrada'
+  redesMigradas: number
+  redesIncompletas: { proyecto: string; red: string; ruta?: string }[]
+  redesFallidas: { proyecto: string; red: string; error: string }[]
+  calculosMigrados: number
+  calculosFallidos: number
+}
+
+const informeVacio = (motivo: InformeMigracion['motivo']): InformeMigracion => ({
+  ejecutada: false,
+  motivo,
+  redesMigradas: 0,
+  redesIncompletas: [],
+  redesFallidas: [],
+  calculosMigrados: 0,
+  calculosFallidos: 0
+})
+
+/** Un proyecto que ya no existe no puede recibir sus redes: la FK lo rechazaría. */
+async function proyectosExistentes(ids: string[]): Promise<Set<string>> {
+  const vivos = new Set<string>()
+  for (const id of ids) {
+    try {
+      const r = await window.electronAPI.hydraulic.getProject(id)
+      if (r?.success && r.data) vivos.add(id)
+    } catch {
+      // Se trata como inexistente: mejor dejarlo en el respaldo que fallar.
+    }
+  }
+  return vivos
+}
+
+export async function migrateProjectAssets(): Promise<InformeMigracion> {
+  if (localStorage.getItem(CLAVE_MARCADOR)) return informeVacio('ya-migrada')
+
+  const bruto = localStorage.getItem(CLAVE_OVERLAY)
+  if (!bruto) return informeVacio('sin-datos')
+
+  let overlay: Overlay
+  try {
+    overlay = JSON.parse(bruto)
+  } catch (error) {
+    logger.error('El overlay heredado no es JSON válido; no se migra nada:', error)
+    return informeVacio('sin-datos')
+  }
+
+  const proyectos = Object.keys(overlay)
+  const tieneAlgo = proyectos.some(
+    p => (overlay[p].networks?.length ?? 0) > 0 || (overlay[p].calculations?.length ?? 0) > 0
+  )
+  if (!tieneAlgo) {
+    // Nada que mover, pero se marca para no volver a comprobarlo en cada arranque.
+    localStorage.setItem(CLAVE_MARCADOR, JSON.stringify({ at: new Date().toISOString(), vacio: true }))
+    return informeVacio('sin-datos')
+  }
+
+  const informe: InformeMigracion = { ...informeVacio(undefined), ejecutada: true, motivo: undefined }
+  const vivos = await proyectosExistentes(proyectos)
+
+  for (const projectId of proyectos) {
+    if (!vivos.has(projectId)) {
+      logger.warn('Proyecto inexistente, sus datos se quedan en el respaldo:', projectId)
+      continue
+    }
+
+    for (const red of overlay[projectId].networks ?? []) {
+      try {
+        const res = await window.electronAPI.networkRepository.save({
+          projectId,
+          networkData: red.data,
+          filePath: red.filePath,
+          filename: red.filePath?.split(/[\\/]/).pop() || `${red.name}.inp`,
+          description: 'Migrada desde el almacenamiento local de una versión anterior',
+          allowMissingFile: true
+        })
+
+        if (!res?.success) {
+          informe.redesFallidas.push({ proyecto: projectId, red: red.name, error: res?.error || 'desconocido' })
+          continue
+        }
+
+        informe.redesMigradas++
+        // `hasFileContent` viene del servidor: es la verdad sobre si el .inp llegó.
+        if (res.data && res.data.hasFileContent === false) {
+          informe.redesIncompletas.push({ proyecto: projectId, red: red.name, ruta: red.filePath })
+        }
+      } catch (error) {
+        informe.redesFallidas.push({
+          proyecto: projectId,
+          red: red.name,
+          error: error instanceof Error ? error.message : 'desconocido'
+        })
+      }
+    }
+
+    for (const calc of overlay[projectId].calculations ?? []) {
+      try {
+        const res = await window.electronAPI.hydraulic.saveCalculation(projectId, {
+          type: 'migrated',
+          name: calc.name,
+          inputs: {},
+          results: calc.results ?? {},
+          formulas: [],
+          notes: `Migrado del almacenamiento local (${calc.date}, estado ${calc.status})`
+        })
+        if (res?.success) informe.calculosMigrados++
+        else informe.calculosFallidos++
+      } catch {
+        informe.calculosFallidos++
+      }
+    }
+  }
+
+  // El marcador se escribe aunque haya fallos: reintentar en cada arranque
+  // duplicaría lo ya migrado. Lo que falló queda listado en el informe, y el
+  // overlay original sigue intacto para recuperarlo a mano.
+  localStorage.setItem(
+    CLAVE_MARCADOR,
+    JSON.stringify({ at: new Date().toISOString(), informe })
+  )
+
+  logger.info('Migración del overlay heredado terminada:', informe)
+  return informe
+}

--- a/src/services/migration/migrateProjectAssets.ts
+++ b/src/services/migration/migrateProjectAssets.ts
@@ -48,6 +48,13 @@ export interface InformeMigracion {
   /** Motivo por el que no se ejecutó, si aplica. */
   motivo?: 'sin-datos' | 'ya-migrada'
   redesMigradas: number
+  /**
+   * Redes que ya estaban en la base de datos. No son un fallo: el overlay
+   * heredado acumulaba copias de la misma red (el codigo antiguo la reañadia en
+   * cada carga), asi que aqui hay muchas y contarlas como errores alarmaria sin
+   * motivo.
+   */
+  redesYaExistentes: { proyecto: string; red: string }[]
   redesIncompletas: { proyecto: string; red: string; ruta?: string }[]
   redesFallidas: { proyecto: string; red: string; error: string }[]
   calculosMigrados: number
@@ -58,6 +65,7 @@ const informeVacio = (motivo: InformeMigracion['motivo']): InformeMigracion => (
   ejecutada: false,
   motivo,
   redesMigradas: 0,
+  redesYaExistentes: [],
   redesIncompletas: [],
   redesFallidas: [],
   calculosMigrados: 0,
@@ -137,7 +145,8 @@ async function ejecutarMigracion(): Promise<InformeMigracion> {
         })
 
         if (!res?.success) {
-          informe.redesFallidas.push({ proyecto: projectId, red: red.name, error: res?.error || 'desconocido' })
+          if (res?.duplicate) informe.redesYaExistentes.push({ proyecto: projectId, red: red.name })
+          else informe.redesFallidas.push({ proyecto: projectId, red: red.name, error: res?.error || 'desconocido' })
           continue
         }
 

--- a/src/services/migration/migrateProjectAssets.ts
+++ b/src/services/migration/migrateProjectAssets.ts
@@ -78,7 +78,21 @@ async function proyectosExistentes(ids: string[]): Promise<Set<string>> {
   return vivos
 }
 
-export async function migrateProjectAssets(): Promise<InformeMigracion> {
+/**
+ * Guarda contra ejecuciones concurrentes. El marcador solo se escribe al final, asi
+ * que dos llamadas simultaneas verian ambas "sin migrar" y duplicarian el volcado.
+ * Pasa de verdad: React.StrictMode invoca los efectos dos veces en desarrollo.
+ */
+let enCurso: Promise<InformeMigracion> | null = null
+
+export function migrateProjectAssets(): Promise<InformeMigracion> {
+  if (!enCurso) {
+    enCurso = ejecutarMigracion().finally(() => { enCurso = null })
+  }
+  return enCurso
+}
+
+async function ejecutarMigracion(): Promise<InformeMigracion> {
   if (localStorage.getItem(CLAVE_MARCADOR)) return informeVacio('ya-migrada')
 
   const bruto = localStorage.getItem(CLAVE_OVERLAY)

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -121,6 +121,17 @@ export const useChatStore = create<ChatState>()(
 
       setActiveConversation: (id) => {
         set({ activeConversationId: id })
+
+        // Aviso de discrepancia con el proyecto activo (#31). Se hace aquí y no
+        // en los componentes porque hay cinco sitios que abren conversaciones;
+        // repartir la comprobación entre ellos es lo que produjo el problema.
+        // El import es dinámico para no crear dependencia circular entre stores.
+        const projectId = get().conversations.find(c => c.id === id)?.projectId
+        import('./projectStore')
+          .then(({ useProjectStore }) => {
+            useProjectStore.getState().notifyConversationOpened(id, projectId)
+          })
+          .catch(error => logger.error('No se pudo comprobar el proyecto de la conversación:', error))
       },
 
       addMessageToConversation: async (conversationId, messageData) => {

--- a/src/stores/projectStore.test.ts
+++ b/src/stores/projectStore.test.ts
@@ -99,6 +99,124 @@ describe('projectStore — proyecto activo global', () => {
     })
   })
 
+  // Reconciliación al abrir una conversación de otro proyecto. Vive en el store
+  // porque hay cinco sitios en la interfaz que abren conversaciones.
+  describe('notifyConversationOpened', () => {
+    beforeEach(() => {
+      useProjectStore.setState({
+        currentProjectId: 'p1',
+        currentProject: proyecto('p1') as never,
+        projects: [proyecto('p1'), proyecto('p2')] as never,
+        projectMismatch: null,
+      })
+    })
+
+    it('avisa cuando la conversación es de otro proyecto', async () => {
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+
+      const m = useProjectStore.getState().projectMismatch
+      expect(m).toMatchObject({
+        conversationId: 'c1',
+        conversationProjectId: 'p2',
+        conversationProjectName: 'Proyecto p2',
+        activeProjectName: 'Proyecto p1',
+      })
+    })
+
+    it('no avisa si la conversación es del proyecto activo', async () => {
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p1')
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+    })
+
+    // Una conversación general se puede leer desde cualquier proyecto: no hay
+    // nada que reconciliar y preguntar sería puro ruido.
+    it('no avisa si la conversación no tiene proyecto', async () => {
+      await useProjectStore.getState().notifyConversationOpened('c1', undefined)
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+    })
+
+    it('limpia un aviso previo al abrir una conversación coherente', async () => {
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+      expect(useProjectStore.getState().projectMismatch).not.toBeNull()
+
+      await useProjectStore.getState().notifyConversationOpened('c2', 'p1')
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+    })
+
+    // La app real nunca puebla `projects` del store: la vista WNTR usa su propio
+    // catálogo. Sembrarlo en los tests ocultó que el nombre se resolvía mal.
+    it('resuelve el nombre por base de datos cuando el catálogo del store está vacío', async () => {
+      useProjectStore.setState({ projects: [] })
+      getProject.mockResolvedValue({ success: true, data: proyecto('p2') })
+
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+
+      expect(getProject).toHaveBeenCalledWith('p2')
+      const m = useProjectStore.getState().projectMismatch
+      expect(m?.conversationProjectName).toBe('Proyecto p2')
+      expect(m?.activeProjectName).toBe('Proyecto p1')
+    })
+
+    it('muestra el id, no un nombre equivocado, si no se puede resolver', async () => {
+      useProjectStore.setState({ projects: [] })
+      getProject.mockRejectedValue(new Error('sin base de datos'))
+
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+
+      const m = useProjectStore.getState().projectMismatch
+      expect(m?.conversationProjectName).toBe('p2')
+      expect(m?.activeProjectName).toBe('Proyecto p1')
+    })
+
+    it('avisa también sin proyecto activo, dejando vacío el nombre del activo', async () => {
+      useProjectStore.setState({ currentProjectId: null, currentProject: null })
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+
+      expect(useProjectStore.getState().projectMismatch?.activeProjectName).toBe('')
+    })
+  })
+
+  describe('resolveProjectMismatch', () => {
+    beforeEach(async () => {
+      useProjectStore.setState({
+        currentProjectId: 'p1',
+        currentProject: proyecto('p1') as never,
+        projects: [proyecto('p1'), proyecto('p2')] as never,
+        projectMismatch: null,
+      })
+      await useProjectStore.getState().notifyConversationOpened('c1', 'p2')
+    })
+
+    it('«switch» conmuta al proyecto de la conversación', async () => {
+      getProject.mockResolvedValue({ success: true, data: proyecto('p2') })
+
+      await useProjectStore.getState().resolveProjectMismatch('switch')
+      expect(useProjectStore.getState().currentProjectId).toBe('p2')
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+    })
+
+    it('«keep» mantiene el proyecto activo y no consulta la base de datos', async () => {
+      await useProjectStore.getState().resolveProjectMismatch('keep')
+
+      expect(useProjectStore.getState().currentProjectId).toBe('p1')
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+      expect(getProject).not.toHaveBeenCalled()
+    })
+
+    // Si el aviso siguiera visible mientras selectProject carga, parecería que
+    // el clic no hizo nada.
+    it('quita el aviso antes de esperar la carga', async () => {
+      let resolver: (v: unknown) => void = () => {}
+      getProject.mockReturnValue(new Promise(r => { resolver = r }))
+
+      const pendiente = useProjectStore.getState().resolveProjectMismatch('switch')
+      expect(useProjectStore.getState().projectMismatch).toBeNull()
+
+      resolver({ success: true, data: proyecto('p2') })
+      await pendiente
+    })
+  })
+
   it('borrar el proyecto activo olvida el id, para no restaurar un borrado al reabrir', async () => {
     getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
     await useProjectStore.getState().selectProject('p1')

--- a/src/stores/projectStore.test.ts
+++ b/src/stores/projectStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useProjectStore } from './projectStore'
+
+// El store llama a window.electronAPI.hydraulic.* y sincroniza con wntrStore.
+const getProject = vi.fn()
+const deleteProject = vi.fn()
+
+vi.mock('./wntrStore', () => ({
+  useWNTRStore: {
+    getState: () => ({
+      syncWithProject: vi.fn(),
+      loadNetworkFromProject: vi.fn().mockResolvedValue(true),
+    }),
+  },
+}))
+
+const proyecto = (id: string) => ({
+  id, name: `Proyecto ${id}`, type: 'analysis', status: 'design',
+  location: {}, regulations: [], calculations: [], documents: [], team: [],
+  timeline: {}, createdAt: new Date(), updatedAt: new Date(),
+})
+
+describe('projectStore — proyecto activo global', () => {
+  beforeEach(() => {
+    getProject.mockReset()
+    deleteProject.mockReset()
+    Object.defineProperty(window, 'electronAPI', {
+      value: { hydraulic: { getProject, deleteProject } },
+      writable: true,
+    })
+    useProjectStore.setState({ currentProject: null, currentProjectId: null, error: null })
+    localStorage.clear()
+  })
+
+  it('selectProject fija el proyecto y su id', async () => {
+    getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+
+    expect(await useProjectStore.getState().selectProject('p1')).toBe(true)
+    expect(useProjectStore.getState().currentProjectId).toBe('p1')
+    expect(useProjectStore.getState().currentProject?.id).toBe('p1')
+  })
+
+  it('no fija el id si la carga falla', async () => {
+    getProject.mockResolvedValue({ success: false, error: 'no existe' })
+
+    expect(await useProjectStore.getState().selectProject('fantasma')).toBe(false)
+    expect(useProjectStore.getState().currentProjectId).toBeNull()
+    expect(useProjectStore.getState().error).toBe('no existe')
+  })
+
+  it('clearProject olvida también el id persistido', async () => {
+    getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+    await useProjectStore.getState().selectProject('p1')
+
+    useProjectStore.getState().clearProject()
+    expect(useProjectStore.getState().currentProjectId).toBeNull()
+    expect(useProjectStore.getState().currentProject).toBeNull()
+  })
+
+  // Sólo se guarda el id: guardar el objeto serviría datos obsoletos si el
+  // proyecto cambió de nombre o de contenido entre sesiones.
+  it('persiste únicamente el id del proyecto activo', async () => {
+    getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+    await useProjectStore.getState().selectProject('p1')
+
+    const guardado = JSON.parse(localStorage.getItem('project-store') || '{}')
+    expect(guardado.state).toEqual({ currentProjectId: 'p1' })
+  })
+
+  describe('restoreActiveProject', () => {
+    it('rehidrata el proyecto desde la base de datos a partir del id', async () => {
+      useProjectStore.setState({ currentProjectId: 'p1', currentProject: null })
+      getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+
+      expect(await useProjectStore.getState().restoreActiveProject()).toBe(true)
+      expect(getProject).toHaveBeenCalledWith('p1')
+      expect(useProjectStore.getState().currentProject?.name).toBe('Proyecto p1')
+    })
+
+    it('descarta el id si el proyecto ya no existe, en vez de dejarlo colgando', async () => {
+      useProjectStore.setState({ currentProjectId: 'borrado', currentProject: null })
+      getProject.mockResolvedValue({ success: false, error: 'not found' })
+
+      expect(await useProjectStore.getState().restoreActiveProject()).toBe(false)
+      expect(useProjectStore.getState().currentProjectId).toBeNull()
+      expect(useProjectStore.getState().error).toBeNull()
+    })
+
+    it('no hace nada si no hay id persistido', async () => {
+      expect(await useProjectStore.getState().restoreActiveProject()).toBe(false)
+      expect(getProject).not.toHaveBeenCalled()
+    })
+
+    it('no recarga si el proyecto ya está cargado', async () => {
+      useProjectStore.setState({ currentProjectId: 'p1', currentProject: proyecto('p1') as never })
+
+      expect(await useProjectStore.getState().restoreActiveProject()).toBe(false)
+      expect(getProject).not.toHaveBeenCalled()
+    })
+  })
+
+  it('borrar el proyecto activo olvida el id, para no restaurar un borrado al reabrir', async () => {
+    getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+    await useProjectStore.getState().selectProject('p1')
+    deleteProject.mockResolvedValue({ success: true })
+
+    await useProjectStore.getState().deleteProject('p1')
+    expect(useProjectStore.getState().currentProjectId).toBeNull()
+  })
+
+  it('borrar otro proyecto no toca el activo', async () => {
+    getProject.mockResolvedValue({ success: true, data: proyecto('p1') })
+    await useProjectStore.getState().selectProject('p1')
+    deleteProject.mockResolvedValue({ success: true })
+
+    await useProjectStore.getState().deleteProject('otro')
+    expect(useProjectStore.getState().currentProjectId).toBe('p1')
+  })
+})

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -31,6 +31,20 @@ interface ProjectState {
   currentProjectId: string | null
   projects: ProjectData[]
 
+  /**
+   * Discrepancia pendiente entre el proyecto de una conversación recién abierta
+   * y el proyecto activo. Se resuelve preguntando al usuario, no en silencio:
+   * conmutar por su cuenta cambiaría el contexto de la red y del Wisdom Center
+   * sin que lo haya pedido, y no conmutar dejaría al LLM respondiendo con el
+   * contexto de otro proyecto.
+   */
+  projectMismatch: {
+    conversationId: string
+    conversationProjectId: string
+    conversationProjectName: string
+    activeProjectName: string
+  } | null
+
   // Loading states
   isLoading: boolean
   isLoadingProjects: boolean
@@ -50,6 +64,16 @@ interface ProjectState {
    */
   restoreActiveProject: () => Promise<boolean>
 
+  /**
+   * La llama chatStore al activar una conversación. Es el único punto de
+   * detección: hay cinco sitios en la interfaz que abren conversaciones, y
+   * repartir la comprobación entre ellos es justo lo que produjo el problema
+   * que arregla este issue.
+   */
+  notifyConversationOpened: (conversationId: string, conversationProjectId?: string) => Promise<void>
+  /** 'switch' conmuta al proyecto de la conversación; 'keep' mantiene el activo. */
+  resolveProjectMismatch: (accion: 'switch' | 'keep') => Promise<void>
+
   // Cross-section synchronization
   syncAllSections: (projectId: string) => Promise<void>
 
@@ -62,6 +86,7 @@ const initialState = {
   currentProject: null,
   currentProjectId: null,
   projects: [],
+  projectMismatch: null,
   isLoading: false,
   isLoadingProjects: false,
   error: null,
@@ -226,6 +251,51 @@ export const useProjectStore = create<ProjectState>()(
           set({ currentProjectId: null, error: null })
         }
         return ok
+      },
+
+      notifyConversationOpened: async (conversationId: string, conversationProjectId?: string) => {
+        const { currentProjectId, currentProject, projects } = get()
+
+        // Sin proyecto en la conversación no hay nada que reconciliar: una
+        // conversación general puede leerse desde cualquier proyecto activo.
+        if (!conversationProjectId || conversationProjectId === currentProjectId) {
+          if (get().projectMismatch) set({ projectMismatch: null })
+          return
+        }
+
+        // `projects` del store puede estar vacío: la vista WNTR carga su propio
+        // catálogo y nadie llama a loadProjects(). Se consulta el nombre a la
+        // base de datos, y si tampoco se puede se muestra el id: enseñar un
+        // nombre equivocado sería peor que enseñar un identificador.
+        let conversationProjectName = projects.find(p => p.id === conversationProjectId)?.name ?? ''
+        if (!conversationProjectName) {
+          try {
+            const result = await window.electronAPI.hydraulic.getProject(conversationProjectId)
+            conversationProjectName = (result?.success && result.data?.name) || conversationProjectId
+          } catch (error) {
+            logger.error('No se pudo resolver el nombre del proyecto de la conversación:', error)
+            conversationProjectName = conversationProjectId
+          }
+        }
+
+        set({
+          projectMismatch: {
+            conversationId,
+            conversationProjectId,
+            conversationProjectName,
+            activeProjectName: currentProject?.name ?? ''
+          }
+        })
+      },
+
+      resolveProjectMismatch: async (accion: 'switch' | 'keep') => {
+        const pendiente = get().projectMismatch
+        // Se limpia antes de conmutar: selectProject es asíncrono y dejar el
+        // aviso en pantalla mientras carga lo haría parecer no atendido.
+        set({ projectMismatch: null })
+        if (accion === 'switch' && pendiente) {
+          await get().selectProject(pendiente.conversationProjectId)
+        }
       },
 
       syncAllSections: async (projectId: string) => {

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/utils/logger'
 import { create } from 'zustand'
-import { devtools } from 'zustand/middleware'
+import { devtools, persist } from 'zustand/middleware'
 
 interface ProjectData {
   id: string
@@ -22,6 +22,13 @@ interface ProjectData {
 interface ProjectState {
   // Current project
   currentProject: ProjectData | null
+  /**
+   * Proyecto activo global. Es lo único que se persiste, y es la fuente de
+   * verdad de "en qué proyecto está el usuario" para toda la aplicación: el
+   * objeto `currentProject` se rehidrata desde la base de datos a partir de
+   * este id, para no arrastrar una copia obsoleta entre sesiones.
+   */
+  currentProjectId: string | null
   projects: ProjectData[]
 
   // Loading states
@@ -36,6 +43,12 @@ interface ProjectState {
   updateProject: (projectId: string, updates: Partial<ProjectData>) => Promise<boolean>
   deleteProject: (projectId: string) => Promise<boolean>
   clearProject: () => void
+  /**
+   * Vuelve a cargar el proyecto activo persistido. La llama la raíz de la
+   * aplicación al arrancar, y no `onRehydrateStorage`, porque necesita
+   * `window.electronAPI` disponible.
+   */
+  restoreActiveProject: () => Promise<boolean>
 
   // Cross-section synchronization
   syncAllSections: (projectId: string) => Promise<void>
@@ -47,6 +60,7 @@ interface ProjectState {
 
 const initialState = {
   currentProject: null,
+  currentProjectId: null,
   projects: [],
   isLoading: false,
   isLoadingProjects: false,
@@ -55,8 +69,9 @@ const initialState = {
 
 export const useProjectStore = create<ProjectState>()(
   devtools(
-    (set, get) => ({
-      ...initialState,
+    persist(
+      (set, get) => ({
+        ...initialState,
 
       loadProjects: async () => {
         set({ isLoadingProjects: true, error: null })
@@ -85,7 +100,7 @@ export const useProjectStore = create<ProjectState>()(
           const result = await window.electronAPI.hydraulic.getProject(projectId)
 
           if (result.success && result.data) {
-            set({ currentProject: result.data })
+            set({ currentProject: result.data, currentProjectId: projectId })
 
             // Trigger cross-section synchronization
             await get().syncAllSections(projectId)
@@ -168,10 +183,11 @@ export const useProjectStore = create<ProjectState>()(
           const result = await window.electronAPI.hydraulic.deleteProject(projectId)
 
           if (result.success) {
-            // Clear current project if it's the one being deleted
-            const { currentProject } = get()
-            if (currentProject && currentProject.id === projectId) {
-              set({ currentProject: null })
+            // Clear current project if it's the one being deleted. También el id
+            // persistido: si no, al reabrir la aplicación intentaría restaurar un
+            // proyecto borrado.
+            if (get().currentProjectId === projectId) {
+              set({ currentProject: null, currentProjectId: null })
             }
 
             // Remove from projects list
@@ -195,7 +211,21 @@ export const useProjectStore = create<ProjectState>()(
       },
 
       clearProject: () => {
-        set({ currentProject: null, error: null })
+        set({ currentProject: null, currentProjectId: null, error: null })
+      },
+
+      restoreActiveProject: async () => {
+        const { currentProjectId, currentProject } = get()
+        if (!currentProjectId || currentProject?.id === currentProjectId) return false
+
+        const ok = await get().selectProject(currentProjectId)
+        if (!ok) {
+          // El proyecto pudo borrarse entre sesiones: se olvida en lugar de
+          // dejar la aplicación apuntando a un id que ya no existe.
+          logger.warn('El proyecto activo persistido ya no existe, se descarta:', currentProjectId)
+          set({ currentProjectId: null, error: null })
+        }
+        return ok
       },
 
       syncAllSections: async (projectId: string) => {
@@ -207,9 +237,11 @@ export const useProjectStore = create<ProjectState>()(
           // Sync WNTR networks
           useWNTRStore.getState().syncWithProject(projectId)
 
-          // Try to load WNTR network from project
-          const wntrStore = useWNTRStore.getState()
-          await wntrStore.loadNetworkFromProject(projectId)
+          // Aquí se cargaba la red del proyecto en el backend de WNTR. Se ha
+          // quitado a propósito: la vista que muestra una red gestiona su propia
+          // carga, y cargar otra por detrás deja el backend simulando una red
+          // distinta de la que el usuario ve. Seleccionar proyecto fija contexto;
+          // cargar una red es una acción explícita.
 
           // Sync chat conversations (filter by project if needed)
           // This could be enhanced to load project-specific conversations
@@ -257,13 +289,15 @@ export const useProjectStore = create<ProjectState>()(
           return false
         }
       }
-    }),
-    {
-      name: 'project-store',
-      partialize: (state: ProjectState) => ({
-        // Only persist current project ID for restoration
-        currentProjectId: state.currentProject?.id || null
-      })
-    }
+      }),
+      {
+        name: 'project-store',
+        // Sólo el id: el objeto del proyecto se rehidrata desde la base de
+        // datos con restoreActiveProject(), para no servir datos obsoletos si
+        // el proyecto cambió entre sesiones.
+        partialize: (state: ProjectState) => ({ currentProjectId: state.currentProjectId }) as Partial<ProjectState>
+      }
+    ),
+    { name: 'project-store' }
   )
 )

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -16,6 +16,10 @@ export interface NetworkAsset {
      * cuyo fichero ya no estaba en disco). Se puede ver, pero no simular.
      */
     incomplete?: boolean;
+    /** Red madre de la que deriva; ausente en las redes importadas. */
+    parentId?: string;
+    /** Etiqueta del escenario, p. ej. "esqueletizada 100 mm". */
+    scenarioLabel?: string;
 }
 
 export interface CalculationAsset {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -5,7 +5,17 @@ export interface NetworkAsset {
     uploadDate: string;
     nodeCount: number;
     linkCount: number;
-    data: any; // The full INP data (or reference to it)
+    /**
+     * Datos completos de la red. Opcional: el listado que viene de la base de
+     * datos solo trae metadatos, y los datos se piden al abrirla
+     * (network-repo:load), en lugar de cargar todas las redes en memoria.
+     */
+    data?: any;
+    /**
+     * La red se guardo sin su .inp original (migrada desde una version anterior
+     * cuyo fichero ya no estaba en disco). Se puede ver, pero no simular.
+     */
+    incomplete?: boolean;
 }
 
 export interface CalculationAsset {
@@ -30,7 +40,11 @@ export interface Project {
     // same catalog Chat's project selector reads, so a project created here
     // shows up there and vice versa. `chatCount` comes from the DB relation
     // (Conversation.projectId), replacing the old always-zero local `chats` array.
+    /** Solo se rellena para el proyecto activo; el resto usa los contadores. */
     networks: NetworkAsset[];
     calculations: CalculationAsset[];
+    /** Contadores de la base de datos, para las tarjetas del panel. */
+    networkCount: number;
+    calculationCount: number;
     chatCount: number;
 }


### PR DESCRIPTION
# Pull Request

## 📋 Description

Implementa el issue #31, la **tarea habilitadora nº 0** del informe de apreciaciones. Once commits en seis fases, todas verificadas ejecutando la aplicación.

Existía un proyecto activo global escrito y sin enchufar: `useProjectStore` **no lo importaba ningún componente**, y cada vista guardaba el proyecto en su propio estado local, perdiéndolo al desmontarse. Redes y cálculos vivían en la clave `wntr_project_assets` de `localStorage`, invisibles para el resto de la aplicación.

| Fase | Contenido |
|---|---|
| 1 | Proyecto activo global en `useProjectStore`, persistido y compartido por todas las vistas |
| 2 | Aviso al abrir una conversación que pertenece a otro proyecto |
| 3 | Redes y cálculos pasan a la base de datos, con migración del almacenamiento local |
| 4 | Jerarquía madre/hija de escenarios en el esquema |
| 5 | La esqueletización puede guardarse como escenario de la red madre |
| 6 | Diseño y decisiones documentados |

**El diseño y el porqué de las once decisiones no obvias están en [`docs/PROYECTO_ACTIVO_GLOBAL.md`](docs/PROYECTO_ACTIVO_GLOBAL.md).** Recomiendo leerlo antes del diff: varias decisiones se entienden mal sin el motivo.

### Desbloquea

Este PR es la precondición de los puntos **4** (precondiciones de navegación), **5** (el agente del chat responde resúmenes de la red), **8** (Wisdom Center general vs. proyecto) y **9** (indexación de simulaciones al RAG).

## 🔗 Related Issues

Closes #31

## 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🔧 Maintenance (dependency updates, refactoring, etc.)
- [ ] 🌍 Internationalization

## 🌊 Hydraulic Engineering Impact
- [x] WNTR integration
- [ ] EPANET file handling
- [ ] Hydraulic calculations
- [ ] Network visualization
- [x] Project management
- [ ] Regulatory compliance

## 🧪 Testing
- [x] Tests pass locally — **84/84** en 9 ficheros (eran 52/5 al empezar)
- [x] I have added tests that prove my fix is effective — `projectStore.test.ts` (20 casos), `migrateProjectAssets.test.ts` (12 casos)
- [ ] I have tested on multiple platforms:
  - [ ] macOS
  - [ ] Windows
  - [x] Linux — desarrollo, con verificación en la aplicación real

## 🔍 Testing Instructions

1. **Proyecto compartido**: abrir un proyecto en *WNTR Network*, cambiar a *Chat*. Su selector debe mostrar el mismo proyecto sin tocar nada.
2. **Persistencia**: cerrar y reabrir Boorie. El último proyecto activo debe restaurarse.
3. **Discrepancia**: con un proyecto activo, abrir una conversación de otro. Debe avisar con **los dos nombres correctos** y, al conmutar, propagar a la vista WNTR.
4. **Migración**: con datos en `wntr_project_assets`, al arrancar debe volcarlos y mostrar un resumen. **La clave original no se borra nunca.**
5. **Escenarios**: esqueletizar una red guardada y elegir «Guardar como escenario de esta red». Debe aparecer sangrada bajo su madre, con su etiqueta.

## 📸 Screenshots

Verificado en la aplicación. Migración sobre datos reales (16 redes en 4 proyectos, 29 cálculos):

```
redes 4 | ya existentes 12 | incompletas 0 | fallidas 0 | cálculos 29/29
```

Las 4 redes conservan su `.inp` y los 29 cálculos sus resultados. El overlay quedó intacto.

## 🌍 Internationalization
- [x] Changes include new user-facing text
- [x] Text has been added to translation files — `project.mismatch.*` en es/ca/en
- [x] All supported languages updated
  - [x] English
  - [x] Spanish
  - [x] Catalan

> El aviso de la migración va sólo en castellano y sin pasar por i18next: es un mensaje puntual de una única versión, que deja de mostrarse en cuanto se ejecuta. Mantener tres traducciones de eso no se sostiene.

## 📚 Documentation
- [x] Documentation has been updated — `docs/PROYECTO_ACTIVO_GLOBAL.md`
- [x] Code comments added/updated — el «por qué» de cada decisión no obvia

## ⚡ Performance
- [x] This change improves performance

El listado de redes trae sólo metadatos y los datos completos se piden al abrir una red, en lugar de cargarlas todas en memoria. Los contadores de las tarjetas vienen en la misma consulta que el catálogo, no en una consulta por tarjeta.

## 🔒 Security
- [x] I have reviewed security implications

El `.inp` se lee y se escribe **en el proceso principal**. Exponer un lector de ficheros genérico al renderer sería un agujero innecesario en una aplicación con aislamiento de contexto.

> Hallazgo colateral: `readFile` está expuesto en `preload.ts` y **no tiene handler**, así que llamarlo falla. No se toca aquí por no mezclar, pero conviene retirarlo antes de que alguien lo use.

## 📦 Dependencies
- [x] No dependency changes

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings — typecheck limpio en frontend y Electron; se cierran además los 4 avisos de `exhaustive-deps` del componente
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally

## 🎯 Breaking Changes

Ninguno para el usuario. Cambios de comportamiento a validar:

- **Seleccionar un proyecto ya no carga su red** en el backend de WNTR. Era una carga implícita que dejaba el backend simulando una red distinta de la mostrada — la clase de desincronización que costó la retirada del rc.7. Cargar una red pasa a ser una acción explícita.
- **La esqueletización ofrece dos destinos**: escenario hijo (nuevo, por defecto) o proyecto aparte (el comportamiento validado en el rc.9, intacto).
- El esquema cambia (`parentId`, `scenarioLabel`, `resultsPath`). El proyecto es *schema-first* con `db push`, sin migraciones versionadas. **Verificado que los datos existentes sobreviven al push.**

## 📝 Additional Notes

**Cuatro fallos latentes encontrados, ninguno mencionado en el issue:**

| Fallo | Consecuencia |
|---|---|
| `projectStore` no aplicaba `persist` (sólo importaba `devtools`) | Nada se persistía, aunque el código lo aparentara. **El criterio de restaurar el proyecto habría fallado igual** |
| `ChatArea` tenía su propio `selectedProjectId` | Se podía estar en un proyecto en WNTR y en otro en el chat, sin aviso |
| El `.inp` se buscaba comparando nombres entre las redes guardadas | Con dos redes homónimas devolvía la equivocada; con una red sin guardar, **el backend simulaba la anterior** |
| `hydraulic:save-calculation` exigía la forma de la calculadora de fórmulas | Cualquier otro llamante fallaba; los 29 cálculos de la migración fallaban |

**Sobre el alcance frente a lo pedido:** el issue sitúa el problema sólo en `WNTRMainInterface`. Había **tres** sitios con estado de proyecto propio, y el chat no es que le faltara el dato del proyecto: **tenía otro**. Y daba por funcionando una persistencia que no existía. Merece tenerlo presente al valorar el diff.
