### PR TITLE
Precondiciones de navegacion y estados vacios accionables (#33)

### DIFF
--- a/docs/PRECONDICIONES_NAVEGACION.md
+++ b/docs/PRECONDICIONES_NAVEGACION.md
@@ -1,0 +1,60 @@
+# Precondiciones de navegación y estados vacíos accionables
+
+Diseño y decisiones de la funcionalidad pedida en el [issue #33](https://github.com/Boorie-AI/boorie_cliente/issues/33), punto 4 del informe de apreciaciones.
+
+## El problema, corregido tras verlo en la aplicación
+
+El issue describe «vistas en blanco sin explicación». Ejecutando la aplicación con el proyecto activo vacío, eso **no ocurre**: la vista de red ya enseñaba el selector de proyectos, y el Wisdom Center, la calculadora y el chat funcionan sin proyecto. Buena parte de lo que el issue daba por roto lo arregló #31.
+
+Lo que sí falla es otra cosa, y no es «vacío» sino **sustitución silenciosa**: pulsas «Red WNTR», el menú marca esa vista como activa, y el contenido es la lista de proyectos —idéntica a la de «Proyectos»— sin una palabra sobre por qué. El usuario no sabe si se ha equivocado, si la aplicación ha fallado, o qué le falta.
+
+A eso se suma que el menú no señalizaba nada en absoluto, y que el recorrido de primer uso terminaba en la calculadora sin llegar nunca a crear un proyecto ni cargar una red.
+
+## Lo que se construye
+
+| Pieza | Fichero |
+|---|---|
+| Tabla de precondiciones | `src/config/precondiciones.ts` |
+| Estado que la alimenta | `src/hooks/usePrecondiciones.ts` |
+| Aviso con la acción que lo resuelve | `src/components/PrecondicionAviso.tsx` |
+| Señalización en el menú | `src/components/chat/Sidebar.tsx` |
+| Recorrido de primer uso | `src/config/onboardingPasos.tsx` |
+
+## Decisiones
+
+### 1. Entrar en la vista de red no exige red cargada
+
+La tabla del issue pide «proyecto **y** red cargada» para la red WNTR. A nivel de navegación sólo se exige el proyecto: **la vista de red es justamente donde se importa el `.inp`**, así que pedir una red para entrar dejaría el módulo inalcanzable para siempre.
+
+La red sigue siendo requisito de las acciones de dentro —simular, analizar, esqueletizar—, que ya tienen su propio estado vacío con el botón de importar. El requisito `red` se mantiene en el modelo porque el chat sobre la red ([#34](https://github.com/Boorie-AI/boorie_cliente/issues/34)) lo necesitará.
+
+### 2. El ítem del menú se atenúa, pero se puede pulsar
+
+El issue pide atenuar y no ocultar, para no perder descubribilidad. Se añade además que **siga siendo accionable**: bloquearlo dejaría al usuario viendo un candado sin ninguna forma de llegar a la pantalla que le explica qué falta y se lo resuelve.
+
+El primer intento marcaba el botón con `aria-disabled="true"`. Es falso —el control sí se activa— y tiene consecuencias reales: le dice a un lector de pantalla que no se puede usar, y Playwright se niega a pulsarlo. Se sustituyó por `title` y `aria-label` con el motivo.
+
+### 3. El aviso va encima del contenido, no en su lugar
+
+Cuando falta el proyecto, la vista de red ya enseña el selector de proyectos, que es **exactamente la acción correcta**. Sustituirlo por una pantalla de «necesitas un proyecto» con un botón que lleva a otra pantalla añadiría un clic sin aportar nada.
+
+Así que el aviso se muestra como una banda encima: dice qué falta, por qué, y ofrece el botón. Lo que faltaba era la explicación, no la acción.
+
+### 4. La calculadora se queda sin requisitos
+
+Explícito en el issue, criterio del Ing. Luis Mora: hoy funciona de forma autónoma y es útil así; exigir proyecto añadiría fricción a un uso legítimo. Hay un test que lo fija, para que no se «arregle» por simetría con el resto de la tabla.
+
+### 5. El recorrido de primer uso termina en la red
+
+Los pasos eran bienvenida → IA → RAG → proyectos → calculadora, y dejaban al usuario nuevo sin proyecto ni red: justo lo que el resto de la aplicación necesita. Se añade un paso final que conduce a crear proyecto e importar el `.inp`.
+
+## De dónde sale el estado
+
+`hayProyecto` viene de `currentProjectId`, que es lo único que el store persiste y lo que ya usa la vista de red.
+
+`hayRed` cuenta las redes **guardadas** en el proyecto. La red que el visor tiene abierta vive en un `useState` dentro de `WNTRMainInterface` y el menú no puede verla; cuando #34 necesite ese dato habrá que levantar el estado en lugar de deducirlo. Hoy ninguna vista se bloquea por este requisito, así que la aproximación no puede inducir a error al usuario.
+
+## Deuda encontrada por el camino
+
+- **Hay dos tipos `ProjectData` distintos con el mismo nombre**: uno en `src/types/project.ts` (`networks: NetworkAsset[]`, contadores) y otro local en `src/stores/projectStore.ts` (`network?: any`). `WNTRMainInterface` no usa ninguno de los dos directamente: deriva su propio view-model. Unificarlos es un trabajo aparte.
+- **Los rótulos del menú estaban fijos en inglés** («Projects», «Calculator», «WNTR Network») mientras el resto usaba `t()`. Se traducen los tres, y un test nuevo comprueba que los tres idiomas mantienen exactamente las mismas claves: era fácil añadir una en español y dejar la interfaz enseñando `precondiciones.faltaProyecto` en catalán.

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -4,51 +4,11 @@ import { useTranslation } from 'react-i18next'
 import {
     ChevronRight,
     ChevronLeft,
-    Bot,
-    Database,
-    Calculator,
-    FolderTree,
     CheckCircle2,
-    Settings
 } from 'lucide-react'
 import { cn } from '@/utils/cn'
+import { ONBOARDING_STEPS } from '@/config/onboardingPasos'
 
-const ONBOARDING_STEPS = [
-    {
-        title: 'onboarding.welcome.title',
-        description: 'onboarding.welcome.desc',
-        icon: <Bot className="w-12 h-12 text-primary" />,
-        color: 'from-blue-500/20 to-cyan-500/20',
-    },
-    {
-        title: 'onboarding.ai.setup',
-        description: 'onboarding.ai.setupDesc',
-        icon: <Settings className="w-12 h-12 text-blue-500" />,
-        color: 'from-blue-500/20 to-purple-500/20',
-        action: 'settings',
-    },
-    {
-        title: 'onboarding.rag.title',
-        description: 'onboarding.rag.desc',
-        icon: <Database className="w-12 h-12 text-amber-500" />,
-        color: 'from-amber-500/20 to-orange-500/20',
-        action: 'rag',
-    },
-    {
-        title: 'onboarding.projects.title',
-        description: 'onboarding.projects.desc',
-        icon: <FolderTree className="w-12 h-12 text-emerald-500" />,
-        color: 'from-emerald-500/20 to-teal-500/20',
-        action: 'projects',
-    },
-    {
-        title: 'onboarding.calculator.title',
-        description: 'onboarding.calculator.desc',
-        icon: <Calculator className="w-12 h-12 text-rose-500" />,
-        color: 'from-rose-500/20 to-red-500/20',
-        action: 'calculator',
-    }
-]
 
 export function Onboarding() {
     const { t } = useTranslation()

--- a/src/components/PrecondicionAviso.tsx
+++ b/src/components/PrecondicionAviso.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next'
+import { FolderOpen, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAppStore } from '@/stores/appStore'
+import { usePrecondiciones } from '@/hooks/usePrecondiciones'
+import type { Vista } from '@/config/precondiciones'
+
+/**
+ * Explica qué precondición falta y ofrece el botón que la resuelve (issue #33).
+ *
+ * Se muestra **encima** del contenido de la vista, no en lugar de él: sin
+ * proyecto activo, la vista de red ya enseña el selector de proyectos, que es
+ * la acción correcta. Lo que faltaba era decir por qué aparece, porque el menú
+ * marcaba «Red WNTR» y el contenido era la lista de proyectos, idéntica a la de
+ * «Proyectos», sin ninguna explicación.
+ */
+export function PrecondicionAviso({ vista }: { vista: Vista }) {
+  const { t } = useTranslation()
+  const { pendientes } = usePrecondiciones()
+  const setCurrentView = useAppStore(s => s.setCurrentView)
+
+  const faltan = pendientes(vista)
+  if (faltan.length === 0) return null
+
+  const faltaProyecto = faltan.includes('proyecto')
+
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-3">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-foreground">
+            {t(faltaProyecto ? 'precondiciones.tituloProyecto' : 'precondiciones.tituloRed')}
+          </h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t(faltaProyecto ? 'precondiciones.descProyecto' : 'precondiciones.descRed')}
+          </p>
+        </div>
+        {faltaProyecto && (
+          <Button size="sm" variant="outline" className="shrink-0" onClick={() => setCurrentView('projects')}>
+            <FolderOpen className="h-3.5 w-3.5 mr-2" />
+            {t('precondiciones.accionElegirProyecto')}
+          </Button>
+        )}
+        {!faltaProyecto && (
+          <Button size="sm" variant="outline" className="shrink-0" onClick={() => setCurrentView('wntr')}>
+            <Plus className="h-3.5 w-3.5 mr-2" />
+            {t('precondiciones.accionImportarRed')}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -8,6 +8,7 @@ import { UnifiedWisdomPanel } from '@/components/wisdom/UnifiedWisdomPanel'
 import { HydraulicProjectsPanel } from '@/components/hydraulic/HydraulicProjectsPanel'
 import { HydraulicCalculator } from '@/components/hydraulic/HydraulicCalculator'
 import { WNTRMainInterface } from '@/components/hydraulic/WNTRMainInterface'
+import { PrecondicionAviso } from '@/components/PrecondicionAviso'
 import { cn } from '@/utils/cn'
 
 export function ChatLayout() {
@@ -53,6 +54,9 @@ export function ChatLayout() {
           sidebarCollapsed ? "ml-16" : "ml-64"
         )}
       >
+        {/* Ninguna vista queda inerte por falta de precondiciones: si algo
+            falta, se dice cuál y se ofrece la acción (#33). */}
+        <PrecondicionAviso vista={currentView} />
         {renderMainContent()}
       </div>
     </div>

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -13,9 +13,11 @@ import {
   FolderOpen,
   Calculator,
   Network,
-  ChevronDown
+  ChevronDown,
+  Lock
 } from 'lucide-react'
 import { cn } from '@/utils/cn'
+import { usePrecondiciones } from '@/hooks/usePrecondiciones'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import * as Collapsible from '@radix-ui/react-collapsible'
 import { hydraulicService } from '@/services/hydraulic/hydraulicService'
@@ -25,6 +27,7 @@ import boorieIconLight from '@/assets/boorie_icon_light.png'
 
 export function Sidebar() {
   const { t } = useTranslation()
+  const precondiciones = usePrecondiciones()
   const {
     currentView,
     setCurrentView,
@@ -69,10 +72,10 @@ export function Sidebar() {
 
   const menuItems = [
     { id: 'chat', icon: MessageSquare, label: t('sidebar.chat'), view: 'chat' as const },
-    { id: 'projects', icon: FolderOpen, label: 'Projects', view: 'projects' as const },
-    { id: 'calculator', icon: Calculator, label: 'Calculator', view: 'calculator' as const },
-    { id: 'wntr', icon: Network, label: 'WNTR Network', view: 'wntr' as const },
-    { id: 'rag', icon: FileText, label: 'Wisdom Center', view: 'rag' as const },
+    { id: 'projects', icon: FolderOpen, label: t('sidebar.projects'), view: 'projects' as const },
+    { id: 'calculator', icon: Calculator, label: t('sidebar.calculator'), view: 'calculator' as const },
+    { id: 'wntr', icon: Network, label: t('sidebar.wntr'), view: 'wntr' as const },
+    { id: 'rag', icon: FileText, label: t('sidebar.wisdom'), view: 'rag' as const },
     { id: 'settings', icon: Settings, label: t('sidebar.settings'), view: 'settings' as const },
   ]
 
@@ -131,27 +134,42 @@ export function Sidebar() {
         <div className="p-3 space-y-1 flex-shrink-0">
           {menuItems.map((item) => {
             const isActive = currentView === item.view
+            // Se atenúa, no se oculta ni se bloquea: ocultarlo haría la
+            // aplicación menos descubrible, y bloquearlo dejaría al usuario sin
+            // forma de llegar a la pantalla que le explica qué falta.
+            const motivo = precondiciones.motivo(item.view)
+            const bloqueada = motivo !== null
+            const ayuda = bloqueada ? `${item.label} — ${t(motivo)}` : item.label
             return (
               <Tooltip.Root key={item.id}>
                 <Tooltip.Trigger asChild>
                   <button
                     onClick={() => setCurrentView(item.view)}
+                    // Sin aria-disabled: el ítem sigue siendo accionable a
+                    // propósito y marcarlo como deshabilitado sería mentir al
+                    // lector de pantalla. El motivo va en el título accesible.
+                    title={bloqueada ? ayuda : undefined}
+                    aria-label={bloqueada ? ayuda : undefined}
                     className={cn(
                       "w-full flex items-center p-3 rounded-lg transition-all duration-200",
                       "hover:bg-accent hover:text-accent-foreground",
                       isActive
                         ? "bg-primary text-primary-foreground shadow-sm"
                         : "text-muted-foreground",
+                      bloqueada && !isActive && "opacity-50",
                       sidebarCollapsed && "justify-center"
                     )}
                   >
                     <item.icon size={20} />
                     {!sidebarCollapsed && <span className="ml-3 font-medium">{item.label}</span>}
+                    {!sidebarCollapsed && bloqueada && (
+                      <Lock size={12} className="ml-auto opacity-70" aria-hidden />
+                    )}
                   </button>
                 </Tooltip.Trigger>
-                {sidebarCollapsed && (
-                  <Tooltip.Content side="right" className="px-2 py-1 bg-popover text-popover-foreground text-sm rounded-md border border-border shadow-md">
-                    {item.label}
+                {(sidebarCollapsed || bloqueada) && (
+                  <Tooltip.Content side="right" className="px-2 py-1 bg-popover text-popover-foreground text-sm rounded-md border border-border shadow-md max-w-xs">
+                    {ayuda}
                   </Tooltip.Content>
                 )}
               </Tooltip.Root>

--- a/src/config/onboardingPasos.test.tsx
+++ b/src/config/onboardingPasos.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { ONBOARDING_STEPS } from './onboardingPasos'
+import es from '@/locales/es.json'
+import en from '@/locales/en.json'
+import ca from '@/locales/ca.json'
+
+const resolver = (dic: unknown, clave: string) =>
+  clave.split('.').reduce<any>((o, p) => o?.[p], dic)
+
+/**
+ * El recorrido de primer uso terminaba en la calculadora y dejaba al usuario
+ * nuevo sin proyecto ni red, que es lo que el resto de la aplicación necesita
+ * (criterio de aceptación del issue #33).
+ */
+describe('recorrido de primer uso', () => {
+  it('termina conduciendo a crear proyecto e importar red', () => {
+    const ultimo = ONBOARDING_STEPS[ONBOARDING_STEPS.length - 1]
+    expect(ultimo.action).toBe('wntr')
+    expect(ultimo.title).toBe('onboarding.red.title')
+  })
+
+  it('pasa por proyectos antes de la red', () => {
+    const acciones: (string | undefined)[] = ONBOARDING_STEPS.map(paso => paso.action)
+    expect(acciones.indexOf('projects')).toBeGreaterThan(-1)
+    expect(acciones.indexOf('projects')).toBeLessThan(acciones.indexOf('wntr'))
+  })
+
+  it('todos los pasos apuntan a una vista real de la aplicación', () => {
+    const vistas = ['chat', 'settings', 'rag', 'projects', 'calculator', 'wntr']
+    for (const paso of ONBOARDING_STEPS) {
+      if (paso.action) expect(vistas).toContain(paso.action)
+    }
+  })
+
+  it('todos los textos existen en los tres idiomas', () => {
+    for (const paso of ONBOARDING_STEPS) {
+      for (const dic of [es, en, ca]) {
+        expect(resolver(dic, paso.title), paso.title).toBeTruthy()
+        expect(resolver(dic, paso.description), paso.description).toBeTruthy()
+      }
+    }
+  })
+})

--- a/src/config/onboardingPasos.tsx
+++ b/src/config/onboardingPasos.tsx
@@ -1,0 +1,61 @@
+import {
+    Bot,
+    Database,
+    Calculator,
+    FolderTree,
+    Network,
+    Settings,
+} from 'lucide-react'
+
+/**
+ * Pasos del recorrido de primer uso (#33).
+ *
+ * Viven fuera del componente para poder testear el recorrido sin montar la
+ * interfaz, y porque exportarlos desde el componente rompe el fast refresh.
+ */
+export const ONBOARDING_STEPS = [
+    {
+        title: 'onboarding.welcome.title',
+        description: 'onboarding.welcome.desc',
+        icon: <Bot className="w-12 h-12 text-primary" />,
+        color: 'from-blue-500/20 to-cyan-500/20',
+    },
+    {
+        title: 'onboarding.ai.setup',
+        description: 'onboarding.ai.setupDesc',
+        icon: <Settings className="w-12 h-12 text-blue-500" />,
+        color: 'from-blue-500/20 to-purple-500/20',
+        action: 'settings',
+    },
+    {
+        title: 'onboarding.rag.title',
+        description: 'onboarding.rag.desc',
+        icon: <Database className="w-12 h-12 text-amber-500" />,
+        color: 'from-amber-500/20 to-orange-500/20',
+        action: 'rag',
+    },
+    {
+        title: 'onboarding.projects.title',
+        description: 'onboarding.projects.desc',
+        icon: <FolderTree className="w-12 h-12 text-emerald-500" />,
+        color: 'from-emerald-500/20 to-teal-500/20',
+        action: 'projects',
+    },
+    {
+        title: 'onboarding.calculator.title',
+        description: 'onboarding.calculator.desc',
+        icon: <Calculator className="w-12 h-12 text-rose-500" />,
+        color: 'from-rose-500/20 to-red-500/20',
+        action: 'calculator',
+    },
+    // El recorrido terminaba en la calculadora y dejaba al usuario nuevo sin
+    // proyecto ni red, que es justo lo que hace falta para el resto de la
+    // aplicación (#33). Este paso cierra el circuito.
+    {
+        title: 'onboarding.red.title',
+        description: 'onboarding.red.desc',
+        icon: <Network className="w-12 h-12 text-cyan-500" />,
+        color: 'from-cyan-500/20 to-blue-500/20',
+        action: 'wntr',
+    }
+]

--- a/src/config/precondiciones.test.ts
+++ b/src/config/precondiciones.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  REQUISITOS_VISTA,
+  requisitosPendientes,
+  vistaDisponible,
+  claveMotivo,
+  type Vista,
+} from './precondiciones'
+
+const SIN_NADA = { hayProyecto: false, hayRed: false }
+const SOLO_PROYECTO = { hayProyecto: true, hayRed: false }
+const TODO = { hayProyecto: true, hayRed: true }
+
+describe('precondiciones de navegación', () => {
+  it('deja pasar a chat, proyectos, wisdom y ajustes sin nada cargado', () => {
+    for (const vista of ['chat', 'projects', 'rag', 'settings'] as Vista[]) {
+      expect(vistaDisponible(vista, SIN_NADA)).toBe(true)
+    }
+  })
+
+  it('mantiene la calculadora autónoma', () => {
+    // Criterio explícito del issue: exigir proyecto añadiría fricción a un uso
+    // legítimo, así que esto no es un descuido de la tabla.
+    expect(REQUISITOS_VISTA.calculator).toEqual([])
+    expect(vistaDisponible('calculator', SIN_NADA)).toBe(true)
+  })
+
+  it('exige proyecto para la red WNTR', () => {
+    expect(vistaDisponible('wntr', SIN_NADA)).toBe(false)
+    expect(requisitosPendientes('wntr', SIN_NADA)).toEqual(['proyecto'])
+    expect(vistaDisponible('wntr', SOLO_PROYECTO)).toBe(true)
+  })
+
+  it('no exige red para entrar en la vista de red', () => {
+    // Es donde se carga el .inp: pedirla para entrar dejaría el módulo
+    // inalcanzable.
+    expect(REQUISITOS_VISTA.wntr).not.toContain('red')
+    expect(vistaDisponible('wntr', SOLO_PROYECTO)).toBe(true)
+  })
+
+  it('con todo cargado no queda ninguna vista bloqueada', () => {
+    for (const vista of Object.keys(REQUISITOS_VISTA) as Vista[]) {
+      expect(vistaDisponible(vista, TODO)).toBe(true)
+    }
+  })
+
+  it('explica primero el requisito más básico', () => {
+    expect(claveMotivo(['proyecto', 'red'])).toBe('precondiciones.faltaProyecto')
+    expect(claveMotivo(['red'])).toBe('precondiciones.faltaRed')
+    expect(claveMotivo([])).toBeNull()
+  })
+
+  it('cubre todas las vistas declaradas en el store', () => {
+    // Si alguien añade una vista nueva y olvida su fila, la tabla deja de ser
+    // la fuente única y volvemos a las guardas dispersas.
+    const vistas: Vista[] = ['chat', 'settings', 'rag', 'projects', 'calculator', 'wntr']
+    for (const vista of vistas) {
+      expect(REQUISITOS_VISTA[vista]).toBeDefined()
+    }
+    expect(Object.keys(REQUISITOS_VISTA).sort()).toEqual([...vistas].sort())
+  })
+})

--- a/src/config/precondiciones.ts
+++ b/src/config/precondiciones.ts
@@ -1,0 +1,65 @@
+/**
+ * Precondiciones de navegación, en un único sitio (issue #33).
+ *
+ * Antes vivían dispersas como guardas defensivas dentro de cada componente, así
+ * que ni el menú ni ninguna otra vista podían saber qué faltaba: el usuario
+ * pulsaba «WNTR Network» sin proyecto activo y la aplicación le sustituía la
+ * pantalla por la lista de proyectos sin decir por qué.
+ */
+
+import type { AppState } from '@/stores/appStore'
+
+export type Vista = AppState['currentView']
+
+/** Lo que puede faltar para usar una vista. */
+export type Requisito = 'proyecto' | 'red'
+
+export interface EstadoPrecondiciones {
+  hayProyecto: boolean
+  hayRed: boolean
+}
+
+/**
+ * Requisitos de cada vista **para entrar en ella**.
+ *
+ * El issue pide que la red WNTR exija «proyecto y red cargada». A nivel de
+ * navegación sólo se exige el proyecto: la vista de red es justamente donde se
+ * carga el .inp, así que pedir una red para entrar dejaría el módulo
+ * inalcanzable. La red sigue siendo requisito de las acciones de dentro
+ * (simular, analizar, esqueletizar), que ya tienen su propio estado vacío.
+ *
+ * La calculadora se queda sin requisitos a propósito: es útil de forma autónoma
+ * y exigir proyecto añadiría fricción a un uso legítimo (criterio del Ing. Luis
+ * Mora recogido en el issue).
+ */
+export const REQUISITOS_VISTA: Record<Vista, Requisito[]> = {
+  chat: [],
+  projects: [],
+  calculator: [],
+  wntr: ['proyecto'],
+  rag: [],
+  settings: [],
+}
+
+/** Requisitos que la vista declara y el estado actual no cumple. */
+export function requisitosPendientes(vista: Vista, estado: EstadoPrecondiciones): Requisito[] {
+  const cumple: Record<Requisito, boolean> = {
+    proyecto: estado.hayProyecto,
+    red: estado.hayRed,
+  }
+  return REQUISITOS_VISTA[vista].filter(r => !cumple[r])
+}
+
+export function vistaDisponible(vista: Vista, estado: EstadoPrecondiciones): boolean {
+  return requisitosPendientes(vista, estado).length === 0
+}
+
+/**
+ * Clave i18n que explica qué falta. Se prefiere el requisito más básico: sin
+ * proyecto no tiene sentido hablar de la red que le falta.
+ */
+export function claveMotivo(pendientes: Requisito[]): string | null {
+  if (pendientes.includes('proyecto')) return 'precondiciones.faltaProyecto'
+  if (pendientes.includes('red')) return 'precondiciones.faltaRed'
+  return null
+}

--- a/src/hooks/usePrecondiciones.ts
+++ b/src/hooks/usePrecondiciones.ts
@@ -1,0 +1,38 @@
+import { useProjectStore } from '@/stores/projectStore'
+import {
+  requisitosPendientes,
+  vistaDisponible,
+  claveMotivo,
+  type EstadoPrecondiciones,
+  type Vista,
+} from '@/config/precondiciones'
+
+/**
+ * Estado que consultan las precondiciones de navegación (issue #33).
+ *
+ * `hayProyecto` sale de `currentProjectId`, que es lo único que el store
+ * persiste y lo que ya usa la vista de red para saber dónde está.
+ *
+ * `hayRed` cuenta las redes **guardadas** en el proyecto, no la que el visor
+ * tenga abierta: esa vive en el estado local de WNTRMainInterface y el menú no
+ * puede verla. Hoy ninguna vista se bloquea por este requisito —la de red es
+ * justamente donde se importa el .inp—, así que sólo alimenta la tabla; cuando
+ * el chat necesite contexto de red (#34) habrá que levantar el estado del visor
+ * en lugar de deducirlo aquí.
+ */
+export function usePrecondiciones() {
+  const currentProjectId = useProjectStore(s => s.currentProjectId)
+  const networkCount = useProjectStore(s => s.currentProject?.networkCount)
+
+  const estado: EstadoPrecondiciones = {
+    hayProyecto: currentProjectId !== null,
+    hayRed: (networkCount ?? 0) > 0,
+  }
+
+  return {
+    estado,
+    disponible: (vista: Vista) => vistaDisponible(vista, estado),
+    pendientes: (vista: Vista) => requisitosPendientes(vista, estado),
+    motivo: (vista: Vista) => claveMotivo(requisitosPendientes(vista, estado)),
+  }
+}

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -26,7 +26,11 @@
     "collapseSidebar": "Contraer barra lateral",
     "recentChats": "Xats Recents",
     "noConversations": "Encara no hi ha converses",
-    "startNewChat": "Inicia un nou xat per començar"
+    "startNewChat": "Inicia un nou xat per començar",
+    "projects": "Projectes",
+    "calculator": "Calculadora",
+    "wntr": "Xarxa WNTR",
+    "wisdom": "Wisdom Center"
   },
   "chat": {
     "newConversation": "Nova Conversa",
@@ -207,6 +211,10 @@
     "calculator": {
       "title": "Eines d'Enginyeria",
       "desc": "Accedeix a calculadores hidràuliques integrades i anàlisi de xarxes amb WNTR de forma directa."
+    },
+    "red": {
+      "title": "Crea un projecte i carrega la teva xarxa",
+      "desc": "Les xarxes, simulacions i càlculs viuen dins d'un projecte. Crea'n un i importa el teu fitxer .inp d'EPANET: és el que desbloqueja la simulació i l'anàlisi de xarxa."
     }
   },
   "project": {
@@ -217,5 +225,16 @@
       "keep": "Continuar a «{{project}}»",
       "bodyNoActive": "La conversa que has obert pertany a «{{conversationProject}}» i ara mateix no hi ha cap projecte actiu."
     }
+  },
+  "precondiciones": {
+    "faltaProyecto": "Necessita un projecte actiu",
+    "faltaRed": "Necessita una xarxa carregada",
+    "tituloProyecto": "La xarxa hidràulica necessita un projecte actiu",
+    "descProyecto": "Tria un dels teus projectes o crea'n un de nou. Les xarxes, simulacions i càlculs es desen dins del projecte.",
+    "accionElegirProyecto": "Triar un projecte",
+    "accionCrearProyecto": "Crear un projecte",
+    "tituloRed": "Aquest mòdul necessita una xarxa carregada",
+    "descRed": "Importa un fitxer .inp d'EPANET per poder simular i analitzar.",
+    "accionImportarRed": "Importar .inp"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,7 +26,11 @@
     "collapseSidebar": "Collapse sidebar",
     "recentChats": "Recent Chats",
     "noConversations": "No conversations yet",
-    "startNewChat": "Start a new chat to begin"
+    "startNewChat": "Start a new chat to begin",
+    "projects": "Projects",
+    "calculator": "Calculator",
+    "wntr": "WNTR Network",
+    "wisdom": "Wisdom Center"
   },
   "chat": {
     "newConversation": "New Conversation",
@@ -207,6 +211,10 @@
     "calculator": {
       "title": "Engineering Tools",
       "desc": "Access integrated hydraulic calculators and network analysis with WNTR directly."
+    },
+    "red": {
+      "title": "Create a project and load your network",
+      "desc": "Networks, simulations and calculations live inside a project. Create one and import your EPANET .inp file: that is what unlocks network simulation and analysis."
     }
   },
   "project": {
@@ -217,5 +225,16 @@
       "keep": "Stay in “{{project}}”",
       "bodyNoActive": "The conversation you opened belongs to “{{conversationProject}}” and there is no active project right now."
     }
+  },
+  "precondiciones": {
+    "faltaProyecto": "Needs an active project",
+    "faltaRed": "Needs a loaded network",
+    "tituloProyecto": "The hydraulic network needs an active project",
+    "descProyecto": "Pick one of your projects or create a new one. Networks, simulations and calculations are stored inside the project.",
+    "accionElegirProyecto": "Pick a project",
+    "accionCrearProyecto": "Create a project",
+    "tituloRed": "This module needs a loaded network",
+    "descRed": "Import an EPANET .inp file to run simulations and analyses.",
+    "accionImportarRed": "Import .inp"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -26,7 +26,11 @@
     "collapseSidebar": "Contraer barra lateral",
     "recentChats": "Chats Recientes",
     "noConversations": "No hay conversaciones aún",
-    "startNewChat": "Inicia un nuevo chat para comenzar"
+    "startNewChat": "Inicia un nuevo chat para comenzar",
+    "projects": "Proyectos",
+    "calculator": "Calculadora",
+    "wntr": "Red WNTR",
+    "wisdom": "Wisdom Center"
   },
   "chat": {
     "newConversation": "Nueva Conversación",
@@ -207,6 +211,10 @@
     "calculator": {
       "title": "Herramientas de Ingeniería",
       "desc": "Accede a calculadoras hidráulicas integradas y análisis de redes con WNTR de forma directa."
+    },
+    "red": {
+      "title": "Crea un proyecto y carga tu red",
+      "desc": "Las redes, simulaciones y cálculos viven dentro de un proyecto. Crea uno e importa tu archivo .inp de EPANET: es lo que desbloquea la simulación y el análisis de red."
     }
   },
   "project": {
@@ -217,5 +225,16 @@
       "keep": "Seguir en «{{project}}»",
       "bodyNoActive": "La conversación que has abierto pertenece a «{{conversationProject}}» y ahora mismo no hay ningún proyecto activo."
     }
+  },
+  "precondiciones": {
+    "faltaProyecto": "Necesita un proyecto activo",
+    "faltaRed": "Necesita una red cargada",
+    "tituloProyecto": "La red hidráulica necesita un proyecto activo",
+    "descProyecto": "Elige uno de tus proyectos o crea uno nuevo. Las redes, simulaciones y cálculos se guardan dentro del proyecto.",
+    "accionElegirProyecto": "Elegir un proyecto",
+    "accionCrearProyecto": "Crear un proyecto",
+    "tituloRed": "Este módulo necesita una red cargada",
+    "descRed": "Importa un archivo .inp de EPANET para poder simular y analizar.",
+    "accionImportarRed": "Importar .inp"
   }
 }

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import es from './es.json'
+import en from './en.json'
+import ca from './ca.json'
+
+/**
+ * Los tres idiomas se editan a mano en cada funcionalidad, así que es fácil
+ * añadir una clave en español y olvidarla en catalán: la interfaz enseña
+ * entonces la clave cruda («precondiciones.faltaProyecto») en lugar del texto.
+ */
+function claves(obj: unknown, prefijo = ''): string[] {
+  if (typeof obj !== 'object' || obj === null) return [prefijo]
+  return Object.entries(obj as Record<string, unknown>)
+    .flatMap(([k, v]) => claves(v, prefijo ? `${prefijo}.${k}` : k))
+}
+
+describe('ficheros de idioma', () => {
+  it('los tres idiomas tienen exactamente las mismas claves', () => {
+    const base = claves(es).sort()
+    expect(claves(en).sort()).toEqual(base)
+    expect(claves(ca).sort()).toEqual(base)
+  })
+
+  it('ninguna traducción queda vacía', () => {
+    for (const [nombre, dic] of [['es', es], ['en', en], ['ca', ca]] as const) {
+      const vacias = claves(dic).filter(k => {
+        const valor = k.split('.').reduce<any>((o, p) => o?.[p], dic)
+        return typeof valor === 'string' && valor.trim() === ''
+      })
+      expect(vacias, `claves vacías en ${nombre}`).toEqual([])
+    }
+  })
+
+  it('las precondiciones de navegación están traducidas en los tres idiomas', () => {
+    for (const dic of [es, en, ca]) {
+      const p = (dic as any).precondiciones
+      expect(p?.faltaProyecto).toBeTruthy()
+      expect(p?.tituloProyecto).toBeTruthy()
+      expect(p?.accionElegirProyecto).toBeTruthy()
+      expect((dic as any).sidebar?.wntr).toBeTruthy()
+      expect((dic as any).onboarding?.red?.title).toBeTruthy()
+    }
+  })
+})

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -11,6 +11,8 @@ interface ProjectData {
   location: any
   regulations: any[]
   network?: any
+  /** Contador que devuelve el IPC de proyectos; lo consumen las precondiciones (#33). */
+  networkCount?: number
   calculations: any[]
   documents: any[]
   team: any[]


### PR DESCRIPTION
Closes #33.

Ninguna vista queda sin explicación por falta de precondiciones: si algo falta, se dice cuál y se ofrece el botón que lo resuelve.

## El diagnóstico del issue no coincide con lo que hace hoy la aplicación

El issue habla de «vistas en blanco sin explicación». Ejecutando la aplicación sin proyecto activo, **eso no ocurre**: la vista de red ya mostraba el selector de proyectos, y el chat, la calculadora y el Wisdom Center funcionan sin nada cargado. Buena parte de lo que el issue daba por roto lo arregló #31.

Lo que sí falla es otra cosa, y no es «vacío» sino **sustitución silenciosa**: pulsas «Red WNTR», el menú marca esa vista como activa, y el contenido es la lista de proyectos —idéntica a la de «Proyectos»— sin una palabra sobre por qué. El usuario no sabe si se equivocó, si la aplicación falló, o qué le falta.

A eso se suma que el menú no señalizaba nada, y que el recorrido de primer uso terminaba en la calculadora sin llegar nunca a crear un proyecto ni cargar una red.

## Decisiones

Detalle completo en `docs/PRECONDICIONES_NAVEGACION.md`.

**Entrar en la vista de red no exige red cargada**, aunque la tabla del issue lo pida. Esa vista es justamente donde se importa el `.inp`: exigir una red para entrar dejaría el módulo inalcanzable para siempre. La red sigue siendo requisito de las acciones de dentro —simular, analizar, esqueletizar—, que ya tienen su propio estado vacío. El requisito se mantiene en el modelo porque el chat sobre la red (#34) lo necesitará.

**El ítem atenuado sigue siendo pulsable.** El issue pide atenuar y no ocultar, para no perder descubribilidad; se añade que siga siendo accionable, porque bloquearlo dejaría al usuario viendo un candado sin ninguna forma de llegar a la pantalla que le explica qué falta y se lo resuelve.

**El aviso va encima del contenido, no en su lugar.** Sin proyecto, el selector de proyectos ya era la acción correcta. Sustituirlo por una pantalla de «necesitas un proyecto» con un botón que lleva a otra pantalla añadiría un clic sin aportar nada: lo que faltaba era la explicación, no la acción.

**La calculadora se queda sin requisitos**, criterio explícito del Ing. Luis Mora recogido en el issue. Hay un test que lo fija, para que no se «arregle» por simetría con el resto de la tabla.

## Un fallo introducido y detectado ejecutando la aplicación

El primer intento marcaba el botón bloqueado con `aria-disabled="true"`. Es **falso** —el control sí se activa a propósito— y tiene consecuencias reales: le dice a un lector de pantalla que no se puede usar, y Playwright se negó a pulsarlo, que es como se detectó. Sustituido por `title` y `aria-label` con el motivo.

## Verificación

- **106 tests en verde** (eran 92). Los 14 nuevos cubren la tabla de precondiciones, el recorrido de primer uso y la coherencia de los tres idiomas.
- `typecheck` limpio en frontend y Electron; lint sin warnings nuevos.
- **Ciclo completo comprobado en la aplicación**: menú atenuado sin proyecto → clic → aviso con acción → seleccionar proyecto → aviso, atenuado y tooltip desaparecen.
- **Primer arranque probado sobre una copia de la base de datos**, no sobre la real. La primera pasada no valía: el tutorial aparecía pero el aviso de precondición no, porque `currentProjectId` vive en `localStorage` y no en la base, así que el proyecto de una sesión anterior seguía activo. Repetido sin esa clave: 6 pasos, el último conduce a la vista de red, y al finalizar el usuario aterriza en el aviso con su botón.

## Deuda encontrada por el camino

- **Hay dos tipos `ProjectData` distintos con el mismo nombre**: uno en `src/types/project.ts` (`networks: NetworkAsset[]`, contadores) y otro local en `src/stores/projectStore.ts` (`network?: any`). `WNTRMainInterface` no usa ninguno: deriva su propio view-model. Unificarlos es un trabajo aparte.
- **Los rótulos del menú estaban fijos en inglés** («Projects», «Calculator», «WNTR Network») mientras el resto usaba `t()`. Se traducen los tres, y un test nuevo comprueba que los tres idiomas mantienen exactamente las mismas claves: era fácil añadir una en español y dejar la interfaz enseñando `precondiciones.faltaProyecto` en catalán.
- **`hayRed` cuenta las redes guardadas del proyecto**, no la que el visor tiene abierta: esa vive en un `useState` dentro de `WNTRMainInterface` y el menú no puede verla. Hoy ninguna vista se bloquea por ese requisito, así que la aproximación no puede inducir a error; cuando #34 lo necesite habrá que levantar el estado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)