### PR TITLE
Poblacion y clientes afectados ante una interrupcion del servicio (#32)

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: run-app
+description: Ejecuta Boorie (Electron + Vite) y conduce su interfaz para verificar un cambio en la aplicación real. Úsalo cuando pidan arrancar la app, hacer una captura, o confirmar que algo funciona de verdad y no solo en los tests.
+---
+
+Boorie es una app Electron cuyo renderer se sirve desde Vite en desarrollo
+(`electron/main.ts` carga `http://localhost:3000` cuando `!app.isPackaged`).
+Para uso automatizado se conduce con el REPL de Playwright que hay en
+`.claude/skills/run-app/driver.mjs`.
+
+Los tests no ven lo que ve un usuario. Ejecutando la app aparecieron el
+redondeo que mostraba «80 %» bajo un umbral de 0.8, las viñetas truncadas del
+historial de versiones y la migración que corría dos veces por `React.StrictMode`.
+
+## Requisitos
+
+`playwright-core` no es dependencia del repo. Instálalo fuera para no tocar
+`package.json`:
+
+```bash
+mkdir -p /tmp/boorie-driver/deps && cd /tmp/boorie-driver/deps
+npm init -y >/dev/null && npm install playwright-core
+```
+
+El driver lo resuelve por `NODE_PATH`. En Linux con escritorio ya hay `DISPLAY`;
+en un contenedor headless hace falta `xvfb-run -a` y los `.so` de Chromium
+(`libnss3 libgbm1 libasound2t64 libgtk-3-0 libxss1 libxkbcommon0
+libatk-bridge2.0-0 libcups2 libdrm2`).
+
+## Arranque
+
+```bash
+cd /home/rayne/Documentos/BOORIE/development/boorie_cliente
+
+npm run build:electron-ts                      # compila el main + copia los .py
+nohup npm run dev:vite > /tmp/boorie-driver/vite.log 2>&1 &
+timeout 90 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 1; done'
+
+mkdir -p /tmp/boorie-driver
+NODE_PATH=/tmp/boorie-driver/deps/node_modules \
+  setsid nohup node .claude/skills/run-app/driver.mjs \
+  > /tmp/boorie-driver/driver.log 2>&1 < /dev/null &
+```
+
+Comandos por fichero, respuestas por otro:
+
+```bash
+IO=/tmp/boorie-driver
+echo "launch" >> $IO/cmd.txt
+timeout 120 bash -c "until grep -q launched $IO/out.txt; do sleep 1; done"
+tail -5 $IO/out.txt
+```
+
+Las capturas van a `/tmp/boorie-driver/shots/` (o `SCREENSHOT_DIR`).
+**Míralas de verdad**: un marco en blanco es un fallo de arranque.
+
+### Comandos
+
+| comando | qué hace |
+|---|---|
+| `launch` | arranca la app y espera a que haya ventana |
+| `click <sel>` | click real de Playwright (el bueno, ver Trampas) |
+| `clicktext <texto>` | click por texto visible |
+| `set <sel> :: <valor>` | escribe en un input controlado por React |
+| `waitfor <sel>` | espera a que exista el selector, 30 s |
+| `scrollto <texto>` | lleva a la vista el elemento que empieza por ese texto |
+| `ss [nombre]` | captura a `shots/<nombre>.png` |
+| `text [sel]` | vuelca `innerText` |
+| `evaljs <expr>` | evalúa en la página y devuelve JSON |
+| `windows` | lista las ventanas |
+| `quit` | cierra la app y termina |
+
+## Llegar a la red hidráulica
+
+La ruta que sirve para casi todo lo de WNTR:
+
+```bash
+IO=/tmp/boorie-driver
+echo "waitfor button:has-text('.inp')" >> $IO/cmd.txt   # la restauración es asíncrona
+echo "clicktext villa_100_casas.inp"   >> $IO/cmd.txt   # carga la red guardada
+sleep 12
+echo "click [role=tab][title=Resilience]" >> $IO/cmd.txt
+```
+
+Pestañas disponibles por `title`: `Simulation`, `Analysis`, `Resilience`, `Layers`.
+
+Las redes guardadas viven en la base SQLite, no en disco. Para sacar un `.inp`
+y contrastar por CLI lo que muestra la interfaz:
+
+```bash
+python3 -c "
+import sqlite3
+c=sqlite3.connect('prisma/hydraulic.db')
+print(c.execute(\"select fileContent from hydraulic_networks where name='villa_100_casas.inp'\").fetchone()[0])
+" > /tmp/boorie-driver/red.inp
+```
+
+## Trampas
+
+- **Radix ignora el `.click()` del DOM.** Pestañas, selects y diálogos escuchan
+  `pointerdown` y sólo reaccionan a eventos de confianza. Despachar `MouseEvent`
+  a mano tampoco vale. Usa `click`, que va por `page.click()` de Playwright.
+- **Los inputs son controlados por React.** Asignar `.value` no dispara
+  `onChange` y el estado no cambia. `set` usa el setter nativo del prototipo más
+  un evento `input`, que es lo que React escucha.
+- **La restauración del proyecto activo es asíncrona.** Justo tras `launch` la
+  vista de proyectos todavía está vacía y un click sobre la red guardada da
+  `NOT_FOUND`. Espera al selector, no a un `sleep` fijo.
+- **Un solo driver a la vez.** Dos procesos consumen el mismo `cmd.txt`, cada uno
+  lanza su propia app y acabas observando una instancia mientras tocas la otra.
+  El driver pone un cerrojo en `driver.pid`; si aborta sucio, bórralo.
+- **`pkill -f driver.mjs` mata tu propia shell**, porque su línea de comandos
+  contiene el patrón. Usa `pkill -f 'driver[.]mjs'` o mata por PID.
+- **Vite tarda en el primer arranque** (optimiza dependencias). Espera al
+  `curl`, no a un `sleep`.
+
+## Cierre
+
+```bash
+IO=/tmp/boorie-driver
+echo "quit" >> $IO/cmd.txt; sleep 3
+ps -eo pid,args | grep -E '[e]lectron/dist|[d]river\.mjs' | awk '{print $1}' | xargs -r kill -9
+ps -eo pid,args | grep '[v]ite' | grep boorie | awk '{print $1}' | xargs -r kill
+```
+
+## Camino humano
+
+`npm run dev` levanta Vite y Electron juntos con recarga en caliente. Es lo
+cómodo para una persona, pero no deja conducir la interfaz desde un agente.

--- a/.claude/skills/run-app/driver.mjs
+++ b/.claude/skills/run-app/driver.mjs
@@ -1,0 +1,141 @@
+// REPL para conducir Boorie (Electron + Vite) desde un agente.
+// Los comandos entran por un fichero y la salida sale por otro, para poder
+// iterar sin relanzar la app (arrancar cuesta ~25 s con la restauración del
+// proyecto activo).
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+const APP_DIR = path.resolve(import.meta.dirname, '..', '..', '..');
+const IO = process.env.BOORIE_DRIVER_IO || '/tmp/boorie-driver';
+const CMD = path.join(IO, 'cmd.txt');
+const OUT = path.join(IO, 'out.txt');
+const SHOTS = process.env.SCREENSHOT_DIR || path.join(IO, 'shots');
+const LOCK = path.join(IO, 'driver.pid');
+
+fs.mkdirSync(SHOTS, { recursive: true });
+
+// Dos drivers vivos consumen el mismo cmd.txt y cada uno lanza su propia app:
+// los comandos se ejecutan por duplicado sobre instancias distintas y el estado
+// que observas no es el que estás tocando. Pasó de verdad; de ahí el cerrojo.
+if (fs.existsSync(LOCK)) {
+  const old = Number(fs.readFileSync(LOCK, 'utf8'));
+  try { process.kill(old, 0); console.error(`Ya hay un driver vivo (pid ${old}). Mátalo o borra ${LOCK}.`); process.exit(1); }
+  catch { /* pid muerto, seguimos */ }
+}
+fs.writeFileSync(LOCK, String(process.pid));
+process.on('exit', () => { try { fs.unlinkSync(LOCK); } catch {} });
+
+// playwright-core no es dependencia del repo: se busca donde se haya instalado.
+const require_ = createRequire(import.meta.url);
+let electron;
+try { ({ _electron: electron } = require_('playwright-core')); }
+catch { console.error('Falta playwright-core. Ver SKILL.md (Requisitos).'); process.exit(1); }
+
+fs.writeFileSync(CMD, ''); fs.writeFileSync(OUT, '');
+const log = (...a) => fs.appendFileSync(OUT, a.join(' ') + '\n');
+
+let app = null, page = null;
+
+const REACT_SET = `(sel, val) => {
+  const el = document.querySelector(sel);
+  if (!el) return 'NOT_FOUND';
+  const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement : HTMLInputElement;
+  Object.getOwnPropertyDescriptor(proto.prototype, 'value').set.call(el, val);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  return 'OK';
+}`;
+
+const C = {
+  async launch() {
+    if (app) return log('ya lanzada');
+    app = await electron.launch({
+      executablePath: path.join(APP_DIR, 'node_modules/electron/dist/electron'),
+      args: ['--no-sandbox', APP_DIR],
+      cwd: APP_DIR,
+      env: { ...process.env, DISPLAY: process.env.DISPLAY || ':1', NODE_ENV: 'development' },
+      timeout: 60_000,
+    });
+    page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+    await new Promise(r => setTimeout(r, 6000));
+    page = app.windows().find(w => !w.url().startsWith('devtools://')) ?? page;
+    log('launched. windows:', app.windows().map(w => w.url()).join(' | '));
+  },
+
+  // Radix (pestañas, selects) ignora el .click() del DOM: escucha pointerdown
+  // y sólo reacciona a eventos de confianza. Este es el click bueno por defecto.
+  async click(sel) {
+    try { await page.click(sel, { timeout: 10_000 }); log('click', sel, '-> OK'); }
+    catch (e) { log('click', sel, '-> FAIL:', e.message.split('\n')[0]); }
+  },
+  // Prioriza lo accionable: buscar por texto suelto engancha antes el párrafo
+  // descriptivo que el botón que lleva el mismo nombre de fichero.
+  async clicktext(t) {
+    for (const loc of [page.getByRole('button', { name: t }), page.getByRole('link', { name: t }), page.getByText(t, { exact: false })]) {
+      try { await loc.first().click({ timeout: 5_000 }); return log('clicktext', t, '-> OK'); }
+      catch { /* siguiente estrategia */ }
+    }
+    log('clicktext', t, '-> FAIL: sin elemento accionable');
+  },
+
+  // Los inputs son controlados por React: asignar .value no dispara onChange.
+  // Sintaxis: set <selector> :: <valor>   (el selector puede llevar '=')
+  async set(spec) {
+    const [sel, ...rest] = spec.split(' :: ');
+    if (!rest.length) return log('uso: set <selector> :: <valor>');
+    log('set', sel, '->', await page.evaluate(
+      ([s, v, fn]) => new Function('return ' + fn)()(s, v),
+      [sel.trim(), rest.join(' :: '), REACT_SET]
+    ));
+  },
+
+  async waitfor(sel) {
+    try { await page.waitForSelector(sel, { timeout: 30_000 }); log('presente:', sel); }
+    catch { log('TIMEOUT esperando', sel); }
+  },
+  async ss(name) {
+    const f = path.join(SHOTS, (name || `ss-${process.hrtime.bigint()}`) + '.png');
+    await page.screenshot({ path: f });
+    log('screenshot:', f);
+  },
+  async text(sel) {
+    log(await page.evaluate(s => (s ? document.querySelector(s) : document.body)?.innerText ?? '(null)', sel || null));
+  },
+  async evaljs(expr) {
+    try { log(JSON.stringify(await page.evaluate(expr))); } catch (e) { log('ERROR:', e.message.split('\n')[0]); }
+  },
+  async scrollto(text) {
+    log('scrollto', text, '->', await page.evaluate(t => {
+      const el = [...document.querySelectorAll('h1,h2,h3,h4,div')].find(e => e.textContent?.trim().startsWith(t));
+      if (!el) return 'NOT_FOUND';
+      el.scrollIntoView({ block: 'start' }); return 'OK';
+    }, text));
+  },
+  async windows() {
+    for (const w of app.windows()) log(' ', w.url());
+  },
+  async quit() { if (app) await app.close().catch(() => {}); log('bye'); process.exit(0); },
+};
+
+let seen = 0, busy = false;
+setInterval(async () => {
+  if (busy) return;                    // sin esto los comandos se solapan
+  busy = true;
+  try {
+    const lines = fs.readFileSync(CMD, 'utf8').split('\n').filter(Boolean);
+    while (seen < lines.length) {
+      const line = lines[seen++];
+      const i = line.indexOf(' ');
+      const cmd = i < 0 ? line : line.slice(0, i);
+      const arg = i < 0 ? '' : line.slice(i + 1);
+      log('$ ' + line);
+      if (cmd !== 'launch' && !page) { log('ERROR: lanza la app primero'); continue; }
+      try { await (C[cmd] ?? (async () => log('comando desconocido:', cmd)))(arg); }
+      catch (e) { log('ERROR:', e.message.split('\n')[0]); }
+    }
+  } catch { /* cmd.txt aún no existe */ }
+  finally { busy = false; }
+}, 400);
+
+log('driver ready');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,23 @@ jobs:
         python -m pip install --upgrade pip
         pip install numpy>=1.20 scipy>=1.7 pandas>=1.3 networkx>=2.6 matplotlib>=3.4 wntr>=0.5.0
         
-    - name: Test WNTR functionality
-      run: |
-        if [ -f "test-files/test-wntr-complete.py" ]; then
-          python test-files/test-wntr-complete.py
-        else
-          echo "WNTR tests not found, skipping"
-        fi
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    # Comprobacion explicita: si WNTR no queda disponible los tests de
+    # integracion se saltan solos y el job pasaria en verde sin probar nada,
+    # que es justo lo que hacia antes.
+    - name: Verify WNTR is importable
+      run: python -c "import wntr; print('WNTR', wntr.__version__)"
+
+    - name: Run WNTR integration tests
+      run: npx vitest run backend/services/hydraulic/resilienceService.integration.test.ts --reporter=verbose
 
   build-electron:
     name: Build Electron Apps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --legacy-peer-deps
 
     # Comprobacion explicita: si WNTR no queda disponible los tests de
     # integracion se saltan solos y el job pasaria en verde sin probar nada,

--- a/backend/services/hydraulic/resilienceService.integration.test.ts
+++ b/backend/services/hydraulic/resilienceService.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import { WNTRResilienceService } from './resilienceService'
+import { getPythonStatus } from './pythonDetector'
 
 /**
  * Tests contra el servicio Python real y una red real (sin mocks), en la línea
@@ -18,16 +19,14 @@ import { WNTRResilienceService } from './resilienceService'
  *  - Sin corrida de referencia, el déficit crónico de la red se atribuía entero
  *    al evento: la bomba 6012 "afectaba" a 2009 hab que ya estaban afectados.
  *
- * Se omiten si el repo no tiene venv-wntr preparado (./setup-python-wntr.sh).
+ * Se omiten si la máquina no tiene un Python con WNTR. El gateo pregunta por
+ * el intérprete resuelto y no por la existencia de venv-wntr: en CI no hay venv
+ * y WNTR está en el Python del sistema, así que atarlo al venv dejaba estos
+ * ocho tests saltados y el check en verde sin haber probado nada.
  */
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
-const VENV_PYTHON = path.join(
-  REPO_ROOT, 'venv-wntr',
-  process.platform === 'win32' ? 'Scripts' : 'bin',
-  process.platform === 'win32' ? 'python.exe' : 'python'
-)
 const NETWORK = path.join(REPO_ROOT, 'test-files', 'SoloChamiseroMedioConPatronComercial-07p1.inp')
-const canRun = fs.existsSync(VENV_PYTHON) && fs.existsSync(NETWORK)
+const canRun = getPythonStatus().wntrAvailable && fs.existsSync(NETWORK)
 
 /** Cada llamada corre dos simulaciones de periodo extendido. */
 const SIM_TIMEOUT = 120_000

--- a/backend/services/hydraulic/resilienceService.integration.test.ts
+++ b/backend/services/hydraulic/resilienceService.integration.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { WNTRResilienceService } from './resilienceService'
+
+/**
+ * Tests contra el servicio Python real y una red real (sin mocks), en la línea
+ * de pythonDetector.integration.test.ts. Cubren la simulación de interrupción
+ * unificada (#22 + #32): una sola ejecución devuelve el impacto en presiones y
+ * el impacto en habitantes, desde las mismas dos corridas PDA.
+ *
+ * Los tres fallos que aparecieron al construirla:
+ *
+ *  - `population()` de WNTR convierte la demanda base negativa de un nudo-fuente
+ *    en población negativa: en esta red daba -4601 hab y dejaba el total en 0.
+ *  - Contar instantes en vez de intervalos daba 25 h de déficit en una ventana
+ *    de 24 h y sobreestimaba el volumen no entregado en un paso completo.
+ *  - Sin corrida de referencia, el déficit crónico de la red se atribuía entero
+ *    al evento: la bomba 6012 "afectaba" a 2009 hab que ya estaban afectados.
+ *
+ * Se omiten si el repo no tiene venv-wntr preparado (./setup-python-wntr.sh).
+ */
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const VENV_PYTHON = path.join(
+  REPO_ROOT, 'venv-wntr',
+  process.platform === 'win32' ? 'Scripts' : 'bin',
+  process.platform === 'win32' ? 'python.exe' : 'python'
+)
+const NETWORK = path.join(REPO_ROOT, 'test-files', 'SoloChamiseroMedioConPatronComercial-07p1.inp')
+const canRun = fs.existsSync(VENV_PYTHON) && fs.existsSync(NETWORK)
+
+/** Cada llamada corre dos simulaciones de periodo extendido. */
+const SIM_TIMEOUT = 120_000
+
+const DURATION_HOURS = 24
+/** Tubería troncal cuyo cierre sí deja nudos sin servicio en esta red. */
+const TRUNK_PIPE = '8062'
+/** Bomba cuyo paro no cambia el servicio: sirve para comprobar la atribución. */
+const NEUTRAL_PUMP = '6012'
+
+const service = new WNTRResilienceService()
+
+const run = (options: Record<string, unknown>) =>
+  service.simulateComponentFailure(NETWORK, {
+    duration_hours: DURATION_HOURS,
+    failure_start_hours: 2,
+    ...options
+  } as never)
+
+describe.skipIf(!canRun)('interrupción del servicio con WNTR real', () => {
+  it('devuelve presiones y habitantes en una sola ejecución', async () => {
+    const res = await run({ components: [{ id: TRUNK_PIPE }] })
+
+    expect(res.success).toBe(true)
+    const d = res.data!
+
+    // El impacto en presiones sigue siendo lo de #22...
+    expect(d.affected_node_count).toBeGreaterThan(0)
+    expect(d.total_junction_count).toBeGreaterThan(0)
+    expect(d.failed_components).toEqual([TRUNK_PIPE])
+
+    // ...y viene acompañado del impacto en habitantes, sin simular otra vez.
+    const p = d.population
+    expect(p.attributable_to_event.population_affected).toBeGreaterThan(0)
+    expect(p.attributable_to_event.affected_node_count).toBeGreaterThan(0)
+    expect(p.attributable_to_event.undelivered_volume_m3).toBeGreaterThan(0)
+  }, SIM_TIMEOUT)
+
+  it('simula en PDA, no en modo dirigido por demanda', async () => {
+    const res = await run({ components: [{ id: TRUNK_PIPE }] })
+
+    // En DDA un nudo con 10 m de presión recibiría el 100% de su demanda y el
+    // impacto en habitantes saldría cero.
+    expect(res.data!.population.traceability.demand_model).toBe('PDA')
+    expect(res.data!.population.traceability.impact_metric).toContain('population_impacted')
+  }, SIM_TIMEOUT)
+
+  it('excluye los nudos de demanda negativa en vez de restarlos de la población', async () => {
+    const p = (await run({ components: [{ id: TRUNK_PIPE }] })).data!.population
+
+    // Sin el recorte, este nudo-fuente cancelaba a toda la población de la red.
+    expect(p.excluded_negative_demand_nodes.length).toBeGreaterThan(0)
+    expect(p.total_population).toBeGreaterThan(0)
+    expect(p.population_nodes).toBeGreaterThan(0)
+
+    for (const node of p.event.affected_nodes) {
+      expect(node.population_affected).toBeGreaterThan(0)
+    }
+  }, SIM_TIMEOUT)
+
+  it('no reporta más horas de déficit ni de corte que la ventana simulada', async () => {
+    const d = (await run({ components: [{ id: TRUNK_PIPE }] })).data!
+
+    expect(d.population.event.max_outage_hours).toBeLessThanOrEqual(DURATION_HOURS)
+    for (const node of d.population.event.affected_nodes) {
+      expect(node.outage_hours).toBeLessThanOrEqual(DURATION_HOURS)
+    }
+    for (const node of d.affected_nodes) {
+      expect(node.outage_hours).toBeLessThanOrEqual(DURATION_HOURS)
+    }
+  }, SIM_TIMEOUT)
+
+  it('no atribuye al evento el déficit que la red ya tenía', async () => {
+    const p = (await run({ components: [{ id: NEUTRAL_PUMP }] })).data!.population
+
+    // La red deja nudos sin servicio incluso sin evento; parar esta bomba no
+    // cambia el resultado, así que lo atribuible tiene que ser cero.
+    expect(p.baseline.population_affected).toBeGreaterThan(0)
+    expect(p.event.population_affected).toBe(p.baseline.population_affected)
+    expect(p.attributable_to_event.population_affected).toBe(0)
+  }, SIM_TIMEOUT)
+
+  it('recalcula la población al cambiar el módulo de demanda', async () => {
+    // pop = demanda_media / R, con R proporcional al módulo: al doblarlo la
+    // población se reduce a la mitad. Es el criterio de aceptación del issue.
+    const base = await run({ components: [{ id: TRUNK_PIPE }], demand_module_lphd: 200 })
+    const doubled = await run({ components: [{ id: TRUNK_PIPE }], demand_module_lphd: 400 })
+
+    expect(base.data!.population.traceability.demand_module_lphd).toBe(200)
+    expect(doubled.data!.population.traceability.demand_module_lphd).toBe(400)
+    expect(doubled.data!.population.total_population)
+      .toBeCloseTo(base.data!.population.total_population / 2, -1)
+  }, SIM_TIMEOUT)
+
+  it('deriva clientes solo cuando se da el factor de acometidas', async () => {
+    const sin = await run({ components: [{ id: TRUNK_PIPE }] })
+    expect(sin.data!.population.connections).toBeNull()
+
+    const con = await run({ components: [{ id: TRUNK_PIPE }], persons_per_connection: 4 })
+    const c = con.data!.population.connections!
+    expect(c.method).toBe('derived_from_population')
+    expect(c.total_connections).toBe(Math.round(con.data!.population.total_population / 4))
+  }, SIM_TIMEOUT)
+
+  it('falla de forma explícita si el componente no existe en la red', async () => {
+    const res = await run({ components: [{ id: 'NO_EXISTE_9999' }] })
+    expect(res.success).toBe(false)
+  }, SIM_TIMEOUT)
+})

--- a/backend/services/hydraulic/resilienceService.ts
+++ b/backend/services/hydraulic/resilienceService.ts
@@ -6,6 +6,8 @@
 
 import { spawn } from 'child_process';
 import { createLogger } from '../../utils/logger';
+import { findPythonPath } from './pythonDetector';
+import { resolvePythonScriptPath } from './pythonScriptPath';
 
 const logger = createLogger('WNTRResilienceService');
 
@@ -24,6 +26,60 @@ export interface SkeletonizeResult {
 export interface ComponentFailureInput {
   id: string;
   type?: 'pipe' | 'pump' | 'valve';
+}
+
+export interface AffectedPopulationNode {
+  id: string;
+  population: number;
+  population_affected: number;
+  min_service_availability: number;
+  outage_hours: number;
+  undelivered_m3: number;
+  min_pressure: number | null;
+}
+
+export interface PopulationSnapshot {
+  population_affected: number;
+  affected_node_count: number;
+  affected_nodes: AffectedPopulationNode[];
+  max_outage_hours: number;
+  undelivered_volume_m3: number;
+  min_service_availability: number;
+}
+
+/** Población y clientes afectados (#32), calculados sobre las mismas dos corridas PDA. */
+export interface PopulationImpact {
+  total_population: number;
+  population_nodes: number;
+  event: PopulationSnapshot;
+  /** Misma red sin el evento: separa el déficit crónico del causado por la interrupción. */
+  baseline: PopulationSnapshot;
+  attributable_to_event: {
+    population_affected: number;
+    affected_node_count: number;
+    undelivered_volume_m3: number;
+  };
+  connections: {
+    persons_per_connection: number;
+    total_connections: number;
+    affected_connections: number;
+    method: string;
+  } | null;
+  /** Nudos con demanda base negativa (fuentes modeladas como junction), excluidos del cómputo. */
+  excluded_negative_demand_nodes: Array<{ id: string; population: number }>;
+  traceability: {
+    demand_model: 'PDA';
+    simulator: string;
+    wntr_version: string;
+    demand_module_lphd: number;
+    per_capita_demand_m3s: number;
+    availability_threshold: number;
+    required_pressure_m: number;
+    minimum_pressure_m: number;
+    timestep_s: number;
+    population_metric: string;
+    impact_metric: string;
+  };
 }
 
 export interface SimulateFailureResult {
@@ -48,6 +104,8 @@ export interface SimulateFailureResult {
     node_results: Record<string, { pressure: number[] }>;
     link_results: Record<string, { flowrate: number[] }>;
     timestamps: number[];
+    convergence_warnings: { baseline: string[]; event: string[]; converged: boolean };
+    population: PopulationImpact;
   };
   error?: string;
 }
@@ -100,14 +158,10 @@ export class WNTRResilienceService {
 
   /** Ver nota en wntrWrapper: se resuelve en cada ejecución, no al construir. */
   private get pythonPath(): string {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { findPythonPath } = require('./pythonDetector');
     return findPythonPath();
   }
 
   constructor() {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { resolvePythonScriptPath } = require('./pythonScriptPath');
     this.servicePath = resolvePythonScriptPath('wntr_resilience_service.py');
   }
 
@@ -126,6 +180,16 @@ export class WNTRResilienceService {
     failure_start_hours?: number;
     restore_hours?: number;
     min_pressure_threshold?: number;
+    /** Módulo de demanda media en l/hab/día (típico LatAm 150-300, por defecto 200). */
+    demand_module_lphd?: number;
+    /** Por debajo de esta fracción de la demanda esperada el nudo cuenta como afectado. */
+    availability_threshold?: number;
+    /** Presión a la que PDA entrega el 100% de la demanda. */
+    required_pressure?: number;
+    /** Presión por debajo de la cual PDA no entrega nada. */
+    minimum_pressure?: number;
+    /** Habitantes por acometida. Si se omite no se reportan clientes. */
+    persons_per_connection?: number;
   }): Promise<SimulateFailureResult> {
     return this.executePythonService('simulate_failure', networkFile, options);
   }

--- a/backend/services/hydraulic/wntr_resilience_service.py
+++ b/backend/services/hydraulic/wntr_resilience_service.py
@@ -12,15 +12,28 @@ import json
 import os
 import time
 import tempfile
+import numpy as np
 import wntr
 import wntr.metrics.hydraulic
 import wntr.network.controls as ctrls
 from wntr.network import LinkStatus
+from wntr.metrics import (
+    expected_demand,
+    water_service_availability,
+    population,
+    population_impacted,
+)
 import warnings
 
 # Suppress specific WNTR warnings that are informational only
 warnings.filterwarnings('ignore', message='Changing the headloss formula from')
 warnings.filterwarnings('ignore', message='Not all curves were used in')
+
+# Población y clientes afectados (#32). Ver docs/POBLACION_AFECTADA_PDA.md.
+DEFAULT_DEMAND_MODULE_LPHD = 200.0    # l/hab/día (rango típico LatAm: 150-300)
+DEFAULT_AVAILABILITY_THRESHOLD = 0.8  # se considera afectado por debajo del 80%
+DEFAULT_REQUIRED_PRESSURE = 20.0      # m, presión a la que se sirve el 100%
+DEFAULT_MINIMUM_PRESSURE = 0.0        # m, por debajo no se entrega nada
 
 
 class WNTRResilienceService:
@@ -189,11 +202,173 @@ class WNTRResilienceService:
             applied.append(comp_id)
         return applied
 
+    # ------------------------------------------------------------------
+    # Población y clientes afectados (#32)
+    # ------------------------------------------------------------------
+    def _enable_pda(self, wn, required_pressure, minimum_pressure):
+        """
+        PDA es el único modo físicamente correcto para un escenario de
+        degradación: en DDA un nudo con 10 m de presión recibe el 100% de su
+        demanda y el impacto sale cero.
+        """
+        wn.options.hydraulic.demand_model = 'PDA'
+        wn.options.hydraulic.required_pressure = float(required_pressure)
+        wn.options.hydraulic.minimum_pressure = float(minimum_pressure)
+
+    def _population(self, wn, demand_module_lphd):
+        """
+        population(wn, R) con R derivado del módulo de demanda del usuario.
+
+        WNTR aplica pob = demanda_media / R sin filtrar signos, así que un nudo
+        que modela una fuente como demanda negativa sale con población negativa
+        (en la red de pruebas: -4601 hab, dejando el total de red en 0). Se
+        recortan a cero y se declaran aparte para que la cifra sea trazable.
+        """
+        R = float(demand_module_lphd) / 1000.0 / 86400.0  # l/hab/día -> m3/s/hab
+        raw = population(wn, R)
+        negative_nodes = [{'id': str(k), 'population': float(v)} for k, v in raw[raw < 0].items()]
+        return raw.clip(lower=0), R, negative_nodes
+
+    def _service_metrics(self, wn, results, pop, threshold):
+        """
+        Disponibilidad de servicio nudo a nudo y población impactada.
+
+        La disponibilidad es NaN donde la demanda esperada es 0 (nudos sin
+        demanda); ahí no hay déficit posible, así que se trata como servicio
+        completo en lugar de propagar el NaN a las sumas.
+        """
+        exp = expected_demand(wn)
+        dem = results.node['demand'].loc[:, exp.columns]
+        wsa = water_service_availability(exp, dem).fillna(1.0)
+        impacted = population_impacted(pop.reindex(wsa.columns).fillna(0.0), wsa, np.less, threshold)
+
+        # Integración por intervalos (Riemann por la izquierda). Una simulación
+        # de 24 h con paso de 1 h reporta 25 instantes, no 25 intervalos: contar
+        # instantes daba 25 h de déficit en una ventana de 24 h y sobreestimaba
+        # el volumen en un paso completo.
+        index = wsa.index.to_numpy(dtype=float)
+        intervals_s = np.diff(index) if len(index) > 1 else np.array([0.0])
+        below = (wsa < threshold).iloc[:-1] if len(index) > 1 else (wsa < threshold)
+        deficit = (exp - dem).clip(lower=0.0)
+        deficit_head = deficit.iloc[:-1] if len(index) > 1 else deficit
+
+        return {
+            'wsa': wsa,
+            'impacted': impacted,
+            'outage_hours': below.multiply(intervals_s, axis=0).sum(axis=0) / 3600.0,
+            'undelivered_m3': deficit_head.multiply(intervals_s, axis=0).sum(axis=0),
+            'timestep_s': float(np.median(intervals_s)) if len(index) > 1 else 0.0,
+        }
+
+    def _summarise_population(self, m, pop, results):
+        wsa, impacted = m['wsa'], m['impacted']
+        peak_per_node = impacted.max(axis=0)
+        outage_hours = m['outage_hours']
+        undelivered_per_node = m['undelivered_m3']
+        pressure = results.node['pressure']
+
+        affected = []
+        for node in peak_per_node.index:
+            if peak_per_node[node] <= 0:
+                continue
+            affected.append({
+                'id': str(node),
+                'population': float(pop.get(node, 0.0)),
+                'population_affected': float(peak_per_node[node]),
+                'min_service_availability': float(wsa[node].min()),
+                'outage_hours': float(outage_hours[node]),
+                'undelivered_m3': float(undelivered_per_node[node]),
+                'min_pressure': float(pressure[node].min()) if node in pressure.columns else None,
+            })
+        affected.sort(key=lambda a: a['population_affected'], reverse=True)
+
+        return {
+            'population_affected': int(round(float(peak_per_node.sum()))),
+            'affected_node_count': len(affected),
+            'affected_nodes': affected,
+            'max_outage_hours': float(outage_hours.max()) if len(outage_hours) else 0.0,
+            'undelivered_volume_m3': float(undelivered_per_node.sum()),
+            'min_service_availability': float(wsa.to_numpy().min()) if wsa.size else 1.0,
+        }
+
+    def _population_impact(self, wn_base, res_base, wn_ev, res_ev, opts):
+        """Población afectada a partir de las dos corridas que ya hizo simulate_failure."""
+        demand_module = float(opts.get('demand_module_lphd', DEFAULT_DEMAND_MODULE_LPHD))
+        threshold = float(opts.get('availability_threshold', DEFAULT_AVAILABILITY_THRESHOLD))
+        persons_per_connection = opts.get('persons_per_connection')
+
+        if demand_module <= 0:
+            raise ValueError('El módulo de demanda debe ser mayor que cero')
+        if not 0 < threshold <= 1:
+            raise ValueError('El umbral de disponibilidad debe estar entre 0 y 1')
+
+        pop, R, negative_nodes = self._population(wn_base, demand_module)
+        baseline = self._summarise_population(
+            self._service_metrics(wn_base, res_base, pop, threshold), pop, res_base)
+        ev_metrics = self._service_metrics(wn_ev, res_ev, pop, threshold)
+        event = self._summarise_population(ev_metrics, pop, res_ev)
+
+        total_population = int(round(float(pop.sum())))
+        connections = None
+        ppc = float(persons_per_connection) if persons_per_connection else 0.0
+        if ppc > 0:
+            connections = {
+                'persons_per_connection': ppc,
+                'total_connections': int(round(total_population / ppc)),
+                'affected_connections': int(round(event['population_affected'] / ppc)),
+                'method': 'derived_from_population',
+            }
+
+        return {
+            'total_population': total_population,
+            'population_nodes': int((pop > 0).sum()),
+            'event': event,
+            'baseline': baseline,
+            # Sin corrida de referencia, el déficit crónico de la red se
+            # atribuiría entero al evento.
+            'attributable_to_event': {
+                'population_affected': event['population_affected'] - baseline['population_affected'],
+                'affected_node_count': event['affected_node_count'] - baseline['affected_node_count'],
+                'undelivered_volume_m3': event['undelivered_volume_m3'] - baseline['undelivered_volume_m3'],
+            },
+            'connections': connections,
+            'excluded_negative_demand_nodes': negative_nodes,
+            'traceability': {
+                'demand_model': 'PDA',
+                'simulator': 'WNTRSimulator',
+                'wntr_version': wntr.__version__,
+                'demand_module_lphd': demand_module,
+                'per_capita_demand_m3s': R,
+                'availability_threshold': threshold,
+                'required_pressure_m': float(opts.get('required_pressure', DEFAULT_REQUIRED_PRESSURE)),
+                'minimum_pressure_m': float(opts.get('minimum_pressure', DEFAULT_MINIMUM_PRESSURE)),
+                'timestep_s': ev_metrics['timestep_s'],
+                'population_metric': 'wntr.metrics.population',
+                'impact_metric': 'wntr.metrics.population_impacted(service_availability < threshold)',
+            },
+        }
+
     def _run_extended(self, wn, duration_hours):
         wn.options.time.duration = float(duration_hours) * 3600.0
         self._prepare_wntr_simulator(wn)
         sim = wntr.sim.WNTRSimulator(wn)
         return sim.run_sim()
+
+    def _run_extended_checked(self, wn, duration_hours):
+        """
+        Como _run_extended, pero recoge los avisos de no convergencia.
+        "Exceeded maximum number of trials" significa que el paso no convergió y
+        las cifras de ese instante no son fiables; se reportan en lugar de
+        silenciarlas, porque el criterio es que ninguna cifra salga de una
+        estimación no simulada.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            results = self._run_extended(wn, duration_hours)
+        return results, [
+            str(w.message) for w in caught
+            if 'maximum number of trials' in str(w.message).lower()
+        ]
 
     def simulate_failure(self, inp_file, options=None):
         start_time = time.time()
@@ -208,30 +383,38 @@ class WNTRResilienceService:
             failure_start_hours = float(options.get('failure_start_hours', 0))
             restore_hours = options.get('restore_hours')
             min_pressure_threshold = float(options.get('min_pressure_threshold', 10.0))
+            required_pressure = float(options.get('required_pressure', DEFAULT_REQUIRED_PRESSURE))
+            minimum_pressure = float(options.get('minimum_pressure', DEFAULT_MINIMUM_PRESSURE))
 
             # Baseline (undisturbed) run, used to report the pressure drop caused by the failure
             wn_baseline = self.load_network(inp_file)
-            baseline_results = self._run_extended(wn_baseline, duration_hours)
+            self._enable_pda(wn_baseline, required_pressure, minimum_pressure)
+            baseline_results, baseline_convergence = self._run_extended_checked(wn_baseline, duration_hours)
             baseline_pressure = baseline_results.node['pressure']
 
             # Failure run
             wn_failure = self.load_network(inp_file)
+            self._enable_pda(wn_failure, required_pressure, minimum_pressure)
             applied = self._apply_component_failures(wn_failure, components, failure_start_hours, restore_hours)
             if not applied:
                 print(json.dumps({'success': False, 'error': 'None of the specified components exist in the network'}))
                 return
 
-            failure_results = self._run_extended(wn_failure, duration_hours)
+            failure_results, event_convergence = self._run_extended_checked(wn_failure, duration_hours)
             pressure = failure_results.node['pressure']
-            report_ts_hours = wn_failure.options.time.report_timestep / 3600.0
+
+            # Por intervalos, no por instantes: una ventana de 24 h con paso de
+            # 1 h reporta 25 instantes y contarlos daba 25 h de corte.
+            index = pressure.index.to_numpy(dtype=float)
+            intervals_h = (np.diff(index) / 3600.0) if len(index) > 1 else np.array([0.0])
 
             affected_nodes = []
             for node_name in wn_failure.junction_name_list:
                 node_pressure = pressure.loc[:, node_name]
                 min_p = float(node_pressure.min())
                 baseline_min_p = float(baseline_pressure.loc[:, node_name].min()) if node_name in baseline_pressure.columns else min_p
-                below_threshold_steps = int((node_pressure < min_pressure_threshold).sum())
-                outage_hours = below_threshold_steps * report_ts_hours
+                below = (node_pressure < min_pressure_threshold).to_numpy()
+                outage_hours = float((below[:-1] * intervals_h).sum()) if len(index) > 1 else 0.0
 
                 if min_p < min_pressure_threshold or outage_hours > 0:
                     affected_nodes.append({
@@ -270,6 +453,16 @@ class WNTRResilienceService:
                     'node_results': node_results,
                     'link_results': link_results,
                     'timestamps': pressure.index.tolist(),
+                    'convergence_warnings': {
+                        'baseline': baseline_convergence,
+                        'event': event_convergence,
+                        'converged': not baseline_convergence and not event_convergence,
+                    },
+                    # Misma interrupción, medida en habitantes: se reaprovechan
+                    # las dos corridas de arriba en vez de simular otra vez.
+                    'population': self._population_impact(
+                        wn_baseline, baseline_results, wn_failure, failure_results, options
+                    ),
                 }
             }
             print(json.dumps(result))

--- a/docs/POBLACION_AFECTADA_PDA.md
+++ b/docs/POBLACION_AFECTADA_PDA.md
@@ -1,0 +1,110 @@
+# Población y clientes afectados ante una interrupción del servicio
+
+Diseño y decisiones de la prueba de concepto pedida en el [issue #32](https://github.com/Boorie-AI/boorie_cliente/issues/32), el punto 1 del informe de apreciaciones adelantado como PoC.
+
+## El problema
+
+La aplicación sabía decir qué presión queda en cada nudo tras una falla, pero no **a cuánta gente deja sin agua**. Es la cifra que distingue a Boorie de EPANET estándar y la que entiende un cliente no hidráulico.
+
+Toda la cadena de cálculo ya existe en WNTR (`water_service_availability`, `population`, `population_impacted`); lo que faltaba era conectarla y decidir tres cosas que WNTR no decide por ti: qué modo de demanda usar, de dónde sale la población, y contra qué se compara el resultado.
+
+## Lo que se construye
+
+El cálculo **no es una funcionalidad aparte**: vive dentro de la simulación de interrupción del servicio (#22). Un solo botón, una sola ejecución, todos los resultados.
+
+| Pieza | Fichero |
+|---|---|
+| Cálculo | `simulate_failure` en `backend/services/hydraulic/wntr_resilience_service.py` |
+| Envoltorio TypeScript | `backend/services/hydraulic/resilienceService.ts` |
+| Handler IPC | `wntr:simulate-component-failure` (el que ya existía) |
+| Interfaz | Sección «Simulación de Interrupción del Servicio», pestaña Resiliencia |
+| Tests | `backend/services/hydraulic/resilienceService.integration.test.ts` |
+
+Se descartó un servicio separado con su propio botón: obligaba al usuario a lanzar dos simulaciones seguidas sobre el mismo evento y, sumando la corrida de #22, costaba **tres simulaciones**. `simulate_failure` ya corría una referencia sin evento y otra con él, que es exactamente lo que necesita el cálculo de población, así que ahora todo sale de **dos**.
+
+## Decisiones
+
+### 1. La simulación corre en PDA, no en DDA
+
+Es la decisión que sostiene todo lo demás, y al fusionarse con #22 pasó a aplicarse también a las presiones que esa sección ya reportaba. En modo dirigido por demanda (DDA, el que usa el resto de la aplicación) un nudo recibe el 100% de su demanda **sea cual sea su presión**. Con 5 m de columna de agua, DDA sigue entregando todo y el impacto sale cero.
+
+En PDA la entrega depende de la presión, con la ley que WNTR aplica por defecto:
+
+```
+entrega = demanda · sqrt((p − p_min) / (p_req − p_min))
+```
+
+Medido en la red de pruebas `SoloChamiseroMedioConPatronComercial-07p1.inp`, el nudo `7949` se queda en 10.56 m frente a los 20 m de servicio pleno. DDA lo da por servido; PDA le asigna una disponibilidad de 0.727 y lo cuenta como afectado. Son 2009 habitantes que el modo dirigido por demanda no ve.
+
+Parámetros por defecto: presión de servicio pleno 20 m, presión mínima 0 m, ambos ajustables.
+
+El cambio de DDA a PDA en la parte de presiones de #22 se midió antes de aplicarlo, sobre las redes `SoloChamiseroMedioConPatronComercial-07p1.inp` y `villa_100_casas.inp`: la diferencia máxima de presión nudo a nudo es de **0.03 a 0.06 m**, muy por debajo de la precisión con la que se reporta, y el recuento de nudos afectados no cambia. Lo que sí cambia son las cifras de servicio, que en DDA eran físicamente falsas.
+
+### 2. La población se recorta a cero antes de sumarla
+
+`wntr.metrics.population(wn, R)` aplica `población = demanda media / R` sin mirar el signo. En redes donde la fuente se modela como un nudo de consumo con **demanda base negativa** —el caso de la red de pruebas, nudo `1`— eso produce una población de **−4601 habitantes** que cancela exactamente a la del resto de la red y deja el total en cero.
+
+Se recortan los negativos y **se declaran aparte** en `excluded_negative_demand_nodes`, en lugar de descartarlos en silencio: el usuario tiene que poder ver que un nudo quedó fuera del cómputo y por qué.
+
+### 3. Cada cálculo corre dos veces: con evento y sin él
+
+Sin corrida de referencia, todo el déficit que la red ya arrastraba se le atribuye a la interrupción. Es un error que produce cifras alarmantes y falsas.
+
+El caso que lo demuestra en la red de pruebas: parar la bomba `6012` reporta 2009 habitantes afectados… pero la misma red **sin ningún evento** también reporta 2009. La bomba no afecta a nadie; el déficit es crónico y precede a la falla.
+
+Por eso el resultado separa tres cifras, y la interfaz destaca la tercera:
+
+| Campo | Significado |
+|---|---|
+| `baseline` | Déficit de la red sin el evento |
+| `event` | Déficit total con el evento aplicado |
+| `attributable_to_event` | La diferencia: lo que causa realmente la interrupción |
+
+Cerrando la tubería troncal `8062`: `event` 4601 hab, `baseline` 2009 hab, **atribuible 2592 hab en 3 nudos y 470.4 m³ no entregados**.
+
+### 4. El déficit se integra por intervalos, no por instantes
+
+Aplica a las dos mitades del resultado: al déficit de servicio y a las horas de corte por presión que #22 ya reportaba, que arrastraban el mismo error.
+
+Una simulación de 24 h con paso de 1 h reporta **25 instantes**. Contarlos daba «25 h de déficit» en una ventana de 24 h —imposible a simple vista— y sobreestimaba el volumen no entregado en un paso completo: 112.4 m³ frente a los 106.9 m³ reales, un 4.9% de más.
+
+Se integra por intervalos (Riemann por la izquierda) usando la diferencia real del índice temporal, así que ni las horas ni el volumen pueden exceder la ventana simulada.
+
+### 5. Los clientes se derivan de la población, y sólo si se pide
+
+El informe original proponía un campo `serviceConnections` por nudo. El formato EPANET no lo lleva, así que en esta PoC las acometidas se derivan de la población con un factor `persons_per_connection` que el usuario introduce.
+
+Si no lo introduce, **no se reportan clientes** en lugar de inventar un factor por defecto. Cuando se reportan, el resultado declara `method: 'derived_from_population'` para que la cifra no se confunda con un dato medido.
+
+Queda pendiente, cuando exista la decisión de negocio: leer acometidas reales por nudo y reportar el método correspondiente.
+
+### 6. La no convergencia se reporta, no se silencia
+
+WNTR avisa con `Exceeded maximum number of trials` cuando un paso no converge; las cifras de ese instante no son fiables. El criterio de aceptación exige que ninguna cifra venga de una estimación no simulada, así que el aviso se captura en `convergence_warnings` y la interfaz muestra una alerta en vez de presentar el número como si nada.
+
+Ocurre de hecho al cerrar las troncales `8062` y `7913` de la red de pruebas.
+
+## Trazabilidad
+
+Todo resultado incluye un bloque `traceability` con el modo de demanda, el simulador, la versión de WNTR, el módulo de demanda usado, el consumo per cápita derivado, el umbral, las presiones de PDA, la ventana simulada y el paso. Es lo que permite reproducir una cifra meses después.
+
+## Parámetros
+
+| Parámetro | Por defecto | Notas |
+|---|---|---|
+| `demand_module_lphd` | 200 | l/hab/día. Rango típico LatAm 150–300 |
+| `availability_threshold` | 0.8 | Por debajo de esta fracción el nudo cuenta como afectado |
+| `required_pressure` | 20 m | Presión de servicio pleno en PDA |
+| `minimum_pressure` | 0 m | Por debajo no se entrega nada |
+| `duration_hours` | 24 | Ventana simulada |
+| `persons_per_connection` | — | Sin valor no se reportan clientes |
+
+`R = demand_module_lphd / 1000 / 86400` convierte el módulo a los m³/s por habitante que espera `population()`.
+
+## Fuera de alcance
+
+Lo delimita el propio issue: el motor de escenarios multi-causa (`pipe_break`, `pump_outage`, `control_loss`, `demand_surge`) y la integración conversacional del motor quedan para sus tickets. Aquí sólo hay eventos simples de cierre de componente.
+
+## Deuda conocida
+
+`resilienceService.ts` y `wntrWrapper.ts` repiten el mismo `executePythonService`. Unificarlos en un único lanzador es un trabajo aparte.

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -370,6 +370,12 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   const [failureResult, setFailureResult] = useState<any>(null);
   const [failureError, setFailureError] = useState<string | null>(null);
 
+  // #32: parámetros de población, entradas de la misma simulación de interrupción
+  const [demandModuleLphd, setDemandModuleLphd] = useState<number>(200);
+  const [availabilityThreshold, setAvailabilityThreshold] = useState<number>(0.8);
+  const [requiredPressure, setRequiredPressure] = useState<number>(20);
+  const [personsPerConnection, setPersonsPerConnection] = useState<string>('');
+
   const [compareWithFailure, setCompareWithFailure] = useState(false);
   const [isCalculatingIndicators, setIsCalculatingIndicators] = useState(false);
   const [resilienceIndicatorsResult, setResilienceIndicatorsResult] = useState<any>(null);
@@ -710,19 +716,26 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
         duration_hours: failureDurationHours,
         failure_start_hours: failureStartHours,
         restore_hours: failureRestoreHours ? Number(failureRestoreHours) : undefined,
-        min_pressure_threshold: minPressureThreshold
+        min_pressure_threshold: minPressureThreshold,
+        demand_module_lphd: demandModuleLphd,
+        availability_threshold: availabilityThreshold,
+        required_pressure: requiredPressure,
+        persons_per_connection: personsPerConnection ? Number(personsPerConnection) : undefined
       });
 
       if (res.success) {
         setFailureResult(res.data);
         // Todos los afectados se resaltan de una vez: son el resultado de la
         // simulación, no algo que el usuario deba ir marcando nudo a nudo.
-        setHighlightedComponents((res.data.affected_nodes ?? []).map((n: any) => n.id));
+        const impacted = res.data.population?.event?.affected_nodes ?? [];
+        setHighlightedComponents(
+          (impacted.length ? impacted : (res.data.affected_nodes ?? [])).map((n: any) => n.id)
+        );
         if (currentProject) {
           const currentNetwork = currentProject.networks.find(n => n.name === networkData.name);
           const networkId = currentNetwork?.id || 'unknown';
           handleSaveCalculationToProject(
-            `Interrupción de Servicio: ${res.data.failed_components.join(', ')}`,
+            `Interrupción de Servicio (PDA): ${res.data.failed_components.join(', ')}`,
             networkId,
             res.data
           );
@@ -735,7 +748,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
     } finally {
       setIsSimulatingFailure(false);
     }
-  }, [networkData, failureComponentIds, failureDurationHours, failureStartHours, failureRestoreHours, minPressureThreshold, currentProject, handleSaveCalculationToProject]);
+  }, [networkData, failureComponentIds, failureDurationHours, failureStartHours, failureRestoreHours,
+      minPressureThreshold, demandModuleLphd, availabilityThreshold, requiredPressure, personsPerConnection,
+      currentProject, handleSaveCalculationToProject]);
 
   // #23: Indicadores de resiliencia
   const handleCalculateResilienceIndicators = useCallback(async () => {
@@ -1409,7 +1424,9 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                       <Zap className="h-3.5 w-3.5" /> Simulación de Interrupción del Servicio
                     </h4>
                     <p className="text-[11px] text-muted-foreground">
-                      Simula la falla de uno o más componentes (tubería, bomba, válvula) y estima el impacto sobre el servicio.
+                      Simula la falla de uno o más componentes (tubería, bomba, válvula) y estima el impacto
+                      sobre el servicio, en presiones y en habitantes sin agua. Una sola ejecución en modo PDA
+                      (demanda dependiente de la presión) devuelve ambos resultados.
                     </p>
                     <AvisoDuracion>
                       Ejecuta una simulación hidráulica completa: en redes grandes puede tardar un minuto o más.
@@ -1462,6 +1479,44 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                           className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
                         />
                       </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Módulo de demanda (l/hab/día)</div>
+                        <input
+                          type="number"
+                          value={demandModuleLphd}
+                          onChange={(e) => setDemandModuleLphd(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Umbral de servicio (0-1)</div>
+                        <input
+                          type="number"
+                          step="0.05"
+                          value={availabilityThreshold}
+                          onChange={(e) => setAvailabilityThreshold(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Presión de servicio pleno (m)</div>
+                        <input
+                          type="number"
+                          value={requiredPressure}
+                          onChange={(e) => setRequiredPressure(Number(e.target.value))}
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div className="bg-background p-2 rounded border">
+                        <div className="text-[10px] text-muted-foreground mb-1">Hab./acometida (opcional)</div>
+                        <input
+                          type="number"
+                          value={personsPerConnection}
+                          onChange={(e) => setPersonsPerConnection(e.target.value)}
+                          placeholder="sin clientes"
+                          className="w-full bg-transparent font-mono text-sm border-b border-border focus:outline-none focus:border-primary"
+                        />
+                      </div>
                     </div>
                     <Button size="sm" className="w-full" onClick={handleSimulateFailure} disabled={isSimulatingFailure}>
                       {isSimulatingFailure ? (
@@ -1480,6 +1535,13 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     {failureResult && (
                       <Card>
                         <CardContent className="p-3 text-xs space-y-2">
+                          {failureResult.convergence_warnings && !failureResult.convergence_warnings.converged && (
+                            <Alert variant="destructive" className="text-[11px]">
+                              <AlertTriangle className="h-3 w-3 inline mr-1" />
+                              La simulación no convergió en todos los pasos. Las cifras de esos instantes
+                              no son fiables.
+                            </Alert>
+                          )}
                           <div className="flex justify-between">
                             <span>Nudos afectados:</span>
                             <span className="font-mono">{failureResult.affected_node_count} / {failureResult.total_junction_count}</span>
@@ -1516,6 +1578,100 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                               </Badge>
                             ))}
                           </div>
+
+                          {failureResult.population && (
+                            <>
+                              {/* Lo atribuible al evento es la cifra que responde a la pregunta;
+                                  el total incluye el déficit que la red ya tenía sin la falla. */}
+                              <div className="pt-2 border-t">
+                                <div className="text-[10px] text-muted-foreground font-semibold">ATRIBUIBLE A LA INTERRUPCIÓN</div>
+                                <div className="grid grid-cols-3 gap-2 mt-1">
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">Habitantes</div>
+                                    <div className="font-mono text-sm">{failureResult.population.attributable_to_event.population_affected.toLocaleString()}</div>
+                                  </div>
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">Nudos</div>
+                                    <div className="font-mono text-sm">{failureResult.population.attributable_to_event.affected_node_count}</div>
+                                  </div>
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">No entregado (m³)</div>
+                                    <div className="font-mono text-sm">{failureResult.population.attributable_to_event.undelivered_volume_m3.toFixed(1)}</div>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="pt-2 border-t">
+                                <div className="text-[10px] text-muted-foreground font-semibold">TOTAL CON EL EVENTO</div>
+                                <div className="grid grid-cols-3 gap-2 mt-1">
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">Habitantes</div>
+                                    <div className="font-mono text-sm">{failureResult.population.event.population_affected.toLocaleString()}</div>
+                                  </div>
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">Déficit máx. (h)</div>
+                                    <div className="font-mono text-sm">{failureResult.population.event.max_outage_hours.toFixed(1)}</div>
+                                  </div>
+                                  <div>
+                                    <div className="text-[9px] text-muted-foreground">No entregado (m³)</div>
+                                    <div className="font-mono text-sm">{failureResult.population.event.undelivered_volume_m3.toFixed(1)}</div>
+                                  </div>
+                                </div>
+                                <div className="text-[10px] text-muted-foreground mt-1">
+                                  Sin el evento la red ya dejaba sin servicio a{' '}
+                                  {failureResult.population.baseline.population_affected.toLocaleString()} hab. de un total de{' '}
+                                  {failureResult.population.total_population.toLocaleString()}.
+                                </div>
+                              </div>
+
+                              {failureResult.population.connections && (
+                                <div className="pt-2 border-t">
+                                  <div className="text-[10px] text-muted-foreground font-semibold">CLIENTES (ACOMETIDAS)</div>
+                                  <div className="font-mono text-sm">
+                                    {failureResult.population.connections.affected_connections.toLocaleString()} de{' '}
+                                    {failureResult.population.connections.total_connections.toLocaleString()}
+                                  </div>
+                                  <div className="text-[10px] text-muted-foreground">
+                                    Derivadas de la población con {failureResult.population.connections.persons_per_connection} hab./acometida.
+                                  </div>
+                                </div>
+                              )}
+
+                              {failureResult.population.excluded_negative_demand_nodes?.length > 0 && (
+                                <div className="pt-2 border-t text-[10px] text-muted-foreground">
+                                  Excluidos {failureResult.population.excluded_negative_demand_nodes.length} nudo(s) con demanda
+                                  base negativa (fuentes modeladas como nudo de consumo):{' '}
+                                  {failureResult.population.excluded_negative_demand_nodes.map((n: any) => n.id).join(', ')}.
+                                </div>
+                              )}
+
+                              {failureResult.population.event.affected_nodes?.length > 0 && (
+                                <div className="pt-2 border-t">
+                                  <div className="text-[10px] text-muted-foreground font-semibold mb-1">HABITANTES POR NUDO</div>
+                                  <div className="max-h-40 overflow-y-auto space-y-1">
+                                    {failureResult.population.event.affected_nodes.map((n: any) => (
+                                      <div key={n.id} className="flex justify-between font-mono text-[11px]">
+                                        <span>{n.id}</span>
+                                        <span className="text-muted-foreground">
+                                          {n.population_affected.toLocaleString()} hab · {n.outage_hours.toFixed(1)} h ·{' '}
+                                          {(n.min_service_availability * 100).toFixed(1)}%
+                                        </span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
+                              <div className="pt-2 border-t text-[10px] text-muted-foreground">
+                                Trazabilidad: {failureResult.population.traceability.demand_model} ·{' '}
+                                {failureResult.population.traceability.simulator} · WNTR{' '}
+                                {failureResult.population.traceability.wntr_version} ·{' '}
+                                {failureResult.population.traceability.demand_module_lphd} l/hab/día · umbral{' '}
+                                {failureResult.population.traceability.availability_threshold} · presión de servicio{' '}
+                                {failureResult.population.traceability.required_pressure_m} m
+                              </div>
+                            </>
+                          )}
                         </CardContent>
                       </Card>
                     )}


### PR DESCRIPTION
Cierra #32.

La simulación de interrupción del servicio devuelve ahora, además del impacto en presiones, **cuántos habitantes y cuántas acometidas se quedan sin agua**. Es la cifra que distingue a Boorie de EPANET estándar y la que entiende un cliente no hidráulico.

## Una sola simulación, no dos

El cálculo va **dentro de la sección de interrupción del servicio** (#22), no como funcionalidad aparte. El usuario define el evento una vez, pulsa un botón y obtiene todos los resultados.

Un servicio separado habría obligado a lanzar dos simulaciones seguidas sobre el mismo evento y, sumando la de #22, habrían sido tres. `simulate_failure` ya corría una referencia sin evento y otra con él —justo lo que necesita el cálculo de población—, así que el coste sigue siendo de **dos corridas**.

## Decisiones

Detalle completo en `docs/POBLACION_AFECTADA_PDA.md`.

**Se simula en PDA.** En modo dirigido por demanda un nudo recibe el 100 % de su demanda sea cual sea su presión: con 10.56 m de columna de agua, DDA entrega todo y el impacto sale cero. En la red de pruebas eso oculta a 2009 habitantes.

**La población se recorta a cero antes de sumarla.** `wntr.metrics.population` no filtra signos. Un nudo-fuente modelado con demanda base negativa salía con **−4601 habitantes** y cancelaba al resto de la red, dejando el total en 0. Los nudos excluidos se declaran en el resultado.

**Cada cálculo se compara contra la red sin evento.** Sin corrida de referencia, el déficit que la red ya arrastraba se atribuye entero a la interrupción. El caso que lo demuestra: parar la bomba `6012` reporta 2009 afectados, pero la misma red sin ningún evento también reporta 2009. La bomba no afecta a nadie.

**Los clientes se derivan de la población sólo si se da el factor de acometidas**, y el resultado declara `method: derived_from_population` para que no se confunda con un dato medido. EPANET no lleva acometidas por nudo; leerlas de verdad requiere la decisión de negocio pendiente.

**La no convergencia se reporta**, no se silencia: si un paso no converge, sus cifras no son fiables y la interfaz lo advierte.

Todo resultado incluye un bloque `traceability` con modo de demanda, simulador, versión de WNTR, módulo usado, umbral, presiones y paso.

## Cambio de comportamiento en #22

Pasar a PDA afecta también a las presiones que la sección ya reportaba. **Se midió antes de aplicarlo** sobre `SoloChamiseroMedioConPatronComercial-07p1.inp` y `villa_100_casas.inp`: la diferencia máxima de presión nudo a nudo es de **0.03–0.06 m**, muy por debajo de la precisión con la que se reporta, y el recuento de nudos afectados no cambia. Lo que sí cambia son las cifras de servicio, que en DDA eran físicamente falsas.

## Fallo corregido de paso

Las horas de corte de #22 contaban instantes en vez de intervalos: una ventana de 24 h con paso de 1 h reporta 25 instantes, y el resultado daba **25 h de corte en 24 h de simulación**. En la red Chamisero el corte máximo pasa de 18 h a 17 h. El mismo error sobreestimaba el volumen no entregado en un paso completo (4.9 %).

## Verificación

- **92 tests en verde** (eran 84). Los 8 nuevos van contra el servicio Python y una red reales, sin mocks, y cada uno cubre uno de los fallos de arriba.
- `typecheck` limpio en frontend y Electron.
- **Ejecutado en la aplicación real**: red cargada desde un proyecto, formulario único, simulación completa, resultados renderizados, nudos resaltados en el mapa y cálculo persistido en el proyecto. Ahí apareció un defecto que los tests no ven: un nudo listado como afectado mostraba «80 %» con el umbral en 0.8, por redondeo de 0.79796. Corregido a un decimal.

## Extra

`.claude/skills/run-app/` añade un driver de Playwright para ejecutar y conducir la aplicación. Ejecutarla es lo que encontró el redondeo de arriba, y antes las viñetas truncadas del historial y la migración que corría dos veces por `React.StrictMode`.

## Fuera de alcance

Lo delimita el propio issue: el motor de escenarios multi-causa y su integración conversacional quedan para sus tickets. Aquí sólo hay eventos simples de cierre de componente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)