### PR TITLE
feat(chat): el agente responde con datos de la red activa (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ rag-knowledge/
 # Temporary files
 *.tmp
 temp.inp
+temp.rpt
+temp.bin
 app_log.txt
 
 # Bug reports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `./dev-start.sh` - Full development setup with complete build
 
 ### Testing
-- No formal test framework configured in package.json
+- `npm test` - Run the full Vitest suite once
+- `npm run test:watch` - Vitest in watch mode
+- `npm run test:ui` - Vitest UI
+- `npm run test:coverage` - Coverage report (v8 provider, text + html)
+- Run a single file with `npx vitest run <path>`
+- Config lives in the `test` block of `vite.config.ts`: `happy-dom` environment,
+  globals enabled, setup in `src/test/setup.ts`, and it picks up
+  `src/**/*.{test,spec}.{ts,tsx}` plus `backend/**/*.{test,spec}.ts`
+- Tests sit next to the code they cover (e.g. `backend/services/hydraulic/networkContext.test.ts`)
+- Suites that need a real resource (the SQLite database, a Python install) guard
+  themselves with `describe.skipIf(...)` so they skip instead of failing where it is absent
 - `test-files/` directory contains EPANET .inp files and test results for hydraulic simulations
 - Manual testing scripts in root directory for system verification:
   - `test-*.js` - Various functionality tests (RAG, WNTR, IPC, database, etc.)

--- a/backend/services/ai/toolWire.test.ts
+++ b/backend/services/ai/toolWire.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { HERRAMIENTAS } from '../hydraulic/agentTools'
 import {
   esErrorDeHerramientas,
+  proveedorSoportaHerramientas,
   herramientasAnthropic,
   herramientasOpenAI,
   llamadasDesdeAnthropic,
@@ -187,5 +188,31 @@ describe('deteccion del rechazo de herramientas', () => {
     expect(esErrorDeHerramientas(400, 'Your credit balance is too low')).toBe(false)
     expect(esErrorDeHerramientas(401, 'invalid api key')).toBe(false)
     expect(esErrorDeHerramientas(429, 'rate limited, too many tool calls')).toBe(false)
+  })
+})
+
+describe('que proveedores saben usar herramientas', () => {
+  it('los cinco cuyo dialecto esta implementado', () => {
+    for (const p of ['anthropic', 'openai', 'openrouter', 'nvidia', 'ollama']) {
+      expect(proveedorSoportaHerramientas(p), p).toBe(true)
+    }
+  })
+
+  it('Google no, porque usa functionDeclarations', () => {
+    // Si esto pasa a true sin implementar el dialecto, el prompt promete una
+    // consulta que el modelo no puede hacer.
+    expect(proveedorSoportaHerramientas('google')).toBe(false)
+  })
+
+  it('el nombre llega de la conversacion, asi que se normaliza', () => {
+    expect(proveedorSoportaHerramientas('Ollama')).toBe(true)
+    expect(proveedorSoportaHerramientas(' Anthropic ')).toBe(true)
+  })
+
+  it('sin proveedor no se presume soporte', () => {
+    expect(proveedorSoportaHerramientas(undefined)).toBe(false)
+    expect(proveedorSoportaHerramientas(null)).toBe(false)
+    expect(proveedorSoportaHerramientas('')).toBe(false)
+    expect(proveedorSoportaHerramientas('un-proveedor-nuevo')).toBe(false)
   })
 })

--- a/backend/services/ai/toolWire.test.ts
+++ b/backend/services/ai/toolWire.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import { HERRAMIENTAS } from '../hydraulic/agentTools'
+import {
+  esErrorDeHerramientas,
+  herramientasAnthropic,
+  herramientasOpenAI,
+  llamadasDesdeAnthropic,
+  llamadasDesdeOpenAI,
+  llamadasDesdeOllama,
+  mensajeResultadosAnthropic,
+  mensajesResultadosOpenAI,
+  textoDesdeAnthropic,
+} from './toolWire'
+
+describe('declaracion de herramientas por dialecto', () => {
+  it('Anthropic las quiere con input_schema', () => {
+    const [primera] = herramientasAnthropic(HERRAMIENTAS)
+    expect(primera.name).toBe('consultar_elemento')
+    expect(primera.input_schema.type).toBe('object')
+    expect(primera.description.length).toBeGreaterThan(0)
+  })
+
+  it('OpenAI las quiere envueltas en function.parameters', () => {
+    const [primera] = herramientasOpenAI(HERRAMIENTAS)
+    expect(primera.type).toBe('function')
+    expect(primera.function.name).toBe('consultar_elemento')
+    expect(primera.function.parameters.type).toBe('object')
+  })
+
+  it('el esquema es el mismo objeto en los dos: no se duplica ni se desfasa', () => {
+    expect(herramientasAnthropic(HERRAMIENTAS)[0].input_schema)
+      .toEqual(herramientasOpenAI(HERRAMIENTAS)[0].function.parameters)
+  })
+})
+
+describe('lectura de las llamadas que pide el modelo', () => {
+  it('Anthropic: bloques tool_use dentro de content', () => {
+    const llamadas = llamadasDesdeAnthropic({
+      stop_reason: 'tool_use',
+      content: [
+        { type: 'text', text: 'Voy a mirarlo.' },
+        { type: 'tool_use', id: 'toolu_01', name: 'consultar_elemento', input: { id: 'J3' } },
+      ],
+    })
+    expect(llamadas).toEqual([{ id: 'toolu_01', nombre: 'consultar_elemento', argumentos: { id: 'J3' } }])
+  })
+
+  it('OpenAI: tool_calls con los argumentos como cadena JSON', () => {
+    // La diferencia que mas facil es pasar por alto: aqui arguments es texto.
+    const llamadas = llamadasDesdeOpenAI({
+      choices: [{ message: { tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'listar_elementos', arguments: '{"tipo":"pipe"}' } },
+      ] } }],
+    })
+    expect(llamadas).toEqual([{ id: 'call_1', nombre: 'listar_elementos', argumentos: { tipo: 'pipe' } }])
+  })
+
+  it('Ollama: cuelga de message y trae los argumentos ya como objeto', () => {
+    // Comprobado contra un Ollama real con nemotron-mini: ni choices[] ni
+    // arguments como cadena, que son las dos suposiciones faciles de arrastrar
+    // desde OpenAI.
+    const llamadas = llamadasDesdeOllama({
+      message: {
+        role: 'assistant',
+        content: ' ',
+        tool_calls: [
+          { id: 'call_gr5yrl3m', function: { index: 0, name: 'consultar_elemento', arguments: { id: 'J3' } } },
+        ],
+      },
+    })
+    expect(llamadas).toEqual([{ id: 'call_gr5yrl3m', nombre: 'consultar_elemento', argumentos: { id: 'J3' } }])
+  })
+
+  it('Ollama sin id de llamada: se fabrica uno en vez de mandar vacio', () => {
+    const llamadas = llamadasDesdeOllama({
+      message: { tool_calls: [{ function: { name: 'listar_elementos', arguments: { tipo: 'pipe' } } }] },
+    })
+    expect(llamadas[0].id).toBe('call_0')
+  })
+
+  it('desenvuelve los argumentos que el modelo mete en otro sobre', () => {
+    // nemotron-mini emite esto de forma consistente en vez de {"id":"121"}.
+    // Sin deshacerlo, la herramienta responde «falta el argumento id» con el
+    // modelo convencido de que lo mando.
+    const llamadas = llamadasDesdeOllama({
+      message: { tool_calls: [{ id: 'c', function: {
+        name: 'consultar_elemento',
+        arguments: { type: 'consultar_elemento', arguments: { id: '121' } },
+      } }] },
+    })
+    expect(llamadas[0].argumentos).toEqual({ id: '121' })
+  })
+
+  it('no desenvuelve cuando «arguments» es un argumento de verdad', () => {
+    // Si al lado hay datos con sustancia, el sobre no es un sobre.
+    const llamadas = llamadasDesdeOllama({
+      message: { tool_calls: [{ id: 'c', function: {
+        name: 'x',
+        arguments: { id: '121', arguments: { algo: 1 } },
+      } }] },
+    })
+    expect(llamadas[0].argumentos).toEqual({ id: '121', arguments: { algo: 1 } })
+  })
+
+  it('una respuesta sin herramientas no produce llamadas', () => {
+    expect(llamadasDesdeAnthropic({ content: [{ type: 'text', text: 'hola' }] })).toEqual([])
+    expect(llamadasDesdeOpenAI({ choices: [{ message: { content: 'hola' } }] })).toEqual([])
+    expect(llamadasDesdeOllama({ message: { content: 'hola' } })).toEqual([])
+  })
+
+  it('unos argumentos con JSON roto no tumban la conversacion', () => {
+    // Pasa con modelos pequenos. Se entrega objeto vacio: la herramienta
+    // respondera que falta el argumento y el modelo puede rectificar.
+    const llamadas = llamadasDesdeOpenAI({
+      choices: [{ message: { tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'consultar_elemento', arguments: '{"id": ' } },
+      ] } }],
+    })
+    expect(llamadas[0].argumentos).toEqual({})
+  })
+
+  it('sin argumentos tampoco falla', () => {
+    const llamadas = llamadasDesdeOpenAI({
+      choices: [{ message: { tool_calls: [{ id: 'c', function: { name: 'x' } }] } }],
+    })
+    expect(llamadas[0].argumentos).toEqual({})
+  })
+})
+
+describe('devolucion de resultados', () => {
+  const resultados = [
+    { llamada: { id: 'a', nombre: 'consultar_elemento', argumentos: {} }, salida: { encontrado: true } },
+    { llamada: { id: 'b', nombre: 'listar_elementos', argumentos: {} }, salida: { total: 6 } },
+  ]
+
+  it('Anthropic: un solo mensaje de usuario con un bloque por llamada', () => {
+    // Mandar un mensaje por resultado da 400.
+    const mensaje = mensajeResultadosAnthropic(resultados)
+    expect(mensaje.role).toBe('user')
+    expect(mensaje.content).toHaveLength(2)
+    expect(mensaje.content[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'a' })
+    expect(JSON.parse(mensaje.content[1].content)).toEqual({ total: 6 })
+  })
+
+  it('OpenAI: un mensaje role tool por llamada', () => {
+    const mensajes = mensajesResultadosOpenAI(resultados)
+    expect(mensajes).toHaveLength(2)
+    expect(mensajes[0]).toMatchObject({ role: 'tool', tool_call_id: 'a' })
+    expect(JSON.parse(mensajes[1].content)).toEqual({ total: 6 })
+  })
+
+  it('los ids vuelven tal cual: emparejarlos mal rompe la conversacion', () => {
+    expect(mensajeResultadosAnthropic(resultados).content.map(b => b.tool_use_id)).toEqual(['a', 'b'])
+    expect(mensajesResultadosOpenAI(resultados).map(m => m.tool_call_id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('texto final de Anthropic', () => {
+  it('junta los bloques de texto y descarta los de herramienta', () => {
+    // data.content[0].text no vale cuando el primer bloque es un tool_use.
+    const texto = textoDesdeAnthropic({
+      content: [
+        { type: 'tool_use', id: 't', name: 'consultar_elemento', input: {} },
+        { type: 'text', text: 'El nudo J3 ' },
+        { type: 'text', text: 'tiene 8 m de cota.' },
+      ],
+    })
+    expect(texto).toBe('El nudo J3 tiene 8 m de cota.')
+  })
+
+  it('sin bloques de texto devuelve cadena vacia', () => {
+    expect(textoDesdeAnthropic({ content: [] })).toBe('')
+    expect(textoDesdeAnthropic({})).toBe('')
+  })
+})
+
+describe('deteccion del rechazo de herramientas', () => {
+  it('reconoce el 400 que se queja de tools o functions', () => {
+    expect(esErrorDeHerramientas(400, 'Tools are not supported for this model')).toBe(true)
+    expect(esErrorDeHerramientas(404, 'No endpoints found that support tool use')).toBe(true)
+    expect(esErrorDeHerramientas(422, 'function calling unavailable')).toBe(true)
+  })
+
+  it('no confunde un 400 cualquiera con uno de herramientas', () => {
+    // Reintentar sin herramientas un error de credito o de clave solo gasta
+    // otra llamada y devuelve el mismo fallo.
+    expect(esErrorDeHerramientas(400, 'Your credit balance is too low')).toBe(false)
+    expect(esErrorDeHerramientas(401, 'invalid api key')).toBe(false)
+    expect(esErrorDeHerramientas(429, 'rate limited, too many tool calls')).toBe(false)
+  })
+})

--- a/backend/services/ai/toolWire.ts
+++ b/backend/services/ai/toolWire.ts
@@ -1,0 +1,163 @@
+/**
+ * Traduccion entre las herramientas de Boorie y el formato de cable de cada
+ * proveedor (#34).
+ *
+ * Son dos dialectos y medio, no cinco: Anthropic tiene el suyo; OpenAI,
+ * OpenRouter y NVIDIA comparten el de OpenAI porque los tres exponen
+ * /chat/completions; y Ollama habla ese mismo con dos desvios. Se aisla aqui
+ * para que el bucle de `chat.handler` no se llene de ramas por proveedor y para
+ * poder contrastar la traduccion en tests, sin red.
+ */
+
+import type { DefinicionHerramienta } from '../hydraulic/agentTools'
+
+/** Una peticion de herramienta ya normalizada, venga del proveedor que venga. */
+export interface LlamadaHerramienta {
+  /** Identificador que el proveedor asigna, y que hay que devolverle tal cual. */
+  id: string
+  nombre: string
+  argumentos: Record<string, unknown>
+}
+
+export function herramientasAnthropic(defs: DefinicionHerramienta[]) {
+  return defs.map(d => ({
+    name: d.nombre,
+    description: d.descripcion,
+    input_schema: d.esquema,
+  }))
+}
+
+export function herramientasOpenAI(defs: DefinicionHerramienta[]) {
+  return defs.map(d => ({
+    type: 'function' as const,
+    function: {
+      name: d.nombre,
+      description: d.descripcion,
+      parameters: d.esquema,
+    },
+  }))
+}
+
+/**
+ * Algunos modelos vuelven a envolver los argumentos dentro de otro sobre con la
+ * forma de la llamada entera. nemotron-mini emite esto en vez de {"id":"121"}:
+ *
+ *   {"type": "consultar_elemento", "arguments": {"id": "121"}}
+ *
+ * Sin deshacerlo, la herramienta recibe un objeto sin `id` y responde que falta
+ * el argumento, con el modelo convencido de que lo mando. Se pela el sobre solo
+ * cuando es inequivoco: una clave `arguments` que contiene un objeto, y nada
+ * mas de sustancia al lado.
+ */
+function desenvolver(args: Record<string, unknown>): Record<string, unknown> {
+  const dentro = args.arguments
+  if (!dentro || typeof dentro !== 'object' || Array.isArray(dentro)) return args
+  const alLado = Object.keys(args).filter(k => k !== 'arguments' && k !== 'type' && k !== 'name')
+  return alLado.length === 0 ? (dentro as Record<string, unknown>) : args
+}
+
+/**
+ * Los argumentos llegan como objeto en Anthropic y como cadena JSON en OpenAI.
+ * Un modelo puede emitir JSON invalido, y eso no debe tumbar la conversacion:
+ * se devuelve un objeto vacio y la herramienta respondera que falta el
+ * argumento, que el modelo sabe corregir en la vuelta siguiente.
+ */
+function parsearArgumentos(bruto: unknown): Record<string, unknown> {
+  if (bruto && typeof bruto === 'object') return desenvolver(bruto as Record<string, unknown>)
+  if (typeof bruto === 'string' && bruto.trim()) {
+    try {
+      const parsed = JSON.parse(bruto)
+      if (parsed && typeof parsed === 'object') return desenvolver(parsed as Record<string, unknown>)
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+export function llamadasDesdeAnthropic(data: any): LlamadaHerramienta[] {
+  if (!Array.isArray(data?.content)) return []
+  return data.content
+    .filter((b: any) => b?.type === 'tool_use')
+    .map((b: any) => ({
+      id: String(b.id),
+      nombre: String(b.name),
+      argumentos: parsearArgumentos(b.input),
+    }))
+}
+
+export function llamadasDesdeOpenAI(data: any): LlamadaHerramienta[] {
+  const llamadas = data?.choices?.[0]?.message?.tool_calls
+  if (!Array.isArray(llamadas)) return []
+  return llamadas.map((c: any) => ({
+    id: String(c.id),
+    nombre: String(c.function?.name ?? ''),
+    argumentos: parsearArgumentos(c.function?.arguments),
+  }))
+}
+
+/**
+ * Ollama es casi el dialecto de OpenAI, con dos diferencias que hay que tratar:
+ * la respuesta cuelga de `message` y no de `choices[0].message`, y los
+ * argumentos llegan ya como objeto en vez de como cadena JSON. Ademas no toda
+ * version rellena el `id` de la llamada, asi que se fabrica uno estable por
+ * posicion: si no, el tool_call_id de vuelta iria vacio.
+ */
+export function llamadasDesdeOllama(data: any): LlamadaHerramienta[] {
+  const llamadas = data?.message?.tool_calls
+  if (!Array.isArray(llamadas)) return []
+  return llamadas.map((c: any, i: number) => ({
+    id: String(c.id || `call_${i}`),
+    nombre: String(c.function?.name ?? ''),
+    argumentos: parsearArgumentos(c.function?.arguments),
+  }))
+}
+
+/**
+ * Anthropic quiere todos los resultados en un unico mensaje de usuario, con un
+ * bloque tool_result por llamada; mandar uno por mensaje da 400. OpenAI quiere
+ * lo contrario: un mensaje role:'tool' por cada tool_call.
+ */
+export function mensajeResultadosAnthropic(
+  resultados: Array<{ llamada: LlamadaHerramienta; salida: unknown }>
+) {
+  return {
+    role: 'user' as const,
+    content: resultados.map(({ llamada, salida }) => ({
+      type: 'tool_result' as const,
+      tool_use_id: llamada.id,
+      content: JSON.stringify(salida),
+    })),
+  }
+}
+
+export function mensajesResultadosOpenAI(
+  resultados: Array<{ llamada: LlamadaHerramienta; salida: unknown }>
+) {
+  return resultados.map(({ llamada, salida }) => ({
+    role: 'tool' as const,
+    tool_call_id: llamada.id,
+    content: JSON.stringify(salida),
+  }))
+}
+
+/** Texto de la respuesta, ignorando los bloques que no son texto. */
+export function textoDesdeAnthropic(data: any): string {
+  if (!Array.isArray(data?.content)) return ''
+  return data.content
+    .filter((b: any) => b?.type === 'text')
+    .map((b: any) => b.text)
+    .join('')
+}
+
+/**
+ * Un 400 por herramientas no soportadas no se puede prever con una lista de
+ * modelos: OpenRouter y NVIDIA sirven cientos, y la lista envejeceria mal. Se
+ * detecta el fallo y se reintenta sin herramientas, que es peor respuesta pero
+ * no un error en la cara del usuario.
+ */
+export function esErrorDeHerramientas(status: number, mensaje: string): boolean {
+  if (status !== 400 && status !== 404 && status !== 422) return false
+  const m = mensaje.toLowerCase()
+  return m.includes('tool') || m.includes('function')
+}

--- a/backend/services/ai/toolWire.ts
+++ b/backend/services/ai/toolWire.ts
@@ -19,6 +19,20 @@ export interface LlamadaHerramienta {
   argumentos: Record<string, unknown>
 }
 
+/**
+ * Proveedores cuyo dialecto de herramientas esta implementado. Es la unica
+ * fuente de verdad: la usa el despacho de `chat.handler` para decidir si
+ * cargar la red, y `network-repo:context` para no prometer en el prompt una
+ * consulta que ese proveedor no puede hacer.
+ *
+ * Google falta a proposito: usa functionDeclarations, otro dialecto.
+ */
+const PROVEEDORES_CON_HERRAMIENTAS = new Set(['anthropic', 'openai', 'openrouter', 'nvidia', 'ollama'])
+
+export function proveedorSoportaHerramientas(proveedor?: string | null): boolean {
+  return !!proveedor && PROVEEDORES_CON_HERRAMIENTAS.has(proveedor.trim().toLowerCase())
+}
+
 export function herramientasAnthropic(defs: DefinicionHerramienta[]) {
   return defs.map(d => ({
     name: d.nombre,

--- a/backend/services/hydraulic/agentTools.test.ts
+++ b/backend/services/hydraulic/agentTools.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { execFileSync } from 'child_process'
+import { HERRAMIENTAS, ejecutarHerramienta, type RedCompleta } from './agentTools'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const DB = path.join(REPO_ROOT, 'prisma', 'hydraulic.db')
+
+const RED: RedCompleta = {
+  nodes: [
+    { id: 'J1', type: 'junction', elevation: 10, demand: 0.000231, pattern: 'P1', x: -71.29, y: 42.34 },
+    { id: 'J2', type: 'junction', elevation: 12, demand: 0.000462 },
+    { id: 'J3', type: 'junction', elevation: 8, demand: 0.000115 },
+    { id: 'R1', type: 'reservoir', total_head: 0 },
+    { id: 'T1', type: 'tank', elevation: 15, init_level: 2, min_level: 0.5, max_level: 3.5, diameter: 4 },
+  ],
+  links: [
+    { id: 'P1', type: 'pipe', from: 'R1', to: 'J1', length: 200, diameter: 0.075, roughness: 100, status: 'Open' },
+    { id: 'P2', type: 'pipe', from: 'J1', to: 'J2', length: 150, diameter: 0.05, roughness: 100, status: 'Open' },
+    { id: 'P3', type: 'pipe', from: 'J2', to: 'J3', length: 400, diameter: 0.1, roughness: 100, status: 'Open' },
+    { id: 'B1', type: 'pump', from: 'T1', to: 'J3', pump_type: 'HEAD', pump_curve: '1', speed: 1, status: 'Closed' },
+  ],
+}
+
+describe('definiciones de las herramientas', () => {
+  it('declaran esquema de objeto con los obligatorios marcados', () => {
+    // Los tres dialectos (Anthropic, OpenAI, Google) exigen JSON Schema de tipo
+    // objeto; un esquema mal formado lo rechaza la API, no el test.
+    for (const h of HERRAMIENTAS) {
+      expect(h.esquema.type, h.nombre).toBe('object')
+      expect(Object.keys(h.esquema.properties).length, h.nombre).toBeGreaterThan(0)
+      for (const obligatorio of h.esquema.required ?? []) {
+        expect(h.esquema.properties, h.nombre).toHaveProperty(obligatorio)
+      }
+    }
+  })
+})
+
+describe('consultar_elemento', () => {
+  it('devuelve el nudo con los tramos que llegan a el', () => {
+    const r = ejecutarHerramienta('consultar_elemento', { id: 'J1' }, RED) as any
+    expect(r.encontrado).toBe(true)
+    expect(r.elemento.id).toBe('J1')
+    expect(r.elemento.cota_m).toBe(10)
+    expect(r.tramos_conectados.map((t: any) => t.id).sort()).toEqual(['P1', 'P2'])
+  })
+
+  it('devuelve el tramo con sus dos nudos extremos', () => {
+    const r = ejecutarHerramienta('consultar_elemento', { id: 'P2' }, RED) as any
+    expect(r.encontrado).toBe(true)
+    expect(r.elemento.desde).toBe('J1')
+    expect(r.elemento.hasta).toBe('J2')
+    expect(r.nudos_extremos.map((n: any) => n.id)).toEqual(['J1', 'J2'])
+  })
+
+  it('entrega diametros en mm y demandas en L/s, no en unidades de WNTR', () => {
+    // WNTR normaliza a SI: 0.075 m y 0.000231 m3/s. Son numeros que el modelo
+    // lee mal o redondea a cero, asi que la conversion se hace aqui.
+    const nudo = ejecutarHerramienta('consultar_elemento', { id: 'J1' }, RED) as any
+    expect(nudo.elemento.demanda_base_litros_por_segundo).toBe(0.231)
+    const tramo = ejecutarHerramienta('consultar_elemento', { id: 'P1' }, RED) as any
+    expect(tramo.elemento.diametro_mm).toBe(75)
+    expect(tramo.elemento.longitud_m).toBe(200)
+  })
+
+  it('acepta el id en minusculas', () => {
+    // Los modelos escriben «j3» donde el .inp pone «J3».
+    const r = ejecutarHerramienta('consultar_elemento', { id: 'j3' }, RED) as any
+    expect(r.encontrado).toBe(true)
+    expect(r.elemento.id).toBe('J3')
+  })
+
+  it('con un id inexistente lo dice y ofrece candidatos, en vez de callar', () => {
+    // El modelo necesita con que decir «ese nudo no esta en tu red». Un error
+    // seco invita justo a lo que #34 quiere evitar: rellenar el hueco.
+    const r = ejecutarHerramienta('consultar_elemento', { id: 'J99' }, RED) as any
+    expect(r.encontrado).toBe(false)
+    expect(r.error).toContain('J99')
+    expect(r.ids_parecidos.length).toBeGreaterThan(0)
+  })
+
+  it('sin id devuelve error en lugar de un resultado vacio', () => {
+    const r = ejecutarHerramienta('consultar_elemento', {}, RED) as any
+    expect(r.error).toContain('id')
+  })
+
+  it('describe la bomba con sus campos propios', () => {
+    const r = ejecutarHerramienta('consultar_elemento', { id: 'B1' }, RED) as any
+    expect(r.elemento.tipo).toBe('pump')
+    expect(r.elemento.tipo_bomba).toBe('HEAD')
+    expect(r.elemento.estado).toBe('Closed')
+    expect(r.elemento.longitud_m).toBeUndefined()
+  })
+})
+
+describe('listar_elementos', () => {
+  it('cuenta y devuelve los elementos de un tipo', () => {
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'junction' }, RED) as any
+    expect(r.total).toBe(3)
+    expect(r.elementos).toHaveLength(3)
+  })
+
+  it('ordena de mayor a menor por defecto', () => {
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'pipe', ordenar_por: 'length' }, RED) as any
+    expect(r.elementos.map((e: any) => e.id)).toEqual(['P3', 'P1', 'P2'])
+  })
+
+  it('ordena al reves cuando se pide', () => {
+    const r = ejecutarHerramienta(
+      'listar_elementos',
+      { tipo: 'pipe', ordenar_por: 'length', descendente: false },
+      RED
+    ) as any
+    expect(r.elementos.map((e: any) => e.id)).toEqual(['P2', 'P1', 'P3'])
+  })
+
+  it('avisa cuando recorta, para que no presente una parte como el todo', () => {
+    // Sin el aviso, el modelo ensena dos tuberias como si fueran las tres.
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'pipe', limite: 2 }, RED) as any
+    expect(r.devueltos).toBe(2)
+    expect(r.total).toBe(3)
+    expect(r.aviso).toContain('2 de 3')
+  })
+
+  it('no deja pedir mas de 50 elementos aunque se pidan', () => {
+    const muchos: RedCompleta = {
+      nodes: Array.from({ length: 200 }, (_, i) => ({ id: `J${i}`, type: 'junction', demand: i / 1000 })),
+      links: [],
+    }
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'junction', limite: 500 }, muchos) as any
+    expect(r.devueltos).toBe(50)
+    expect(r.total).toBe(200)
+  })
+
+  it('rechaza ordenar nudos por una magnitud de tramo', () => {
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'junction', ordenar_por: 'length' }, RED) as any
+    expect(r.error).toContain('length')
+  })
+
+  it('rechaza un tipo que no existe', () => {
+    const r = ejecutarHerramienta('listar_elementos', { tipo: 'hidrante' }, RED) as any
+    expect(r.error).toContain('hidrante')
+  })
+})
+
+it('una herramienta desconocida se responde con error, no lanza', () => {
+  // El error viaja al modelo como resultado: puede rectificar o explicarlo.
+  const r = ejecutarHerramienta('borrar_red', {}, RED) as any
+  expect(r.error).toContain('borrar_red')
+})
+
+/**
+ * Contraste con las redes guardadas: `Net3 2.inp` tiene 92 nudos y 117 tramos,
+ * que es el caso que justifica las herramientas (no cabe en el resumen).
+ */
+describe.skipIf(!fs.existsSync(DB))('contraste con las redes guardadas', () => {
+  const leerRedes = (): Array<{ nombre: string; datos: RedCompleta }> => {
+    const salida = execFileSync('python3', ['-c', `
+import sqlite3, json, sys
+c = sqlite3.connect(${JSON.stringify(DB)})
+filas = [{'nombre': n, 'datos': json.loads(d)} for n, d in c.execute('select name, networkData from hydraulic_networks')]
+json.dump(filas, sys.stdout)
+`], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+    return JSON.parse(salida)
+  }
+
+  it('todo id de la red se puede consultar y se encuentra', () => {
+    for (const { nombre, datos } of leerRedes()) {
+      for (const n of datos.nodes ?? []) {
+        const r = ejecutarHerramienta('consultar_elemento', { id: n.id }, datos) as any
+        expect(r.encontrado, `${nombre} / ${n.id}`).toBe(true)
+      }
+      for (const l of datos.links ?? []) {
+        const r = ejecutarHerramienta('consultar_elemento', { id: l.id }, datos) as any
+        expect(r.encontrado, `${nombre} / ${l.id}`).toBe(true)
+      }
+    }
+  })
+
+  it('el listado nunca supera el tope aunque la red sea grande', () => {
+    for (const { nombre, datos } of leerRedes()) {
+      const r = ejecutarHerramienta('listar_elementos', { tipo: 'pipe', limite: 999 }, datos) as any
+      expect(r.devueltos, nombre).toBeLessThanOrEqual(50)
+      expect(r.total, nombre).toBe((datos.links ?? []).filter(l => l.type === 'pipe').length)
+    }
+  })
+
+  it('el resultado de una consulta cabe holgadamente en el prompt', () => {
+    // Un nudo de Net3 con todos sus tramos no puede acercarse al tamano de la
+    // red entera: si lo hiciera, las herramientas no resolverian nada.
+    for (const { nombre, datos } of leerRedes()) {
+      for (const n of datos.nodes ?? []) {
+        const r = ejecutarHerramienta('consultar_elemento', { id: n.id }, datos)
+        expect(JSON.stringify(r).length, `${nombre} / ${n.id}`).toBeLessThan(4000)
+      }
+    }
+  })
+})

--- a/backend/services/hydraulic/agentTools.ts
+++ b/backend/services/hydraulic/agentTools.ts
@@ -1,0 +1,282 @@
+/**
+ * Herramientas que el agente puede llamar para consultar la red activa (#34).
+ *
+ * El resumen de `networkContext.ts` son doce lineas fijas: sirve para que el
+ * agente sepa de que red se habla, no para responder sobre un nudo concreto.
+ * En `Net3 2.inp` hay 92 nudos y 117 tramos, y volcarlos todos en el prompt no
+ * es una opcion. De ahi el segundo nivel de detalle bajo demanda que el issue
+ * dejaba fuera de alcance.
+ *
+ * Modulo puro a proposito, igual que networkContext: recibe la red ya leida y
+ * devuelve datos, sin tocar la base ni Electron.
+ */
+
+export interface NodoRed {
+  id: string
+  label?: string
+  type: string
+  x?: number | null
+  y?: number | null
+  elevation?: number | null
+  demand?: number | null
+  pattern?: string | null
+  total_head?: number | null
+  init_level?: number | null
+  min_level?: number | null
+  max_level?: number | null
+  diameter?: number | null
+}
+
+export interface TramoRed {
+  id: string
+  label?: string
+  type: string
+  from?: string
+  to?: string
+  length?: number | null
+  diameter?: number | null
+  roughness?: number | null
+  status?: string | null
+  pump_type?: string | null
+  pump_curve?: string | null
+  speed?: number | null
+}
+
+export interface RedCompleta {
+  nodes?: NodoRed[]
+  links?: TramoRed[]
+}
+
+export interface DefinicionHerramienta {
+  nombre: string
+  descripcion: string
+  esquema: {
+    type: 'object'
+    properties: Record<string, unknown>
+    required?: string[]
+  }
+}
+
+/** Lo que devuelve una herramienta, ya listo para serializar hacia el modelo. */
+export type ResultadoHerramienta = Record<string, unknown>
+
+const TIPOS_NODO = ['junction', 'tank', 'reservoir']
+const TIPOS_TRAMO = ['pipe', 'pump', 'valve']
+
+/** Tope duro de elementos por respuesta: 117 tramos no caben en el prompt. */
+const LIMITE_MAXIMO = 50
+const LIMITE_POR_DEFECTO = 10
+
+export const HERRAMIENTAS: DefinicionHerramienta[] = [
+  {
+    nombre: 'consultar_elemento',
+    descripcion:
+      'Devuelve los datos de un nudo (junction, tank, reservoir) o de un tramo (pipe, pump, valve) ' +
+      'de la red activa, buscandolo por su identificador. Para un nudo incluye ademas los tramos ' +
+      'conectados a el. Usala siempre que la pregunta mencione un elemento concreto por su id, ' +
+      'en lugar de responder de memoria.',
+    esquema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          // Sin la advertencia, nemotron-mini copiaba el prefijo del ejemplo y
+          // pedia «J121» para un nudo que en la red se llama «121».
+          description:
+            'Identificador exacto del elemento, copiado tal cual de la red. Puede ser numerico ("121") ' +
+            'o alfanumerico ("J3"): usa el que aparezca en la pregunta sin anadirle ni quitarle prefijos.',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    nombre: 'listar_elementos',
+    descripcion:
+      'Lista los elementos de la red activa de un tipo dado, opcionalmente ordenados por una magnitud. ' +
+      'Usala para preguntas agregadas ("las tuberias mas largas", "los nudos de mayor demanda", ' +
+      '"cuantas bombas hay"). Devuelve como mucho 50 elementos.',
+    esquema: {
+      type: 'object',
+      properties: {
+        tipo: {
+          type: 'string',
+          enum: [...TIPOS_NODO, ...TIPOS_TRAMO],
+          description: 'Tipo de elemento a listar.',
+        },
+        ordenar_por: {
+          type: 'string',
+          enum: ['demand', 'elevation', 'length', 'diameter'],
+          description:
+            'Magnitud por la que ordenar. demand y elevation solo aplican a nudos; length y diameter, a tramos. ' +
+            'Si se omite, se devuelven en el orden del archivo.',
+        },
+        descendente: {
+          type: 'boolean',
+          description: 'De mayor a menor. Por defecto true cuando se ordena.',
+        },
+        limite: {
+          type: 'number',
+          description: `Cuantos elementos devolver (por defecto ${LIMITE_POR_DEFECTO}, maximo ${LIMITE_MAXIMO}).`,
+        },
+      },
+      required: ['tipo'],
+    },
+  },
+]
+
+const mm = (metros?: number | null) =>
+  typeof metros === 'number' ? Math.round(metros * 1000) : null
+
+const ls = (m3s?: number | null) =>
+  typeof m3s === 'number' ? Number((m3s * 1000).toFixed(3)) : null
+
+/**
+ * Las unidades se convierten aqui, no en el modelo. WNTR normaliza a SI al
+ * cargar el .inp, asi que los diametros vienen en metros y las demandas en
+ * m3/s: numeros como 0.075 o 0.000231 que el modelo tiende a leer mal o a
+ * redondear. Se le entregan ya en mm y L/s, con el nombre de campo diciendo la
+ * unidad, para que no tenga que hacer aritmetica.
+ *
+ * El nombre del campo va sin abreviar: probando con nemotron-mini, un
+ * `demanda_base_ls` se leyo en voz alta como «Ligado a tierra». El numero era
+ * correcto, la unidad inventada.
+ */
+function describirNodo(n: NodoRed): ResultadoHerramienta {
+  const datos: ResultadoHerramienta = { id: n.id, tipo: n.type }
+  if (typeof n.elevation === 'number') datos.cota_m = n.elevation
+  if (typeof n.demand === 'number') datos.demanda_base_litros_por_segundo = ls(n.demand)
+  if (n.pattern) datos.patron = n.pattern
+  if (typeof n.total_head === 'number') datos.altura_total_m = n.total_head
+  if (typeof n.init_level === 'number') datos.nivel_inicial_m = n.init_level
+  if (typeof n.min_level === 'number') datos.nivel_minimo_m = n.min_level
+  if (typeof n.max_level === 'number') datos.nivel_maximo_m = n.max_level
+  if (n.type === 'tank' && typeof n.diameter === 'number') datos.diametro_deposito_m = n.diameter
+  if (typeof n.x === 'number' && typeof n.y === 'number') datos.coordenadas = [n.x, n.y]
+  return datos
+}
+
+function describirTramo(l: TramoRed): ResultadoHerramienta {
+  const datos: ResultadoHerramienta = { id: l.id, tipo: l.type, desde: l.from, hasta: l.to }
+  if (typeof l.length === 'number') datos.longitud_m = l.length
+  if (typeof l.diameter === 'number') datos.diametro_mm = mm(l.diameter)
+  if (typeof l.roughness === 'number') datos.rugosidad = l.roughness
+  if (l.status) datos.estado = l.status
+  if (l.pump_type) datos.tipo_bomba = l.pump_type
+  if (l.pump_curve) datos.curva_bomba = l.pump_curve
+  if (typeof l.speed === 'number') datos.velocidad_giro = l.speed
+  return datos
+}
+
+/**
+ * Con un id que no existe se devuelven candidatos parecidos en vez de un error
+ * seco: el modelo puede corregir el tiro en la siguiente llamada, y sobre todo
+ * tiene con que decir «ese nudo no esta en tu red» en lugar de inventarselo,
+ * que es justo lo que #34 quiere evitar.
+ */
+function sugerencias(id: string, ids: string[]): string[] {
+  const buscado = id.trim().toLowerCase()
+  const parecidos = ids.filter(otro => {
+    const o = otro.toLowerCase()
+    return o.includes(buscado) || buscado.includes(o)
+  })
+  return (parecidos.length ? parecidos : ids).slice(0, 10)
+}
+
+function consultarElemento(argumentos: Record<string, unknown>, red: RedCompleta): ResultadoHerramienta {
+  const id = typeof argumentos.id === 'string' ? argumentos.id.trim() : ''
+  if (!id) return { error: 'Falta el argumento "id".' }
+
+  const nodos = red.nodes ?? []
+  const tramos = red.links ?? []
+
+  // Insensible a mayusculas: los modelos escriben "j3" donde el .inp pone "J3".
+  const igual = (a: string) => a.toLowerCase() === id.toLowerCase()
+
+  const nodo = nodos.find(n => igual(n.id))
+  if (nodo) {
+    const conectados = tramos.filter(l => igual(l.from ?? '') || igual(l.to ?? ''))
+    return {
+      encontrado: true,
+      elemento: describirNodo(nodo),
+      tramos_conectados: conectados.map(describirTramo),
+    }
+  }
+
+  const tramo = tramos.find(l => igual(l.id))
+  if (tramo) {
+    const extremos = [tramo.from, tramo.to]
+      .map(ext => nodos.find(n => n.id === ext))
+      .filter((n): n is NodoRed => !!n)
+    return {
+      encontrado: true,
+      elemento: describirTramo(tramo),
+      nudos_extremos: extremos.map(describirNodo),
+    }
+  }
+
+  return {
+    encontrado: false,
+    error: `No hay ningun elemento con id "${id}" en la red activa.`,
+    ids_parecidos: sugerencias(id, [...nodos.map(n => n.id), ...tramos.map(l => l.id)]),
+  }
+}
+
+function listarElementos(argumentos: Record<string, unknown>, red: RedCompleta): ResultadoHerramienta {
+  const tipo = typeof argumentos.tipo === 'string' ? argumentos.tipo.toLowerCase() : ''
+  if (!TIPOS_NODO.includes(tipo) && !TIPOS_TRAMO.includes(tipo)) {
+    return { error: `Tipo no reconocido: "${tipo}". Validos: ${[...TIPOS_NODO, ...TIPOS_TRAMO].join(', ')}.` }
+  }
+
+  const esNodo = TIPOS_NODO.includes(tipo)
+  const todos: Array<NodoRed | TramoRed> = esNodo
+    ? (red.nodes ?? []).filter(n => n.type === tipo)
+    : (red.links ?? []).filter(l => l.type === tipo)
+
+  const campo = typeof argumentos.ordenar_por === 'string' ? argumentos.ordenar_por : null
+  const camposValidos = esNodo ? ['demand', 'elevation'] : ['length', 'diameter']
+  if (campo && !camposValidos.includes(campo)) {
+    return { error: `No se puede ordenar ${tipo} por "${campo}". Validos: ${camposValidos.join(', ')}.` }
+  }
+
+  const ordenados = [...todos]
+  if (campo) {
+    const descendente = argumentos.descendente !== false
+    const valor = (e: NodoRed | TramoRed) => {
+      const v = (e as unknown as Record<string, unknown>)[campo]
+      return typeof v === 'number' ? v : -Infinity
+    }
+    ordenados.sort((a, b) => (descendente ? valor(b) - valor(a) : valor(a) - valor(b)))
+  }
+
+  const pedido = typeof argumentos.limite === 'number' ? argumentos.limite : LIMITE_POR_DEFECTO
+  const limite = Math.max(1, Math.min(LIMITE_MAXIMO, Math.floor(pedido)))
+  const pagina = ordenados.slice(0, limite)
+
+  return {
+    tipo,
+    total: todos.length,
+    devueltos: pagina.length,
+    // Que el recorte sea explicito: si el modelo no sabe que hay mas, presenta
+    // diez tuberias como si fueran las 117 de la red.
+    ...(todos.length > pagina.length
+      ? { aviso: `Se muestran ${pagina.length} de ${todos.length}. Pide un limite mayor o afina la consulta si necesitas el resto.` }
+      : {}),
+    elementos: pagina.map(e => (esNodo ? describirNodo(e as NodoRed) : describirTramo(e as TramoRed))),
+  }
+}
+
+export function ejecutarHerramienta(
+  nombre: string,
+  argumentos: Record<string, unknown>,
+  red: RedCompleta
+): ResultadoHerramienta {
+  switch (nombre) {
+    case 'consultar_elemento':
+      return consultarElemento(argumentos, red)
+    case 'listar_elementos':
+      return listarElementos(argumentos, red)
+    default:
+      return { error: `Herramienta desconocida: "${nombre}".` }
+  }
+}

--- a/backend/services/hydraulic/networkContext.test.ts
+++ b/backend/services/hydraulic/networkContext.test.ts
@@ -85,6 +85,33 @@ describe('resumen de la red para el agente', () => {
     expect(texto).toContain('Tuberías: 6')
   })
 
+  it('con herramientas, manda consultar en vez de estimar', () => {
+    const texto = formatearContextoRed(construirResumenRed(VILLA), true)
+    expect(texto).toContain('usa las')
+    expect(texto).toContain('herramientas de consulta')
+    expect(texto).toContain('No estimes lo que puedes mirar')
+  })
+
+  it('sin herramientas, no promete una consulta que no puede hacer', () => {
+    // Con Google el dialecto no está implementado y no hay herramientas.
+    // Decirle que consulte le pide justo la invención que el bloque evita.
+    const texto = formatearContextoRed(construirResumenRed(VILLA))
+    expect(texto).toContain('no puedes consultar nudos ni tramos concretos')
+    expect(texto).not.toContain('herramientas de consulta')
+  })
+
+  it('por defecto no hay herramientas: quien no lo sabe, no promete', () => {
+    expect(formatearContextoRed(construirResumenRed(VILLA)))
+      .toBe(formatearContextoRed(construirResumenRed(VILLA), false))
+  })
+
+  it('el chat general no menciona herramientas en ningún caso', () => {
+    // Sin red no se ofrece ninguna, la soporte el proveedor o no.
+    for (const conHerramientas of [true, false]) {
+      expect(formatearContextoRed(null, conHerramientas)).not.toContain('herramientas')
+    }
+  })
+
   it('cita la última simulación cuando existe, y lo dice cuando no', () => {
     const con = formatearContextoRed(construirResumenRed({
       ...VILLA,

--- a/backend/services/hydraulic/networkContext.test.ts
+++ b/backend/services/hydraulic/networkContext.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { execFileSync } from 'child_process'
+import { construirResumenRed, formatearContextoRed, type EntradaResumen } from './networkContext'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const DB = path.join(REPO_ROOT, 'prisma', 'hydraulic.db')
+
+const VILLA: EntradaResumen = {
+  nombreRed: 'villa_100_casas.inp',
+  contadores: { junctions: 5, tanks: 1, reservoirs: 1, pipes: 6, pumps: 0, valves: 0 },
+  datos: {
+    nodes: [{ demand: 0.000231 }, { demand: 0.000231 }, { demand: 0.000231 }, { demand: 0.000231 }, { demand: 0.000231 }],
+    links: [
+      { length: 200, diameter: 0.1 }, { length: 150, diameter: 0.075 },
+      { length: 180, diameter: 0.075 }, { length: 200, diameter: 0.05 },
+      { length: 150, diameter: 0.05 }, { length: 150, diameter: 0.05 },
+    ],
+    coordinate_system: { type: 'geographic', epsg: null },
+  },
+}
+
+describe('resumen de la red para el agente', () => {
+  it('suma longitudes y demandas de la red', () => {
+    const r = construirResumenRed(VILLA)
+    expect(r.longitudTotalM).toBe(1030)
+    expect(r.demandaTotalM3s).toBeCloseTo(0.001155, 6)
+    expect(r.diametroMinMm).toBe(50)
+    expect(r.diametroMaxMm).toBe(100)
+  })
+
+  it('ignora las demandas negativas', () => {
+    // Una demanda base negativa modela una entrada de agua, no un consumo:
+    // sumarla restaría del total y daría una demanda menor que la real.
+    const r = construirResumenRed({
+      ...VILLA,
+      datos: { ...VILLA.datos, nodes: [{ demand: 0.01 }, { demand: -0.008 }, { demand: 0.002 }] },
+    })
+    expect(r.demandaTotalM3s).toBeCloseTo(0.012, 6)
+  })
+
+  it('no inventa un EPSG que la red no trae', () => {
+    // En las redes reales el epsg viene a null; decir «EPSG:null» o suponer uno
+    // sería peor que declarar simplemente que son geográficas.
+    expect(construirResumenRed(VILLA).sistemaCoordenadas).toBe('geográficas (lat/lon)')
+    const proyectada = construirResumenRed({
+      ...VILLA,
+      datos: { ...VILLA.datos, coordinate_system: { type: 'projected', units: 'feet', epsg: null } },
+    })
+    expect(proyectada.sistemaCoordenadas).toBe('proyectadas (feet)')
+    const conEpsg = construirResumenRed({
+      ...VILLA,
+      datos: { ...VILLA.datos, coordinate_system: { type: 'projected', epsg: 25831 } },
+    })
+    expect(conEpsg.sistemaCoordenadas).toBe('EPSG:25831')
+  })
+
+  it('sin proyecto, declara el chat general y acota lo que puede responder', () => {
+    // Sin proyecto no es un estado degradado sino el chat general: responde de
+    // forma general y con la base de conocimiento, pero no sobre redes que no
+    // tiene delante.
+    const texto = formatearContextoRed(null)
+    expect(texto).toContain('=== CHAT GENERAL ===')
+    expect(texto).toContain('esto es el chat general')
+    expect(texto).toContain('base de conocimiento')
+    expect(texto).toContain('No describas ninguna red concreta')
+    expect(texto).toContain('ingeniería hidráulica y redes de agua')
+    expect(texto).not.toMatch(/Nudos de consumo/)
+  })
+
+  it('sin red, prohíbe también los ejemplos numéricos', () => {
+    // Con el texto anterior, llama3.2 pedía más datos pero soltaba un «Ejemplo»
+    // con 5 tuberías y 500 metros, que un usuario distraído puede leer como su
+    // red.
+    expect(formatearContextoRed(null)).toContain('tampoco inventes ejemplos numéricos')
+  })
+
+  it('el texto lleva las cifras que se le pasan, en unidades legibles', () => {
+    const texto = formatearContextoRed(construirResumenRed(VILLA))
+    expect(texto).toContain('Red: villa_100_casas.inp')
+    expect(texto).toContain('1.03 km')     // 1030 m
+    expect(texto).toContain('1.16 L/s')    // 0.001155 m3/s
+    expect(texto).toContain('Nudos de consumo: 5')
+    expect(texto).toContain('Tuberías: 6')
+  })
+
+  it('cita la última simulación cuando existe, y lo dice cuando no', () => {
+    const con = formatearContextoRed(construirResumenRed({
+      ...VILLA,
+      ultimaSimulacion: { nombre: 'Interrupción de Servicio (PDA): P2', fecha: '2026-08-18T22:16:36.000Z' },
+    }))
+    expect(con).toContain('Interrupción de Servicio (PDA): P2')
+    expect(con).toContain('2026-08-18')
+    expect(formatearContextoRed(construirResumenRed(VILLA))).toContain('ninguna todavía')
+  })
+})
+
+/**
+ * Contraste contra las redes realmente guardadas: el criterio de aceptación
+ * pide que las cifras del agente coincidan con las de la red, así que se
+ * comprueban contra la base de datos y no sólo contra un objeto inventado.
+ */
+describe.skipIf(!fs.existsSync(DB))('contraste con las redes guardadas', () => {
+  const leerRedes = () => {
+    const salida = execFileSync('python3', ['-c', `
+import sqlite3, json, sys
+c = sqlite3.connect(${JSON.stringify(DB)})
+filas = []
+for name, summary, nd in c.execute('select name, summary, networkData from hydraulic_networks'):
+    filas.append({'nombreRed': name, 'contadores': json.loads(summary), 'datos': json.loads(nd)})
+json.dump(filas, sys.stdout)
+`], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+    return JSON.parse(salida) as EntradaResumen[]
+  }
+
+  it('los contadores del resumen son los que guarda la red', () => {
+    for (const red of leerRedes()) {
+      const r = construirResumenRed(red)
+      expect(r.pipes, red.nombreRed).toBe(red.contadores.pipes ?? 0)
+      expect(r.junctions, red.nombreRed).toBe(red.contadores.junctions ?? 0)
+      expect(r.pumps, red.nombreRed).toBe(red.contadores.pumps ?? 0)
+    }
+  })
+
+  it('longitud y demanda salen positivas y coherentes con el número de tramos', () => {
+    for (const red of leerRedes()) {
+      const r = construirResumenRed(red)
+      expect(r.longitudTotalM, red.nombreRed).toBeGreaterThan(0)
+      expect(r.demandaTotalM3s, red.nombreRed).toBeGreaterThanOrEqual(0)
+      // Cada tramo aporta longitud: el total no puede ser menor que el mayor.
+      const maxTramo = Math.max(...(red.datos.links ?? []).map(l => l.length ?? 0))
+      expect(r.longitudTotalM, red.nombreRed).toBeGreaterThanOrEqual(maxTramo)
+    }
+  })
+})

--- a/backend/services/hydraulic/networkContext.ts
+++ b/backend/services/hydraulic/networkContext.ts
@@ -121,8 +121,15 @@ const MARCA_GLOBAL_FIN = '=== FIN CHAT GENERAL ==='
  * Texto que se inyecta en el prompt de sistema. Incluye la instrucción de no
  * inventar: el criterio del issue es que sin red el agente lo diga, en lugar de
  * responder generalidades como si fueran de la red del usuario.
+ *
+ * `conHerramientas` cambia el cierre del bloque, y no es un detalle de estilo:
+ * con herramientas hay que empujar al modelo a consultar en vez de suponer, y
+ * sin ellas prometerle una consulta que no puede hacer es pedirle justo la
+ * invención que el resto del texto trata de evitar. Lo decide el proveedor de
+ * la conversación (ver `proveedorSoportaHerramientas`), así que por defecto va
+ * a `false`: si el llamante no lo sabe, mejor no prometer.
  */
-export function formatearContextoRed(resumen: ResumenRed | null): string {
+export function formatearContextoRed(resumen: ResumenRed | null, conHerramientas = false): string {
   if (!resumen) {
     // Sin proyecto seleccionado esto es el chat general de Boorie. No es un
     // estado degradado: es un modo con sus propias reglas, y hay que decirlas,
@@ -168,12 +175,23 @@ export function formatearContextoRed(resumen: ResumenRed | null): string {
     lineas.push('Última simulación guardada: ninguna todavía.')
   }
 
-  lineas.push(
-    'Estas cifras vienen de la red cargada. Cíñete a ellas y no las completes con supuestos:',
-    'si te preguntan algo que no está aquí, dilo y ofrece ejecutar la simulación o el análisis que haga falta.',
-    MARCA_FIN,
-    '',
-  )
+  lineas.push('Estas cifras vienen de la red cargada. Cíñete a ellas y no las completes con supuestos.')
+
+  if (conHerramientas) {
+    lineas.push(
+      'Este resumen es sólo el total: no trae los nudos ni los tramos uno a uno. Para cualquier',
+      'pregunta sobre un elemento concreto, o sobre un dato que no aparezca arriba, usa las',
+      'herramientas de consulta antes de responder. No estimes lo que puedes mirar.',
+    )
+  } else {
+    lineas.push(
+      'Este resumen es todo lo que tienes de la red: no puedes consultar nudos ni tramos concretos.',
+      'Si te preguntan por uno, dilo con claridad en lugar de estimarlo, y ofrece ejecutar la',
+      'simulación o el análisis que haga falta.',
+    )
+  }
+
+  lineas.push(MARCA_FIN, '')
 
   return lineas.join('\n')
 }

--- a/backend/services/hydraulic/networkContext.ts
+++ b/backend/services/hydraulic/networkContext.ts
@@ -1,0 +1,179 @@
+/**
+ * Resumen de la red activa para el agente del chat (issue #34).
+ *
+ * Antes el contexto del proyecto decía «Network model: loaded (EPANET .inp data
+ * available for this project)» y ni una cifra más. Eso es peor que no decir
+ * nada: el modelo sabe que existe una red, no tiene ningún dato sobre ella, y
+ * nada le impide rellenar el hueco con generalidades presentadas como propias
+ * de la red del usuario.
+ *
+ * Módulo puro a propósito: recibe lo que ya está guardado y devuelve texto, sin
+ * tocar la base ni Electron, para poder contrastarlo contra redes reales.
+ */
+
+/** Contadores tal como los guarda `HydraulicNetwork.summary`. */
+export interface ContadoresRed {
+  junctions?: number
+  tanks?: number
+  reservoirs?: number
+  pipes?: number
+  pumps?: number
+  valves?: number
+  patterns?: number
+  curves?: number
+}
+
+/** Subconjunto de `HydraulicNetwork.networkData` que se necesita. */
+export interface DatosRed {
+  nodes?: Array<{ demand?: number | null }>
+  links?: Array<{ length?: number | null; diameter?: number | null }>
+  coordinate_system?: { type?: string; units?: string; epsg?: number | null }
+}
+
+export interface SimulacionCitada {
+  nombre: string
+  fecha: Date | string
+}
+
+export interface EntradaResumen {
+  nombreRed: string
+  contadores: ContadoresRed
+  datos: DatosRed
+  /** Última simulación guardada para esta red, si la hay. */
+  ultimaSimulacion?: SimulacionCitada | null
+}
+
+export interface ResumenRed {
+  nombre: string
+  junctions: number
+  tanks: number
+  reservoirs: number
+  pipes: number
+  pumps: number
+  valves: number
+  /** Suma de longitudes de tramo, en metros. */
+  longitudTotalM: number
+  /** Suma de demandas base positivas, en m3/s. */
+  demandaTotalM3s: number
+  diametroMinMm: number | null
+  diametroMaxMm: number | null
+  sistemaCoordenadas: string | null
+  ultimaSimulacion: SimulacionCitada | null
+}
+
+/**
+ * WNTR normaliza a SI al cargar el .inp, así que las longitudes vienen en
+ * metros, los diámetros en metros y las demandas en m3/s aunque el fichero
+ * original estuviera en pies o en galones.
+ */
+export function construirResumenRed(entrada: EntradaResumen): ResumenRed {
+  const { contadores, datos } = entrada
+  const links = datos.links ?? []
+  const nodes = datos.nodes ?? []
+
+  const longitudTotalM = links.reduce((total, l) => total + (l.length ?? 0), 0)
+
+  // Sólo las demandas positivas: una demanda base negativa modela una entrada
+  // de agua, no un consumo, y sumarla restaría del total (mismo caso que en
+  // docs/POBLACION_AFECTADA_PDA.md).
+  const demandaTotalM3s = nodes.reduce((total, n) => {
+    const d = n.demand ?? 0
+    return d > 0 ? total + d : total
+  }, 0)
+
+  const diametros = links
+    .map(l => l.diameter)
+    .filter((d): d is number => typeof d === 'number' && d > 0)
+
+  const cs = datos.coordinate_system
+  let sistemaCoordenadas: string | null = null
+  if (cs?.epsg) {
+    sistemaCoordenadas = `EPSG:${cs.epsg}`
+  } else if (cs?.type) {
+    // El epsg viene a null en las redes reales, así que se dice lo que se sabe
+    // (geográficas o proyectadas) en lugar de inventar un código.
+    sistemaCoordenadas = cs.type === 'geographic' ? 'geográficas (lat/lon)' : `proyectadas${cs.units ? ` (${cs.units})` : ''}`
+  }
+
+  return {
+    nombre: entrada.nombreRed,
+    junctions: contadores.junctions ?? 0,
+    tanks: contadores.tanks ?? 0,
+    reservoirs: contadores.reservoirs ?? 0,
+    pipes: contadores.pipes ?? 0,
+    pumps: contadores.pumps ?? 0,
+    valves: contadores.valves ?? 0,
+    longitudTotalM,
+    demandaTotalM3s,
+    diametroMinMm: diametros.length ? Math.round(Math.min(...diametros) * 1000) : null,
+    diametroMaxMm: diametros.length ? Math.round(Math.max(...diametros) * 1000) : null,
+    sistemaCoordenadas,
+    ultimaSimulacion: entrada.ultimaSimulacion ?? null,
+  }
+}
+
+const MARCA_INICIO = '=== RED HIDRÁULICA ACTIVA ==='
+const MARCA_FIN = '=== FIN RED HIDRÁULICA ==='
+const MARCA_GLOBAL_INICIO = '=== CHAT GENERAL ==='
+const MARCA_GLOBAL_FIN = '=== FIN CHAT GENERAL ==='
+
+/**
+ * Texto que se inyecta en el prompt de sistema. Incluye la instrucción de no
+ * inventar: el criterio del issue es que sin red el agente lo diga, en lugar de
+ * responder generalidades como si fueran de la red del usuario.
+ */
+export function formatearContextoRed(resumen: ResumenRed | null): string {
+  if (!resumen) {
+    // Sin proyecto seleccionado esto es el chat general de Boorie. No es un
+    // estado degradado: es un modo con sus propias reglas, y hay que decirlas,
+    // porque callar deja la respuesta a merced de la disposición del modelo.
+    return [
+      MARCA_GLOBAL_INICIO,
+      'No hay ningún proyecto ni red hidráulica cargados: esto es el chat general.',
+      'Responde con conocimiento general de ingeniería hidráulica y con la documentación',
+      'de la base de conocimiento cuando venga adjunta al mensaje.',
+      'No describas ninguna red concreta ni des cifras de «la red del usuario»: no hay ninguna',
+      'a la vista, y tampoco inventes ejemplos numéricos que puedan confundirse con ella.',
+      'Si preguntan por su red, por sus nudos o por sus resultados, dilo con claridad e',
+      'indícales que abran un proyecto e importen su archivo .inp para poder responder con datos.',
+      'Mantente dentro del ámbito de la aplicación: ingeniería hidráulica y redes de agua.',
+      MARCA_GLOBAL_FIN,
+      '',
+    ].join('\n')
+  }
+
+  const km = (resumen.longitudTotalM / 1000).toFixed(2)
+  const ls = (resumen.demandaTotalM3s * 1000).toFixed(2)
+
+  const lineas = [
+    MARCA_INICIO,
+    `Red: ${resumen.nombre}`,
+    `Nudos de consumo: ${resumen.junctions} · Depósitos: ${resumen.tanks} · Embalses: ${resumen.reservoirs}`,
+    `Tuberías: ${resumen.pipes} · Bombas: ${resumen.pumps} · Válvulas: ${resumen.valves}`,
+    `Longitud total de tubería: ${km} km`,
+    `Demanda base total: ${ls} L/s`,
+  ]
+
+  if (resumen.diametroMinMm !== null && resumen.diametroMaxMm !== null) {
+    lineas.push(`Diámetros: de ${resumen.diametroMinMm} a ${resumen.diametroMaxMm} mm`)
+  }
+  if (resumen.sistemaCoordenadas) {
+    lineas.push(`Coordenadas: ${resumen.sistemaCoordenadas}`)
+  }
+  if (resumen.ultimaSimulacion) {
+    const f = new Date(resumen.ultimaSimulacion.fecha)
+    const fecha = isNaN(f.getTime()) ? String(resumen.ultimaSimulacion.fecha) : f.toISOString().slice(0, 10)
+    lineas.push(`Última simulación guardada: «${resumen.ultimaSimulacion.nombre}» (${fecha})`)
+  } else {
+    lineas.push('Última simulación guardada: ninguna todavía.')
+  }
+
+  lineas.push(
+    'Estas cifras vienen de la red cargada. Cíñete a ellas y no las completes con supuestos:',
+    'si te preguntan algo que no está aquí, dilo y ofrece ejecutar la simulación o el análisis que haga falta.',
+    MARCA_FIN,
+    '',
+  )
+
+  return lineas.join('\n')
+}

--- a/backend/services/hydraulic/pythonDetector.test.ts
+++ b/backend/services/hydraulic/pythonDetector.test.ts
@@ -64,11 +64,17 @@ describe('pythonDetector', () => {
     expect(second).toBe('/second/python3')
   })
 
+  // Es el unico test que deja sondear el sistema de verdad, y sondear cuesta:
+  // el detector lanza execSync por cada candidato con timeouts propios de 5 s y
+  // de 30 s, asi que con los 5 s por defecto de vitest una sola sonda lenta ya
+  // se pasa de largo. En CI tardaba 4,07 s -de 5- antes de que un fichero de
+  // test mas de carga en paralelo lo tumbara. El limite va por encima de lo que
+  // el propio detector se permite; lo que se comprueba aqui no es la rapidez.
   it('should return a string path when no PYTHON_PATH is set', () => {
     const result = findPythonPath()
     expect(typeof result).toBe('string')
     expect(result.length).toBeGreaterThan(0)
-  })
+  }, 60_000)
 
   it('resolves the managed venv directory inside userData', () => {
     vi.stubEnv('BOORIE_USER_DATA', USER_DATA)

--- a/backend/services/hydraulic/redActiva.ts
+++ b/backend/services/hydraulic/redActiva.ts
@@ -1,0 +1,51 @@
+/**
+ * Lectura de la red activa de un proyecto.
+ *
+ * La necesitan dos sitios: `network-repo:context`, para el resumen que va en el
+ * prompt, y `chat:send-message`, para responder a las herramientas del agente.
+ * Vive aqui para que no acaben con dos consultas parecidas que se separen con
+ * el tiempo y hagan que el resumen y las herramientas hablen de redes distintas.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import type { ContadoresRed } from './networkContext'
+import type { NodoRed, TramoRed } from './agentTools'
+
+/**
+ * `HydraulicNetwork.networkData` ya parseado. Es a la vez lo que consume el
+ * resumen (`DatosRed`) y lo que consumen las herramientas (`RedCompleta`): se
+ * describe una sola vez y ambos encajan estructuralmente.
+ */
+export interface DatosRedGuardados {
+  nodes?: NodoRed[]
+  links?: TramoRed[]
+  coordinate_system?: { type?: string; units?: string; epsg?: number | null }
+}
+
+export interface RedActiva {
+  id: string
+  nombre: string
+  /** `HydraulicNetwork.summary` ya parseado. */
+  contadores: ContadoresRed
+  datos: DatosRedGuardados
+}
+
+export async function leerRedActiva(
+  prisma: PrismaClient,
+  projectId?: string | null
+): Promise<RedActiva | null> {
+  if (!projectId) return null
+
+  const red = await prisma.hydraulicNetwork.findFirst({
+    where: { projectId, isActive: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+  if (!red) return null
+
+  return {
+    id: red.id,
+    nombre: red.name,
+    contadores: JSON.parse(red.summary || '{}'),
+    datos: JSON.parse(red.networkData || '{}'),
+  }
+}

--- a/docs/CONTEXTO_RED_AGENTE.md
+++ b/docs/CONTEXTO_RED_AGENTE.md
@@ -1,0 +1,101 @@
+# La red activa en el contexto del agente
+
+Diseño y decisiones de la funcionalidad pedida en el [issue #34](https://github.com/Boorie-AI/boorie_cliente/issues/34), punto 5 del informe de apreciaciones.
+
+## El problema, precisado
+
+El issue dice que «el chat no recibe ningún contexto de la red». No es exacto, y el matiz importa: `buildProjectContext` ya existía en `chatStore` e inyectaba proyecto, ubicación y lista de cálculos. Sobre la red decía esto, y sólo esto:
+
+```
+Network model: loaded (EPANET .inp data available for this project)
+```
+
+Eso es **peor que no decir nada**. El modelo sabe que existe una red, no tiene una sola cifra sobre ella, y nada le impide rellenar el hueco. En la base de pruebas hay una conversación real que lo enseña: a la pregunta «¿cómo puedo mejorar el flujo de agua en la junta 3?» el agente respondió consejos genéricos sobre limpiar una junta mecánica, sin enterarse de que J3 es un nudo de una red de cinco.
+
+## Lo que se construye
+
+| Pieza | Fichero |
+|---|---|
+| Resumen y formato (módulo puro) | `backend/services/hydraulic/networkContext.ts` |
+| Lectura de datos y cita de simulación | `network-repo:context` en `electron/handlers/networkRepository.handler.ts` |
+| Inyección en el prompt | `buildProjectContext` en `src/stores/chatStore.ts` |
+| Indicador en la interfaz | `src/components/chat/RedEnContexto.tsx` |
+
+## Qué entra en el resumen
+
+Decidido con Rayne antes de implementar, que es lo que el issue pedía cerrar:
+
+```
+=== RED HIDRÁULICA ACTIVA ===
+Red: villa_100_casas.inp
+Nudos de consumo: 5 · Depósitos: 1 · Embalses: 1
+Tuberías: 6 · Bombas: 0 · Válvulas: 0
+Longitud total de tubería: 1.03 km
+Demanda base total: 1.16 L/s
+Diámetros: de 50 a 100 mm
+Coordenadas: geográficas (lat/lon)
+Última simulación guardada: «Interrupción de Servicio (PDA): P2» (2026-08-18)
+=== FIN RED HIDRÁULICA ===
+```
+
+Son unas doce líneas, fijas: no crecen con el tamaño de la red.
+
+## Decisiones
+
+### 1. Tres de los campos que pedía el issue no existían
+
+Medido sobre las cuatro redes guardadas antes de escribir código:
+
+| Campo | Dónde estaba |
+|---|---|
+| Contadores | `HydraulicNetwork.summary`, tal cual |
+| Longitud total | **No existía**: se suma `networkData.links[].length` |
+| Demanda total | **No existía**: se suma `networkData.nodes[].demand` |
+| CRS | `epsg` viene a `null` en las cuatro; sólo hay `geographic`/`projected` |
+
+Se declara lo que se sabe («geográficas (lat/lon)») en vez de inventar un código EPSG.
+
+### 2. La última simulación no sale de donde el issue decía
+
+El issue pide citar `HydraulicNetwork.simulationResults`. Esa columna está **vacía en las cuatro redes**, y la causa es concreta: el handler que la escribe, `network-repo:save-simulation`, está expuesto en el preload y **no lo llama nadie**. Es el mismo patrón de infraestructura construida y sin conectar que ya arrastraban `useProjectStore` y `NetworkRepositoryService`.
+
+Los datos reales están en `HydraulicCalculation`, con el id de la red dentro del JSON de `inputs`. De ahí se lee la última simulación, así que la funcionalidad cita lo que el usuario ha ejecutado de verdad en lugar de una columna que nunca se rellenó.
+
+### 3. El contexto se inyecta también en los chats sin proyecto
+
+`buildProjectContext` sólo se llamaba si la conversación tenía `projectId`. Después de #31 el proyecto es global, así que un chat «General» no recibía nada aunque hubiera una red cargada delante. Ahora se usa el proyecto de la conversación o, si no tiene, el proyecto activo.
+
+### 4. Sin proyecto no hay «estado degradado»: hay chat general
+
+Sin proyecto seleccionado, Boorie está en **chat general**. Es un modo con sus propias reglas, no una versión rota del otro: responde con conocimiento general de ingeniería hidráulica y con la documentación del Wisdom Center, pero **no admite preguntas sobre redes que no tiene delante**. Esas reglas se inyectan explícitamente:
+
+```
+=== CHAT GENERAL ===
+No hay ningún proyecto ni red hidráulica cargados: esto es el chat general.
+Responde con conocimiento general de ingeniería hidráulica y con la documentación
+de la base de conocimiento cuando venga adjunta al mensaje.
+No describas ninguna red concreta ni des cifras de «la red del usuario»: no hay ninguna
+a la vista, y tampoco inventes ejemplos numéricos que puedan confundirse con ella.
+Si preguntan por su red, por sus nudos o por sus resultados, dilo con claridad e
+indícales que abran un proyecto e importen su archivo .inp para poder responder con datos.
+Mantente dentro del ámbito de la aplicación: ingeniería hidráulica y redes de agua.
+=== FIN CHAT GENERAL ===
+```
+
+**Esto se inyecta siempre, haya proyecto o no.** La primera versión sólo lo hacía cuando había proyecto, y eso dejaba el caso general sin ninguna instrucción. Se probó preguntando «resume mi red hidráulica» sin proyecto: `llama3.2` no inventó cifras como propias del usuario —pidió más información—, pero incluyó un «Ejemplo» con 5 tuberías y 500 metros que un usuario distraído puede leer como su red. Que se portara razonablemente era disposición del modelo, no una garantía del prompt; de ahí la prohibición explícita de los ejemplos numéricos.
+
+El RAG es ortogonal: `enhancePromptWithRAG` ya se aplica a cada mensaje según la configuración de Wisdom de la conversación, con proyecto o sin él.
+
+### 5. Las demandas negativas no se suman
+
+Una demanda base negativa modela una entrada de agua, no un consumo; sumarla daría una demanda total menor que la real. Mismo caso que en [`POBLACION_AFECTADA_PDA.md`](POBLACION_AFECTADA_PDA.md).
+
+## Verificación
+
+El criterio de aceptación pide que las cifras coincidan con el panel de la red. Se comprobó en la aplicación: el panel muestra 5 nudos, 1 depósito, 1 embalse, 6 tuberías, 0 bombas y 0 válvulas para `villa_100_casas.inp`, y el contexto inyectado dice exactamente eso.
+
+Los tests contrastan además el resumen contra las redes realmente guardadas en `prisma/hydraulic.db`, no sólo contra objetos de prueba.
+
+## Fuera de alcance
+
+El issue propone un segundo nivel de detalle bajo demanda, vía herramienta, para consultas sobre nudos o tramos concretos. No entra aquí: requiere que el proveedor de IA soporte llamada a herramientas, y hoy la aplicación construye el prompt como texto plano.

--- a/docs/CONTEXTO_RED_AGENTE.md
+++ b/docs/CONTEXTO_RED_AGENTE.md
@@ -96,6 +96,31 @@ El criterio de aceptación pide que las cifras coincidan con el panel de la red.
 
 Los tests contrastan además el resumen contra las redes realmente guardadas en `prisma/hydraulic.db`, no sólo contra objetos de prueba.
 
+## El segundo nivel: herramientas
+
+El resumen son doce líneas fijas y no sirve para responder sobre un nudo concreto: en `Net3 2.inp` hay 92 nudos y 117 tramos. El issue proponía un segundo nivel bajo demanda, y está implementado:
+
+| Pieza | Fichero |
+|---|---|
+| Las dos herramientas y su ejecutor (módulo puro) | `backend/services/hydraulic/agentTools.ts` |
+| Traducción a los dialectos de cada proveedor | `backend/services/ai/toolWire.ts` |
+| El bucle de vueltas | `electron/handlers/chat.handler.ts` |
+
+`consultar_elemento(id)` devuelve un nudo con sus tramos conectados, o un tramo con sus extremos. `listar_elementos(tipo, ordenar_por, límite)` responde agregados, con tope de 50 y aviso explícito cuando recorta.
+
+**El bucle se cierra dentro de una sola llamada a `chat:send-message`.** Los turnos intermedios no salen del handler, así que la conversación guardada sigue siendo texto plano: ni Prisma, ni el render, ni el tipo `ChatMessage` cambian. El precio es que en el turno siguiente el modelo ya no ve los resultados salvo por lo que escribió en su respuesta.
+
+### El texto depende del proveedor
+
+`formatearContextoRed` recibe un `conHerramientas` que decide su cierre, y no es cosmética:
+
+- **Con herramientas**: «no estimes lo que puedes mirar», empujando a consultar.
+- **Sin ellas**: «no puedes consultar nudos ni tramos concretos», que es la verdad.
+
+Prometer una consulta que el proveedor no puede hacer le pide al modelo justo la invención que el resto del bloque trata de evitar. Quien decide es `proveedorSoportaHerramientas` en `toolWire.ts`, **la misma función que usa el despacho de `chat.handler` para cargar la red**: si divergieran, el prompt prometería lo que el código no ofrece. El parámetro va a `false` por defecto, así que un llamante que no sepa el proveedor no promete nada.
+
+Google queda fuera porque usa `functionDeclarations`, otro dialecto. En el resto —Anthropic, OpenAI, OpenRouter, NVIDIA y Ollama— si la API rechaza las herramientas se reintenta sin ellas, en lugar de mantener una lista blanca de modelos que envejecería mal.
+
 ## Fuera de alcance
 
-El issue propone un segundo nivel de detalle bajo demanda, vía herramienta, para consultas sobre nudos o tramos concretos. No entra aquí: requiere que el proveedor de IA soporte llamada a herramientas, y hoy la aplicación construye el prompt como texto plano.
+Google, por el dialecto. Y las herramientas de escritura —lanzar una simulación desde el chat—: aquí sólo se lee.

--- a/electron/handlers/chat.handler.test.ts
+++ b/electron/handlers/chat.handler.test.ts
@@ -267,6 +267,22 @@ describe('degradacion cuando no hay herramientas que ofrecer', () => {
     expect(cuerpoDe(0).tools).toBeUndefined()
   })
 
+  it('Google no recibe herramientas: su dialecto no esta implementado', async () => {
+    // El prompt de `network-repo:context` se redacta con la misma funcion que
+    // decide esto, asi que si un dia divergen, este test cae antes de que el
+    // texto empiece a prometer consultas que Google no puede hacer.
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValueOnce(respuesta({
+      candidates: [{ content: { parts: [{ text: 'Respuesta de Google.' }] } }],
+    }))
+
+    const r = await enviar({ provider: 'google' })
+
+    expect(r.success).toBe(true)
+    expect(cuerpoDe(0).tools).toBeUndefined()
+    expect(fetchSimulado.mock.calls[0][0]).toContain('generativelanguage')
+  })
+
   it('si el modelo las rechaza, reintenta sin ellas en vez de dar error', async () => {
     new ChatHandler(baseDeDatos(true))
     fetchSimulado

--- a/electron/handlers/chat.handler.test.ts
+++ b/electron/handlers/chat.handler.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * El bucle de herramientas es la pieza con mas formas de salir mal: emparejar
+ * ids, devolver los resultados en la forma que cada proveedor exige, no
+ * quedarse dando vueltas y saber degradar cuando el modelo no las soporta.
+ * Nada de eso se ve en los modulos puros, asi que se prueba aqui contra un
+ * fetch simulado, sin red.
+ */
+
+const handlersRegistrados: Record<string, (evento: unknown, params: any) => Promise<any>> = {}
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (canal: string, fn: any) => { handlersRegistrados[canal] = fn },
+    removeAllListeners: () => {},
+  },
+}))
+
+import { ChatHandler } from './chat.handler'
+
+const RED = {
+  nodes: [
+    { id: 'J3', type: 'junction', elevation: 8, demand: 0.000115 },
+    { id: 'J1', type: 'junction', elevation: 10, demand: 0.000231 },
+  ],
+  links: [
+    { id: 'P2', type: 'pipe', from: 'J1', to: 'J3', length: 150, diameter: 0.05 },
+  ],
+}
+
+const baseDeDatos = (conRed: boolean) => ({
+  prisma: {
+    appSetting: { findUnique: async () => null },
+    aIProvider: { findMany: async () => [] },
+    hydraulicNetwork: {
+      findFirst: async () =>
+        conRed ? { id: 'n1', name: 'villa.inp', summary: '{}', networkData: JSON.stringify(RED) } : null,
+    },
+  },
+}) as any
+
+const respuesta = (cuerpo: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => cuerpo,
+})
+
+const anthropicPideHerramienta = {
+  stop_reason: 'tool_use',
+  usage: { input_tokens: 100, output_tokens: 20 },
+  content: [
+    { type: 'text', text: 'Lo miro.' },
+    { type: 'tool_use', id: 'toolu_01', name: 'consultar_elemento', input: { id: 'J3' } },
+  ],
+}
+
+const anthropicResponde = {
+  stop_reason: 'end_turn',
+  usage: { input_tokens: 300, output_tokens: 40 },
+  content: [{ type: 'text', text: 'J3 esta a 8 m de cota.' }],
+}
+
+const openaiPideHerramienta = {
+  created: 1_700_000_000,
+  usage: { total_tokens: 120 },
+  choices: [{
+    finish_reason: 'tool_calls',
+    message: {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'consultar_elemento', arguments: '{"id":"J3"}' } }],
+    },
+  }],
+}
+
+const openaiResponde = {
+  created: 1_700_000_001,
+  usage: { total_tokens: 340 },
+  choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'J3 esta a 8 m de cota.' } }],
+}
+
+let fetchSimulado: ReturnType<typeof vi.fn>
+
+const enviar = (params: Record<string, unknown>) =>
+  handlersRegistrados['chat:send-message'](null, {
+    model: 'un-modelo',
+    messages: [{ role: 'user', content: '¿como mejoro el flujo en J3?' }],
+    apiKey: 'k',
+    projectId: 'p1',
+    ...params,
+  })
+
+const cuerpoDe = (llamada: number) => JSON.parse(fetchSimulado.mock.calls[llamada][1].body)
+
+beforeEach(() => {
+  fetchSimulado = vi.fn()
+  vi.stubGlobal('fetch', fetchSimulado)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('bucle de herramientas con Anthropic', () => {
+  it('ejecuta la herramienta y devuelve la respuesta de la segunda vuelta', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta(anthropicPideHerramienta))
+      .mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    const r = await enviar({ provider: 'anthropic' })
+
+    expect(r.success).toBe(true)
+    expect(r.data.response).toBe('J3 esta a 8 m de cota.')
+    expect(fetchSimulado).toHaveBeenCalledTimes(2)
+  })
+
+  it('declara las herramientas y devuelve el resultado con el tool_use_id que le dieron', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta(anthropicPideHerramienta))
+      .mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    await enviar({ provider: 'anthropic' })
+
+    expect(cuerpoDe(0).tools.map((t: any) => t.name))
+      .toEqual(['consultar_elemento', 'listar_elementos'])
+
+    // Anthropic exige que el turno del asistente se reenvie intacto y que el
+    // resultado venga en un mensaje de usuario con el id que el asigno.
+    const segundo = cuerpoDe(1)
+    expect(segundo.messages).toHaveLength(3)
+    expect(segundo.messages[1]).toMatchObject({ role: 'assistant' })
+    const bloque = segundo.messages[2].content[0]
+    expect(bloque).toMatchObject({ type: 'tool_result', tool_use_id: 'toolu_01' })
+    expect(JSON.parse(bloque.content).elemento).toMatchObject({ id: 'J3', cota_m: 8 })
+  })
+
+  it('el texto sale de los bloques de texto, no de content[0]', async () => {
+    // Con herramientas, content[0] deja de ser texto: puede ser un tool_use o
+    // un bloque de razonamiento. Leerlo a pelo devolvia «No response from
+    // Anthropic» teniendo la respuesta delante.
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValueOnce(respuesta({
+      stop_reason: 'end_turn',
+      content: [
+        { type: 'thinking', thinking: 'Ya tengo la cota.' },
+        { type: 'text', text: 'La respuesta.' },
+      ],
+    }))
+
+    const r = await enviar({ provider: 'anthropic' })
+    expect(r.data.response).toBe('La respuesta.')
+    expect(fetchSimulado).toHaveBeenCalledTimes(1)
+  })
+
+  it('suma los tokens de todas las vueltas, no solo los de la ultima', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta(anthropicPideHerramienta))
+      .mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    const r = await enviar({ provider: 'anthropic' })
+    expect(r.data.metadata.tokens).toBe(100 + 20 + 300 + 40)
+  })
+})
+
+describe('bucle de herramientas con los compatibles con OpenAI', () => {
+  it('devuelve un mensaje role tool por cada llamada', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta(openaiPideHerramienta))
+      .mockResolvedValueOnce(respuesta(openaiResponde))
+
+    const r = await enviar({ provider: 'openai' })
+
+    expect(r.data.response).toBe('J3 esta a 8 m de cota.')
+    const segundo = cuerpoDe(1)
+    expect(segundo.messages[1]).toMatchObject({ role: 'assistant' })
+    expect(segundo.messages[2]).toMatchObject({ role: 'tool', tool_call_id: 'call_1' })
+    expect(JSON.parse(segundo.messages[2].content).elemento).toMatchObject({ id: 'J3' })
+  })
+
+  it('las herramientas van envueltas en function', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValueOnce(respuesta(openaiResponde))
+
+    await enviar({ provider: 'openai' })
+    expect(cuerpoDe(0).tools[0]).toMatchObject({ type: 'function', function: { name: 'consultar_elemento' } })
+  })
+
+  it('OpenRouter y NVIDIA pasan por el mismo bucle', async () => {
+    for (const provider of ['openrouter', 'nvidia']) {
+      fetchSimulado.mockReset()
+      fetchSimulado
+        .mockResolvedValueOnce(respuesta(openaiPideHerramienta))
+        .mockResolvedValueOnce(respuesta(openaiResponde))
+      new ChatHandler(baseDeDatos(true))
+
+      const r = await enviar({ provider })
+      expect(r.data.response, provider).toBe('J3 esta a 8 m de cota.')
+      expect(fetchSimulado, provider).toHaveBeenCalledTimes(2)
+    }
+  })
+})
+
+describe('bucle de herramientas con Ollama', () => {
+  const ollamaPide = {
+    prompt_eval_count: 90,
+    eval_count: 15,
+    message: {
+      role: 'assistant',
+      content: ' ',
+      tool_calls: [{ id: 'call_x', function: { name: 'consultar_elemento', arguments: { id: 'J3' } } }],
+    },
+  }
+  const ollamaResponde = {
+    prompt_eval_count: 200,
+    eval_count: 30,
+    message: { role: 'assistant', content: ' La cota de J3 es 8 m.' },
+  }
+
+  it('resuelve la llamada y contesta con el dato', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta(ollamaPide))
+      .mockResolvedValueOnce(respuesta(ollamaResponde))
+
+    const r = await enviar({ provider: 'ollama' })
+
+    // El trim importa: pidiendo herramientas, nemotron devuelve content=' ' y
+    // sin recortarlo el chat ensena un mensaje en blanco.
+    expect(r.data.response).toBe('La cota de J3 es 8 m.')
+    const segundo = cuerpoDe(1)
+    expect(segundo.messages[2]).toMatchObject({ role: 'tool', tool_call_id: 'call_x' })
+    expect(JSON.parse(segundo.messages[2].content).elemento).toMatchObject({ id: 'J3', cota_m: 8 })
+  })
+
+  it('un modelo local sin plantilla de herramientas no rompe el chat', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'registry.ollama.ai does not support tools' })
+      .mockResolvedValueOnce(respuesta(ollamaResponde))
+
+    const r = await enviar({ provider: 'ollama' })
+
+    expect(r.success).toBe(true)
+    expect(cuerpoDe(1).tools).toBeUndefined()
+  })
+})
+
+describe('degradacion cuando no hay herramientas que ofrecer', () => {
+  it('sin proyecto no se declaran herramientas', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    await enviar({ provider: 'anthropic', projectId: undefined })
+    expect(cuerpoDe(0).tools).toBeUndefined()
+  })
+
+  it('con proyecto pero sin red tampoco', async () => {
+    new ChatHandler(baseDeDatos(false))
+    fetchSimulado.mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    await enviar({ provider: 'anthropic' })
+    expect(cuerpoDe(0).tools).toBeUndefined()
+  })
+
+  it('si el modelo las rechaza, reintenta sin ellas en vez de dar error', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado
+      .mockResolvedValueOnce(respuesta({ error: { message: 'Tools are not supported by this model' } }, 400))
+      .mockResolvedValueOnce(respuesta(anthropicResponde))
+
+    const r = await enviar({ provider: 'anthropic' })
+
+    expect(r.success).toBe(true)
+    expect(cuerpoDe(0).tools).toBeDefined()
+    expect(cuerpoDe(1).tools).toBeUndefined()
+  })
+
+  it('un 400 que no es de herramientas sigue siendo un error, sin reintento', async () => {
+    // Reintentar un problema de credito solo gasta otra llamada.
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValueOnce(
+      respuesta({ error: { message: 'Your credit balance is too low' } }, 400)
+    )
+
+    const r = await enviar({ provider: 'anthropic' })
+
+    expect(r.success).toBe(false)
+    expect(r.error).toContain('credits')
+    expect(fetchSimulado).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('tope de vueltas', () => {
+  it('corta al modelo que no para de pedir herramientas y le exige respuesta', async () => {
+    new ChatHandler(baseDeDatos(true))
+    fetchSimulado.mockResolvedValue(respuesta(anthropicPideHerramienta))
+
+    const r = await enviar({ provider: 'anthropic' })
+
+    // Cuatro vueltas con herramientas y una quinta ya sin ellas, que es la que
+    // obliga a contestar en texto en lugar de encadenar otra llamada.
+    expect(fetchSimulado).toHaveBeenCalledTimes(5)
+    expect(cuerpoDe(4).tools).toBeUndefined()
+    expect(r.data.metadata.vueltas_herramientas).toBe(4)
+
+    // Los tool_use pendientes quedan respondidos: dejarlos sin tool_result da 400.
+    const ultimo = cuerpoDe(4)
+    const asistentes = ultimo.messages.filter((m: any) => m.role === 'assistant').length
+    const resultados = ultimo.messages.filter(
+      (m: any) => Array.isArray(m.content) && m.content[0]?.type === 'tool_result'
+    ).length
+    expect(asistentes).toBe(resultados)
+  })
+})

--- a/electron/handlers/chat.handler.ts
+++ b/electron/handlers/chat.handler.ts
@@ -11,6 +11,7 @@ import {
   llamadasDesdeAnthropic,
   llamadasDesdeOpenAI,
   llamadasDesdeOllama,
+  proveedorSoportaHerramientas,
   mensajeResultadosAnthropic,
   mensajesResultadosOpenAI,
   textoDesdeAnthropic,
@@ -129,11 +130,13 @@ export class ChatHandler {
       const messagesWithSystemPrompt = await this.addSystemPrompt(messages)
       logger.info('Messages after system prompt processing', { messageCount: messagesWithSystemPrompt.length })
 
-      // Google queda fuera por ahora: usa otro dialecto
-      // (functionDeclarations). Ollama si entra, pero solo llega aqui cuando el
-      // renderer decide no ir por su ruta de streaming (ver chatStore).
-      
-      const red = await this.cargarRedActiva(projectId)
+      // La red solo se carga si el proveedor sabe usar herramientas, con la
+      // misma funcion que consulta `network-repo:context` para redactar el
+      // prompt. Asi el texto que promete la consulta y el codigo que la ofrece
+      // no pueden decir cosas distintas.
+      const red = proveedorSoportaHerramientas(provider)
+        ? await this.cargarRedActiva(projectId)
+        : null
 
       let result: ChatResponse
 

--- a/electron/handlers/chat.handler.ts
+++ b/electron/handlers/chat.handler.ts
@@ -2,6 +2,20 @@
 import { ipcMain } from 'electron'
 import { createLogger } from '../../backend/utils/logger'
 import { DatabaseService } from '../../backend/services'
+import { HERRAMIENTAS, ejecutarHerramienta, type RedCompleta } from '../../backend/services/hydraulic/agentTools'
+import { leerRedActiva } from '../../backend/services/hydraulic/redActiva'
+import {
+  esErrorDeHerramientas,
+  herramientasAnthropic,
+  herramientasOpenAI,
+  llamadasDesdeAnthropic,
+  llamadasDesdeOpenAI,
+  llamadasDesdeOllama,
+  mensajeResultadosAnthropic,
+  mensajesResultadosOpenAI,
+  textoDesdeAnthropic,
+  type LlamadaHerramienta,
+} from '../../backend/services/ai/toolWire'
 // Import types
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system'
@@ -32,7 +46,27 @@ export interface SendChatMessageParams {
   messages: ChatMessage[]
   apiKey: string
   stream?: boolean
+  /** Proyecto cuya red activa puede consultar el agente con herramientas (#34). */
+  projectId?: string
 }
+
+/**
+ * Tope de vueltas del bucle de herramientas. Cuatro dan de sobra para el uso
+ * previsto (mirar un nudo, mirar sus tramos, responder) y acotan tanto el gasto
+ * como el caso del modelo que se queda pidiendo herramientas sin concluir.
+ */
+const MAX_VUELTAS_HERRAMIENTAS = 4
+
+/**
+ * Un modelo local tarda lo suyo, y con herramientas cada respuesta cuesta dos
+ * inferencias completas en vez de una. Con los 120 s de siempre, llama3.1:8b
+ * sobre Net3 se pasaba de largo en la primera vuelta y el chat mostraba «The
+ * operation was aborted due to timeout». El margen ancho solo se aplica cuando
+ * hay herramientas: sin ellas, el limite corto sigue siendo el aviso util de
+ * que Ollama no responde.
+ */
+const TIMEOUT_OLLAMA_MS = 120000
+const TIMEOUT_OLLAMA_HERRAMIENTAS_MS = 300000
 
 export interface IPCChatResponse {
   success: boolean
@@ -87,7 +121,7 @@ export class ChatHandler {
   }
 
   private async sendChatMessage(params: SendChatMessageParams): Promise<IPCChatResponse> {
-    const { provider, model, messages, apiKey } = params
+    const { provider, model, messages, apiKey, projectId } = params
 
     try {
       // Get system prompt from database and add it to messages if not already present
@@ -95,26 +129,32 @@ export class ChatHandler {
       const messagesWithSystemPrompt = await this.addSystemPrompt(messages)
       logger.info('Messages after system prompt processing', { messageCount: messagesWithSystemPrompt.length })
 
+      // Google queda fuera por ahora: usa otro dialecto
+      // (functionDeclarations). Ollama si entra, pero solo llega aqui cuando el
+      // renderer decide no ir por su ruta de streaming (ver chatStore).
+      
+      const red = await this.cargarRedActiva(projectId)
+
       let result: ChatResponse
 
       switch (provider.toLowerCase()) {
         case 'anthropic':
-          result = await this.sendAnthropicMessage(model, messagesWithSystemPrompt, apiKey)
+          result = await this.sendAnthropicMessage(model, messagesWithSystemPrompt, apiKey, red)
           break
         case 'openai':
-          result = await this.sendOpenAIMessage(model, messagesWithSystemPrompt, apiKey)
+          result = await this.sendOpenAIMessage(model, messagesWithSystemPrompt, apiKey, red)
           break
         case 'google':
           result = await this.sendGoogleMessage(model, messagesWithSystemPrompt, apiKey)
           break
         case 'openrouter':
-          result = await this.sendOpenRouterMessage(model, messagesWithSystemPrompt, apiKey)
+          result = await this.sendOpenRouterMessage(model, messagesWithSystemPrompt, apiKey, red)
           break
         case 'ollama':
-          result = await this.sendOllamaMessage(model, messagesWithSystemPrompt, apiKey || '')
+          result = await this.sendOllamaMessage(model, messagesWithSystemPrompt, apiKey || '', red)
           break
         case 'nvidia':
-          result = await this.sendNvidiaMessage(model, messagesWithSystemPrompt, apiKey)
+          result = await this.sendNvidiaMessage(model, messagesWithSystemPrompt, apiKey, red)
           break
         default:
           throw new Error(`Unsupported chat provider: ${provider}`)
@@ -135,6 +175,37 @@ export class ChatHandler {
         error: error instanceof Error ? error.message : 'Unknown error'
       }
     }
+  }
+
+  /**
+   * La red que el agente puede consultar. Sin proyecto no hay red, y entonces
+   * no se ofrecen herramientas: el prompt de chat general ya le dice que no
+   * hable de redes que no tiene delante.
+   */
+  private async cargarRedActiva(projectId?: string): Promise<RedCompleta | null> {
+    if (!projectId) return null
+    try {
+      const red = await leerRedActiva(this.databaseService.prisma, projectId)
+      return red ? red.datos : null
+    } catch (error) {
+      // Quedarse sin herramientas degrada la respuesta; tumbar el mensaje del
+      // usuario por no poder leer la red seria peor.
+      logger.warn('No se pudo cargar la red activa para las herramientas', { error: (error as Error).message })
+      return null
+    }
+  }
+
+  private ejecutarLlamadas(llamadas: LlamadaHerramienta[], red: RedCompleta) {
+    return llamadas.map(llamada => {
+      logger.debug('Herramienta solicitada por el agente', { nombre: llamada.nombre, argumentos: llamada.argumentos })
+      try {
+        return { llamada, salida: ejecutarHerramienta(llamada.nombre, llamada.argumentos, red) }
+      } catch (error) {
+        // El error se le devuelve al modelo como resultado, no se lanza: puede
+        // reformular la llamada o explicar que no ha podido consultarlo.
+        return { llamada, salida: { error: (error as Error).message } }
+      }
+    })
   }
 
   private async addSystemPrompt(messages: ChatMessage[]): Promise<ChatMessage[]> {
@@ -169,84 +240,133 @@ export class ChatHandler {
     }
   }
 
-  private async sendAnthropicMessage(model: string, messages: ChatMessage[], apiKey: string): Promise<ChatResponse> {
+  private async sendAnthropicMessage(
+    model: string,
+    messages: ChatMessage[],
+    apiKey: string,
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
     // Convert messages to Anthropic format
-    const anthropicMessages = this.convertToAnthropicFormat(messages)
+    const historial: any[] = this.convertToAnthropicFormat(messages)
 
-    const requestBody = {
-      model: model,
-      max_tokens: 4000,
-      messages: anthropicMessages,
-      stream: false,
-    }
+    let usarHerramientas = !!red
+    let vueltas = 0
+    let entrada = 0
+    let salida = 0
+    let ultima: any = null
 
-    logger.debug('Anthropic API Request via backend', { model, messagesCount: anthropicMessages.length })
+    for (;;) {
+      const requestBody: any = {
+        model: model,
+        max_tokens: 4000,
+        messages: historial,
+        stream: false,
+      }
+      if (usarHerramientas) requestBody.tools = herramientasAnthropic(HERRAMIENTAS)
 
-    const response = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(90000) // 90 second timeout (allows for RAG-enhanced prompts)
-    })
+      logger.debug('Anthropic API Request via backend', {
+        model,
+        messagesCount: historial.length,
+        herramientas: usarHerramientas,
+      })
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as any
-      const errorMessage = errorData.error?.message || 'Unknown error'
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify(requestBody),
+        signal: AbortSignal.timeout(90000) // 90 second timeout (allows for RAG-enhanced prompts)
+      })
 
-      // Provide specific error messages based on status code
-      switch (response.status) {
-        case 400:
-          if (errorMessage.toLowerCase().includes('credit') || errorMessage.toLowerCase().includes('billing') || errorMessage.toLowerCase().includes('balance')) {
-            throw new Error('💳 Insufficient Anthropic credits. Please go to Plans & Billing in your Anthropic account to add credits or upgrade your plan.')
-          }
-          throw new Error(`Bad request to Anthropic: ${errorMessage}`)
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({})) as any
+        const errorMessage = errorData.error?.message || 'Unknown error'
 
-        case 401:
-          throw new Error('🔑 Invalid Anthropic API key. Please check your API key in settings.')
+        // Reintento sin herramientas antes de dar el error por bueno: el modelo
+        // puede no soportarlas, y una respuesta sin datos de red es mejor que
+        // un error en la cara del usuario.
+        if (usarHerramientas && esErrorDeHerramientas(response.status, errorMessage)) {
+          logger.warn('Anthropic rechaza las herramientas, se reintenta sin ellas', { model, errorMessage })
+          usarHerramientas = false
+          continue
+        }
 
-        case 403:
-          if (errorMessage.toLowerCase().includes('credit') || errorMessage.toLowerCase().includes('billing') || errorMessage.toLowerCase().includes('balance')) {
-            throw new Error('💳 Insufficient Anthropic credits. Please go to Plans & Billing in your Anthropic account to add credits or upgrade your plan.')
-          }
-          throw new Error('🚫 Access denied to Anthropic API. Please check your account permissions.')
+        this.lanzarErrorAnthropic(response.status, errorMessage, model)
+      }
 
-        case 404:
-          throw new Error(`Anthropic model "${model}" not found. Please select a different model.`)
+      const data = await response.json() as any
+      ultima = data
+      entrada += data.usage?.input_tokens || 0
+      salida += data.usage?.output_tokens || 0
 
-        case 429:
-          throw new Error('Too many requests to Anthropic. Please try again later.')
+      const llamadas = usarHerramientas ? llamadasDesdeAnthropic(data) : []
+      if (llamadas.length === 0) break
 
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new Error('Anthropic API is temporarily unavailable. Please try again in a few moments.')
+      historial.push({ role: 'assistant', content: data.content })
+      historial.push(mensajeResultadosAnthropic(this.ejecutarLlamadas(llamadas, red!)))
 
-        default:
-          throw new Error(`Anthropic API error (${response.status}): ${errorMessage}`)
+      // Al agotar las vueltas no se corta en seco: se responden las llamadas
+      // pendientes (Anthropic exige un tool_result por cada tool_use) y se pide
+      // la respuesta final ya sin herramientas.
+      if (++vueltas >= MAX_VUELTAS_HERRAMIENTAS) {
+        logger.warn('Tope de vueltas de herramientas alcanzado', { model, vueltas })
+        usarHerramientas = false
       }
     }
 
-    const data = await response.json() as any
-
     return {
-      response: data.content?.[0]?.text || 'No response from Anthropic',
+      response: textoDesdeAnthropic(ultima) || 'No response from Anthropic',
       metadata: {
         model: model,
         provider: 'Anthropic',
-        tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0),
+        tokens: entrada + salida,
         usage: {
-          prompt_tokens: data.usage?.input_tokens || 0,
-          completion_tokens: data.usage?.output_tokens || 0,
-          total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0),
+          prompt_tokens: entrada,
+          completion_tokens: salida,
+          total_tokens: entrada + salida,
         },
-        finish_reason: data.stop_reason,
+        finish_reason: ultima?.stop_reason,
+        vueltas_herramientas: vueltas,
         created_at: new Date().toISOString(),
       }
+    }
+  }
+
+  private lanzarErrorAnthropic(status: number, errorMessage: string, model: string): never {
+    // Provide specific error messages based on status code
+    switch (status) {
+      case 400:
+        if (errorMessage.toLowerCase().includes('credit') || errorMessage.toLowerCase().includes('billing') || errorMessage.toLowerCase().includes('balance')) {
+          throw new Error('\u{1F4B3} Insufficient Anthropic credits. Please go to Plans & Billing in your Anthropic account to add credits or upgrade your plan.')
+        }
+        throw new Error(`Bad request to Anthropic: ${errorMessage}`)
+
+      case 401:
+        throw new Error('\u{1F511} Invalid Anthropic API key. Please check your API key in settings.')
+
+      case 403:
+        if (errorMessage.toLowerCase().includes('credit') || errorMessage.toLowerCase().includes('billing') || errorMessage.toLowerCase().includes('balance')) {
+          throw new Error('\u{1F4B3} Insufficient Anthropic credits. Please go to Plans & Billing in your Anthropic account to add credits or upgrade your plan.')
+        }
+        throw new Error('\u{1F6AB} Access denied to Anthropic API. Please check your account permissions.')
+
+      case 404:
+        throw new Error(`Anthropic model "${model}" not found. Please select a different model.`)
+
+      case 429:
+        throw new Error('Too many requests to Anthropic. Please try again later.')
+
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+        throw new Error('Anthropic API is temporarily unavailable. Please try again in a few moments.')
+
+      default:
+        throw new Error(`Anthropic API error (${status}): ${errorMessage}`)
     }
   }
 
@@ -275,64 +395,140 @@ export class ChatHandler {
     return converted
   }
 
-  private async sendOpenAIMessage(model: string, messages: ChatMessage[], apiKey: string): Promise<ChatResponse> {
-    const requestBody = {
-      model: model,
-      messages: messages,
-      stream: false,
-      max_tokens: 4000,
-      temperature: 0.7,
+  /**
+   * Nucleo compartido por OpenAI, OpenRouter y NVIDIA: los tres exponen
+   * /chat/completions y hablan el mismo dialecto de herramientas. Solo cambian
+   * la URL, las cabeceras, algun parametro del cuerpo y como nombran los
+   * errores, asi que eso es lo que entra por configuracion.
+   */
+  private async enviarOpenAICompat(
+    cfg: {
+      url: string
+      proveedor: string
+      cabeceras: Record<string, string>
+      cuerpoExtra: Record<string, unknown>
+      timeout: number
+      extraerError: (errorData: any, status: number) => string
+      lanzarError: (status: number, errorMessage: string) => never
+      modeloDeLaRespuesta: boolean
+    },
+    model: string,
+    messages: ChatMessage[],
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
+    const historial: any[] = [...messages]
+
+    let usarHerramientas = !!red
+    let vueltas = 0
+    let ultima: any = null
+    let tokens = 0
+
+    for (;;) {
+      const requestBody: any = {
+        model: model,
+        messages: historial,
+        stream: false,
+        ...cfg.cuerpoExtra,
+      }
+      if (usarHerramientas) requestBody.tools = herramientasOpenAI(HERRAMIENTAS)
+
+      logger.debug(`${cfg.proveedor} API Request via backend`, {
+        model,
+        messagesCount: historial.length,
+        herramientas: usarHerramientas,
+      })
+
+      const response = await fetch(cfg.url, {
+        method: 'POST',
+        headers: cfg.cabeceras,
+        body: JSON.stringify(requestBody),
+        signal: AbortSignal.timeout(cfg.timeout)
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({})) as any
+        const errorMessage = cfg.extraerError(errorData, response.status)
+
+        // Ni OpenRouter ni NVIDIA garantizan herramientas en todos los modelos
+        // que sirven, y una lista de cuales las soportan envejeceria mal: se
+        // detecta el rechazo y se reintenta sin ellas.
+        if (usarHerramientas && esErrorDeHerramientas(response.status, errorMessage)) {
+          logger.warn(`${cfg.proveedor} rechaza las herramientas, se reintenta sin ellas`, { model, errorMessage })
+          usarHerramientas = false
+          continue
+        }
+
+        cfg.lanzarError(response.status, errorMessage)
+      }
+
+      const data = await response.json() as any
+      ultima = data
+      tokens += data.usage?.total_tokens || 0
+
+      const llamadas = usarHerramientas ? llamadasDesdeOpenAI(data) : []
+      if (llamadas.length === 0) break
+
+      historial.push(data.choices[0].message)
+      historial.push(...mensajesResultadosOpenAI(this.ejecutarLlamadas(llamadas, red!)))
+
+      if (++vueltas >= MAX_VUELTAS_HERRAMIENTAS) {
+        logger.warn('Tope de vueltas de herramientas alcanzado', { model, vueltas })
+        usarHerramientas = false
+      }
     }
 
-    logger.debug('OpenAI API Request via backend', { model, messagesCount: messages.length })
+    return {
+      response: ultima?.choices?.[0]?.message?.content || `No response from ${cfg.proveedor}`,
+      metadata: {
+        model: cfg.modeloDeLaRespuesta ? (ultima?.model || model) : model,
+        provider: cfg.proveedor,
+        tokens: tokens,
+        usage: ultima?.usage || {},
+        finish_reason: ultima?.choices?.[0]?.finish_reason,
+        vueltas_herramientas: vueltas,
+        created_at: ultima?.created ? new Date(ultima.created * 1000).toISOString() : new Date().toISOString(),
+      }
+    }
+  }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
+  private async sendOpenAIMessage(
+    model: string,
+    messages: ChatMessage[],
+    apiKey: string,
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
+    return this.enviarOpenAICompat({
+      url: 'https://api.openai.com/v1/chat/completions',
+      proveedor: 'OpenAI',
+      cabeceras: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(90000) // 90 second timeout (allows for RAG-enhanced prompts)
-    })
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as any
-      const errorMessage = errorData.error?.message || 'Unknown error'
-
-      switch (response.status) {
-        case 401:
-          throw new Error('🔑 Invalid OpenAI API key. Please check your API key in settings.')
-        case 403:
-          throw new Error('🚫 Access denied to OpenAI API. Please check your account permissions.')
-        case 429:
-          if (errorMessage.toLowerCase().includes('quota') || errorMessage.toLowerCase().includes('billing')) {
-            throw new Error('💳 OpenAI quota exceeded. Please check your billing and usage limits.')
-          }
-          throw new Error('Too many requests to OpenAI. Please try again later.')
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new Error('OpenAI API is temporarily unavailable. Please try again in a few moments.')
-        default:
-          throw new Error(`OpenAI API error (${response.status}): ${errorMessage}`)
-      }
-    }
-
-    const data = await response.json() as any
-
-    return {
-      response: data.choices[0]?.message?.content || 'No response from OpenAI',
-      metadata: {
-        model: model,
-        provider: 'OpenAI',
-        tokens: data.usage?.total_tokens || 0,
-        usage: data.usage || {},
-        finish_reason: data.choices[0]?.finish_reason,
-        created_at: new Date(data.created * 1000).toISOString(),
-      }
-    }
+      cuerpoExtra: { max_tokens: 4000, temperature: 0.7 },
+      timeout: 90000, // 90 second timeout (allows for RAG-enhanced prompts)
+      modeloDeLaRespuesta: false,
+      extraerError: (errorData) => errorData.error?.message || 'Unknown error',
+      lanzarError: (status, errorMessage) => {
+        switch (status) {
+          case 401:
+            throw new Error('\u{1F511} Invalid OpenAI API key. Please check your API key in settings.')
+          case 403:
+            throw new Error('\u{1F6AB} Access denied to OpenAI API. Please check your account permissions.')
+          case 429:
+            if (errorMessage.toLowerCase().includes('quota') || errorMessage.toLowerCase().includes('billing')) {
+              throw new Error('\u{1F4B3} OpenAI quota exceeded. Please check your billing and usage limits.')
+            }
+            throw new Error('Too many requests to OpenAI. Please try again later.')
+          case 500:
+          case 502:
+          case 503:
+          case 504:
+            throw new Error('OpenAI API is temporarily unavailable. Please try again in a few moments.')
+          default:
+            throw new Error(`OpenAI API error (${status}): ${errorMessage}`)
+        }
+      },
+    }, model, messages, red)
   }
 
   private async sendGoogleMessage(model: string, messages: ChatMessage[], apiKey: string): Promise<ChatResponse> {
@@ -425,72 +621,54 @@ export class ChatHandler {
     return { contents, systemInstruction }
   }
 
-  private async sendOpenRouterMessage(model: string, messages: ChatMessage[], apiKey: string): Promise<ChatResponse> {
-    const requestBody = {
-      model: model,
-      messages: messages,
-      stream: false,
-      max_tokens: 4000,
-      temperature: 0.7,
-      // OpenRouter specific parameters
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
-    }
-
-    logger.debug('OpenRouter API Request via backend', { model, messagesCount: messages.length })
-
-    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-      method: 'POST',
-      headers: {
+  private async sendOpenRouterMessage(
+    model: string,
+    messages: ChatMessage[],
+    apiKey: string,
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
+    return this.enviarOpenAICompat({
+      url: 'https://openrouter.ai/api/v1/chat/completions',
+      proveedor: 'OpenRouter',
+      cabeceras: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${apiKey}`,
         'HTTP-Referer': 'https://boorie.app', // Required by OpenRouter
         'X-Title': 'Boorie', // Required by OpenRouter
       },
-      body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(90000) // 90 second timeout (allows for RAG-enhanced prompts)
-    })
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as any
-      const errorMessage = errorData.error?.message || 'Unknown error'
-
-      switch (response.status) {
-        case 401:
-          throw new Error('🔑 Invalid OpenRouter API key. Please check your API key in settings.')
-        case 402:
-          throw new Error('💳 Insufficient OpenRouter credits. Please add credits to your OpenRouter account.')
-        case 403:
-          throw new Error('🚫 Access denied to OpenRouter API. Please check your account permissions.')
-        case 429:
-          throw new Error('Too many requests to OpenRouter. Please try again later.')
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new Error('OpenRouter API is temporarily unavailable. Please try again in a few moments.')
-        default:
-          throw new Error(`OpenRouter API error (${response.status}): ${errorMessage}`)
-      }
-    }
-
-    const data = await response.json() as any
-
-    return {
-      response: data.choices[0]?.message?.content || 'No response from OpenRouter',
-      metadata: {
-        model: data.model || model,
-        provider: 'OpenRouter',
-        tokens: data.usage?.total_tokens || 0,
-        usage: data.usage || {},
-        finish_reason: data.choices[0]?.finish_reason,
-        created_at: new Date(data.created * 1000).toISOString(),
-      }
-    }
+      // OpenRouter specific parameters
+      cuerpoExtra: { max_tokens: 4000, temperature: 0.7, top_p: 1, frequency_penalty: 0, presence_penalty: 0 },
+      timeout: 90000, // 90 second timeout (allows for RAG-enhanced prompts)
+      modeloDeLaRespuesta: true,
+      extraerError: (errorData) => errorData.error?.message || 'Unknown error',
+      lanzarError: (status, errorMessage) => {
+        switch (status) {
+          case 401:
+            throw new Error('\u{1F511} Invalid OpenRouter API key. Please check your API key in settings.')
+          case 402:
+            throw new Error('\u{1F4B3} Insufficient OpenRouter credits. Please add credits to your OpenRouter account.')
+          case 403:
+            throw new Error('\u{1F6AB} Access denied to OpenRouter API. Please check your account permissions.')
+          case 429:
+            throw new Error('Too many requests to OpenRouter. Please try again later.')
+          case 500:
+          case 502:
+          case 503:
+          case 504:
+            throw new Error('OpenRouter API is temporarily unavailable. Please try again in a few moments.')
+          default:
+            throw new Error(`OpenRouter API error (${status}): ${errorMessage}`)
+        }
+      },
+    }, model, messages, red)
   }
 
-  private async sendOllamaMessage(model: string, messages: ChatMessage[], _apiKey: string): Promise<ChatResponse> {
+  private async sendOllamaMessage(
+    model: string,
+    messages: ChatMessage[],
+    _apiKey: string,
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
     // Get Ollama base URL from provider config
     const providers = await this.databaseService.prisma.aIProvider.findMany({
       where: { type: 'ollama', isActive: true }
@@ -499,56 +677,96 @@ export class ChatHandler {
     const baseUrl = ollamaProvider?.config ? JSON.parse(ollamaProvider.config).baseUrl : 'http://127.0.0.1:11434'
 
     // Convert messages to Ollama format
-    const ollamaMessages = messages.map(msg => ({
+    const historial: any[] = messages.map(msg => ({
       role: msg.role,
       content: msg.content
     }))
 
-    const requestBody = {
-      model: model,
-      messages: ollamaMessages,
-      stream: false,
-    }
-
-    logger.debug('Ollama API Request', { model, messagesCount: ollamaMessages.length, baseUrl })
+    let usarHerramientas = !!red
+    let vueltas = 0
+    let entrada = 0
+    let salida = 0
+    let ultima: any = null
 
     try {
-      const response = await fetch(`${baseUrl}/api/chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-        signal: AbortSignal.timeout(120000) // 120 second timeout for local models
-      })
+      for (;;) {
+        const requestBody: any = {
+          model: model,
+          messages: historial,
+          stream: false,
+        }
+        if (usarHerramientas) requestBody.tools = herramientasOpenAI(HERRAMIENTAS)
 
-      if (!response.ok) {
-        const errorData = await response.text()
-        logger.error('Ollama API error', new Error(errorData), { status: response.status })
+        logger.debug('Ollama API Request', {
+          model,
+          messagesCount: historial.length,
+          baseUrl,
+          herramientas: usarHerramientas,
+        })
 
-        switch (response.status) {
-          case 404:
-            throw new Error(`Ollama model "${model}" not found. Please pull the model first: ollama pull ${model}`)
-          case 500:
-            throw new Error('Ollama internal error. Please check if Ollama is running.')
-          default:
-            throw new Error(`Ollama API error (${response.status}): ${errorData}`)
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+          signal: AbortSignal.timeout(usarHerramientas ? TIMEOUT_OLLAMA_HERRAMIENTAS_MS : TIMEOUT_OLLAMA_MS)
+        })
+
+        if (!response.ok) {
+          const errorData = await response.text()
+
+          // Muchos modelos locales no traen plantilla de herramientas y Ollama
+          // responde 400. Se reintenta sin ellas antes de dar error.
+          if (usarHerramientas && esErrorDeHerramientas(response.status, errorData)) {
+            logger.warn('Ollama rechaza las herramientas, se reintenta sin ellas', { model })
+            usarHerramientas = false
+            continue
+          }
+
+          logger.error('Ollama API error', new Error(errorData), { status: response.status })
+
+          switch (response.status) {
+            case 404:
+              throw new Error(`Ollama model "${model}" not found. Please pull the model first: ollama pull ${model}`)
+            case 500:
+              throw new Error('Ollama internal error. Please check if Ollama is running.')
+            default:
+              throw new Error(`Ollama API error (${response.status}): ${errorData}`)
+          }
+        }
+
+        const data = await response.json() as any
+        ultima = data
+        entrada += data.prompt_eval_count || 0
+        salida += data.eval_count || 0
+
+        const llamadas = usarHerramientas ? llamadasDesdeOllama(data) : []
+        if (llamadas.length === 0) break
+
+        historial.push(data.message)
+        historial.push(...mensajesResultadosOpenAI(this.ejecutarLlamadas(llamadas, red!)))
+
+        if (++vueltas >= MAX_VUELTAS_HERRAMIENTAS) {
+          logger.warn('Tope de vueltas de herramientas alcanzado', { model, vueltas })
+          usarHerramientas = false
         }
       }
 
-      const data = await response.json() as any
-
       return {
-        response: data.message?.content || 'No response from Ollama',
+        // Al pedir herramientas, nemotron devuelve content=" ": si se toma tal
+        // cual, el chat ensena una respuesta en blanco.
+        response: ultima?.message?.content?.trim() || 'No response from Ollama',
         metadata: {
           model: model,
           provider: 'Ollama',
-          tokens: data.prompt_eval_count + data.eval_count || 0,
+          tokens: entrada + salida,
           usage: {
-            prompt_tokens: data.prompt_eval_count || 0,
-            completion_tokens: data.eval_count || 0,
-            total_tokens: (data.prompt_eval_count || 0) + (data.eval_count || 0),
+            prompt_tokens: entrada,
+            completion_tokens: salida,
+            total_tokens: entrada + salida,
           },
+          vueltas_herramientas: vueltas,
           created_at: new Date().toISOString(),
         }
       }
@@ -575,62 +793,39 @@ export class ChatHandler {
     }
   }
 
-  private async sendNvidiaMessage(model: string, messages: ChatMessage[], apiKey: string): Promise<ChatResponse> {
-    const requestBody = {
-      model: model,
-      messages: messages,
-      stream: false,
-      max_tokens: 4096,
-      temperature: 0.5,
-      top_p: 1,
-      // frequency_penalty: 0,
-      // presence_penalty: 0
-    }
-
-    logger.debug('Nvidia API Request via backend', { model, messagesCount: messages.length })
-
-    const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
+  private async sendNvidiaMessage(
+    model: string,
+    messages: ChatMessage[],
+    apiKey: string,
+    red?: RedCompleta | null
+  ): Promise<ChatResponse> {
+    return this.enviarOpenAICompat({
+      url: 'https://integrate.api.nvidia.com/v1/chat/completions',
+      proveedor: 'Nvidia',
+      cabeceras: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${apiKey}`,
-        'Accept': 'application/json'
+        'Accept': 'application/json',
       },
-      body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(120000) // 120 second timeout for Nvidia
-    })
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as any
-      const errorMessage = errorData.detail || errorData.title || `Error ${response.status}`
-
-      switch (response.status) {
-        case 401:
-          throw new Error('🔑 Invalid Nvidia API key. Please check your API key in settings.')
-        case 402:
-          throw new Error('💳 Insufficient Nvidia credits.')
-        case 403:
-          throw new Error('🚫 Access denied to Nvidia API. Please check your account permissions.')
-        case 429:
-          throw new Error('Too many requests to Nvidia. Please try again later.')
-        default:
-          throw new Error(`Nvidia API error (${response.status}): ${errorMessage}`)
-      }
-    }
-
-    const data = await response.json() as any
-
-    return {
-      response: data.choices?.[0]?.message?.content || 'No response from Nvidia',
-      metadata: {
-        model: data.model || model,
-        provider: 'Nvidia',
-        tokens: data.usage?.total_tokens || 0,
-        usage: data.usage || {},
-        finish_reason: data.choices?.[0]?.finish_reason,
-        created_at: new Date(data.created * 1000).toISOString(),
-      }
-    }
+      cuerpoExtra: { max_tokens: 4096, temperature: 0.5, top_p: 1 },
+      timeout: 120000, // 120 second timeout for Nvidia
+      modeloDeLaRespuesta: true,
+      extraerError: (errorData, status) => errorData.detail || errorData.title || `Error ${status}`,
+      lanzarError: (status, errorMessage) => {
+        switch (status) {
+          case 401:
+            throw new Error('\u{1F511} Invalid Nvidia API key. Please check your API key in settings.')
+          case 402:
+            throw new Error('\u{1F4B3} Insufficient Nvidia credits.')
+          case 403:
+            throw new Error('\u{1F6AB} Access denied to Nvidia API. Please check your account permissions.')
+          case 429:
+            throw new Error('Too many requests to Nvidia. Please try again later.')
+          default:
+            throw new Error(`Nvidia API error (${status}): ${errorMessage}`)
+        }
+      },
+    }, model, messages, red)
   }
 
   unregisterHandlers(): void {

--- a/electron/handlers/networkRepository.handler.test.ts
+++ b/electron/handlers/networkRepository.handler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * `window.electronAPI.networkRepository` no está declarado en
+ * `src/types/declarations.d.ts`, así que la llamada del renderer no se
+ * comprueba en compilación: pasar el proveedor en la posición equivocada daría
+ * un texto sin herramientas sin que nadie se entere. Esto fija el contrato del
+ * canal por el lado del main.
+ */
+
+const handlersRegistrados: Record<string, (evento: unknown, ...args: any[]) => Promise<any>> = {}
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (canal: string, fn: any) => { handlersRegistrados[canal] = fn },
+    removeHandler: () => {},
+    removeAllListeners: () => {},
+  },
+}))
+
+import { NetworkRepositoryHandler } from './networkRepository.handler'
+
+const RED = {
+  nodes: [{ id: 'J1', type: 'junction', elevation: 10, demand: 0.000231 }],
+  links: [{ id: 'P1', type: 'pipe', from: 'R1', to: 'J1', length: 200, diameter: 0.075 }],
+}
+
+// La red solo existe para «p1»: si el fake respondiera a cualquier projectId,
+// el test de los argumentos invertidos pasaria sin comprobar nada.
+const prismaFalso = {
+  hydraulicNetwork: {
+    findFirst: async ({ where }: any) =>
+      where?.projectId === 'p1'
+        ? {
+            id: 'n1',
+            name: 'villa_100_casas.inp',
+            summary: JSON.stringify({ junctions: 1, pipes: 1 }),
+            networkData: JSON.stringify(RED),
+          }
+        : null,
+  },
+  hydraulicCalculation: { findMany: async () => [] },
+} as any
+
+const pedirContexto = (projectId: string, proveedor?: string) =>
+  handlersRegistrados['network-repo:context'](null, projectId, proveedor)
+
+describe('network-repo:context', () => {
+  it('con un proveedor que sabe usar herramientas, manda consultar', async () => {
+    new NetworkRepositoryHandler(prismaFalso)
+    const r = await pedirContexto('p1', 'anthropic')
+
+    expect(r.success).toBe(true)
+    expect(r.data.resumen.nombre).toBe('villa_100_casas.inp')
+    expect(r.data.texto).toContain('herramientas de consulta')
+  })
+
+  it('con Google no promete una consulta que no puede hacer', async () => {
+    new NetworkRepositoryHandler(prismaFalso)
+    const r = await pedirContexto('p1', 'google')
+
+    expect(r.data.texto).toContain('no puedes consultar nudos ni tramos concretos')
+    expect(r.data.texto).not.toContain('herramientas de consulta')
+  })
+
+  it('sin proveedor tampoco promete', async () => {
+    // Es lo que pasa con `RedEnContexto`, que llama sin proveedor porque solo
+    // usa el resumen. Que el texto salga conservador es lo correcto.
+    new NetworkRepositoryHandler(prismaFalso)
+    const r = await pedirContexto('p1')
+
+    expect(r.data.texto).not.toContain('herramientas de consulta')
+  })
+
+  it('projectId va primero y proveedor segundo, y el orden importa', async () => {
+    // El renderer llama sin tipos, asi que invertirlos no lo cazaria el
+    // compilador: «anthropic» se leeria como projectId, no habria red y el
+    // agente se quedaria con el bloque de chat general teniendo una delante.
+    new NetworkRepositoryHandler(prismaFalso)
+
+    const bien = await pedirContexto('p1', 'anthropic')
+    expect(bien.data.texto).toContain('=== RED HIDRÁULICA ACTIVA ===')
+    expect(bien.data.texto).toContain('herramientas de consulta')
+
+    const alReves = await pedirContexto('anthropic', 'p1')
+    expect(alReves.data.resumen).toBeNull()
+    expect(alReves.data.texto).toContain('=== CHAT GENERAL ===')
+  })
+
+  it('sin proyecto devuelve el bloque de chat general', async () => {
+    new NetworkRepositoryHandler(prismaFalso)
+    const r = await pedirContexto('', 'anthropic')
+
+    expect(r.data.resumen).toBeNull()
+    expect(r.data.texto).toContain('=== CHAT GENERAL ===')
+  })
+})

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -3,13 +3,16 @@ import { readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { NetworkRepositoryService } from '../../backend/services/hydraulic/networkRepository'
+import { construirResumenRed, formatearContextoRed } from '../../backend/services/hydraulic/networkContext'
 import type { PrismaClient } from '@prisma/client'
 import { appLogger } from '../../backend/utils/logger'
 
 export class NetworkRepositoryHandler {
   private networkRepo: NetworkRepositoryService
+  private prisma: PrismaClient
 
   constructor(prisma: PrismaClient) {
+    this.prisma = prisma
     this.networkRepo = new NetworkRepositoryService(prisma)
     this.setupHandlers()
   }
@@ -289,6 +292,58 @@ export class NetworkRepositoryHandler {
           success: false,
           error: (error as Error).message
         }
+      }
+    })
+
+    // Resumen de la red activa para el agente del chat (#34)
+    ipcMain.handle('network-repo:context', async (_, projectId: string) => {
+      try {
+        if (!projectId) {
+          return { success: true, data: { resumen: null, texto: formatearContextoRed(null) } }
+        }
+
+        const red = await this.prisma.hydraulicNetwork.findFirst({
+          where: { projectId, isActive: true },
+          orderBy: { updatedAt: 'desc' }
+        })
+
+        if (!red) {
+          return { success: true, data: { resumen: null, texto: formatearContextoRed(null) } }
+        }
+
+        // La última simulación no sale de HydraulicNetwork.simulationResults:
+        // esa columna está vacía en todas las redes porque el handler que la
+        // escribe (network-repo:save-simulation) no lo llama nadie. Los datos
+        // reales están en HydraulicCalculation, con el id de la red dentro del
+        // JSON de `inputs`.
+        const calculos = await this.prisma.hydraulicCalculation.findMany({
+          where: { projectId },
+          orderBy: { createdAt: 'desc' },
+          take: 50,
+          select: { name: true, createdAt: true, inputs: true }
+        })
+
+        const ultima = calculos.find(c => {
+          try {
+            return JSON.parse(c.inputs ?? '{}')?.networkId === red.id
+          } catch {
+            return false
+          }
+        })
+
+        const resumen = construirResumenRed({
+          nombreRed: red.name,
+          contadores: JSON.parse(red.summary || '{}'),
+          datos: JSON.parse(red.networkData || '{}'),
+          ultimaSimulacion: ultima ? { nombre: ultima.name, fecha: ultima.createdAt } : null
+        })
+
+        return { success: true, data: { resumen, texto: formatearContextoRed(resumen) } }
+      } catch (error) {
+        appLogger.error('Failed to build network context', error as Error)
+        // Sin contexto es mejor no decir nada que decir que hay una red y no
+        // dar ni una cifra, que es justo lo que hacía antes.
+        return { success: false, error: (error as Error).message }
       }
     })
   }

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { NetworkRepositoryService } from '../../backend/services/hydraulic/networkRepository'
 import { construirResumenRed, formatearContextoRed } from '../../backend/services/hydraulic/networkContext'
 import { leerRedActiva } from '../../backend/services/hydraulic/redActiva'
+import { proveedorSoportaHerramientas } from '../../backend/services/ai/toolWire'
 import type { PrismaClient } from '@prisma/client'
 import { appLogger } from '../../backend/utils/logger'
 
@@ -296,8 +297,12 @@ export class NetworkRepositoryHandler {
       }
     })
 
-    // Resumen de la red activa para el agente del chat (#34)
-    ipcMain.handle('network-repo:context', async (_, projectId: string) => {
+    // Resumen de la red activa para el agente del chat (#34).
+    // El proveedor llega porque el texto cambia segun pueda o no consultar la
+    // red con herramientas: prometer una consulta que no existe le pide al
+    // modelo justo la invencion que el resto del bloque trata de evitar.
+    ipcMain.handle('network-repo:context', async (_, projectId: string, proveedor?: string) => {
+      const conHerramientas = proveedorSoportaHerramientas(proveedor)
       try {
         if (!projectId) {
           return { success: true, data: { resumen: null, texto: formatearContextoRed(null) } }
@@ -336,7 +341,7 @@ export class NetworkRepositoryHandler {
           ultimaSimulacion: ultima ? { nombre: ultima.name, fecha: ultima.createdAt } : null
         })
 
-        return { success: true, data: { resumen, texto: formatearContextoRed(resumen) } }
+        return { success: true, data: { resumen, texto: formatearContextoRed(resumen, conHerramientas) } }
       } catch (error) {
         appLogger.error('Failed to build network context', error as Error)
         // Sin contexto es mejor no decir nada que decir que hay una red y no

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { NetworkRepositoryService } from '../../backend/services/hydraulic/networkRepository'
 import { construirResumenRed, formatearContextoRed } from '../../backend/services/hydraulic/networkContext'
+import { leerRedActiva } from '../../backend/services/hydraulic/redActiva'
 import type { PrismaClient } from '@prisma/client'
 import { appLogger } from '../../backend/utils/logger'
 
@@ -302,10 +303,7 @@ export class NetworkRepositoryHandler {
           return { success: true, data: { resumen: null, texto: formatearContextoRed(null) } }
         }
 
-        const red = await this.prisma.hydraulicNetwork.findFirst({
-          where: { projectId, isActive: true },
-          orderBy: { updatedAt: 'desc' }
-        })
+        const red = await leerRedActiva(this.prisma, projectId)
 
         if (!red) {
           return { success: true, data: { resumen: null, texto: formatearContextoRed(null) } }
@@ -332,9 +330,9 @@ export class NetworkRepositoryHandler {
         })
 
         const resumen = construirResumenRed({
-          nombreRed: red.name,
-          contadores: JSON.parse(red.summary || '{}'),
-          datos: JSON.parse(red.networkData || '{}'),
+          nombreRed: red.nombre,
+          contadores: red.contadores,
+          datos: red.datos,
           ultimaSimulacion: ultima ? { nombre: ultima.name, fecha: ultima.createdAt } : null
         })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -189,6 +189,8 @@ const electronAPI = {
 
     // Simulation results
     saveSimulation: (data: { networkId: string; results: any }) => ipcRenderer.invoke('network-repo:save-simulation', data),
+    /** Resumen de la red activa para el agente del chat (#34) */
+    context: (projectId: string) => ipcRenderer.invoke('network-repo:context', projectId),
 
     // Statistics
     getStats: (projectId: string) => ipcRenderer.invoke('network-repo:stats', projectId),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -190,7 +190,7 @@ const electronAPI = {
     // Simulation results
     saveSimulation: (data: { networkId: string; results: any }) => ipcRenderer.invoke('network-repo:save-simulation', data),
     /** Resumen de la red activa para el agente del chat (#34) */
-    context: (projectId: string) => ipcRenderer.invoke('network-repo:context', projectId),
+    context: (projectId: string, proveedor?: string) => ipcRenderer.invoke('network-repo:context', projectId, proveedor),
 
     // Statistics
     getStats: (projectId: string) => ipcRenderer.invoke('network-repo:stats', projectId),

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -8,6 +8,7 @@ import { ModelSelector } from './ModelSelector'
 import { WisdomSelector } from './WisdomSelector'
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal'
 import { ProjectSelector } from './ProjectSelector'
+import { RedEnContexto } from './RedEnContexto'
 import { NewProjectDialog } from '@/components/hydraulic/NewProjectDialog'
 import * as Dialog from '@radix-ui/react-dialog'
 
@@ -142,6 +143,10 @@ export function ChatHeader({ conversation }: ChatHeaderProps) {
           selectedProjectId={conversation.projectId}
           onProjectSelect={handleProjectChange}
         />
+
+        {/* Qué red está viendo el agente (#34): sin esto el usuario no puede
+            saber si el chat responde sobre su red o de memoria. */}
+        <RedEnContexto />
         
         {isEditing ? (
           <input

--- a/src/components/chat/RedEnContexto.tsx
+++ b/src/components/chat/RedEnContexto.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Network, AlertCircle } from 'lucide-react'
+import { useProjectStore } from '@/stores/projectStore'
+import { logger } from '@/utils/logger'
+
+interface ResumenRed {
+  nombre: string
+  junctions: number
+  pipes: number
+  longitudTotalM: number
+}
+
+interface RespuestaContexto {
+  success: boolean
+  data?: { resumen: ResumenRed | null }
+}
+
+/**
+ * Dice qué red está viendo el agente (issue #34, criterio 3).
+ *
+ * Sin esto el usuario no puede saber si el chat responde sobre su red o de
+ * memoria, que es justo la confusión que el issue quiere eliminar.
+ */
+export function RedEnContexto() {
+  const { t } = useTranslation()
+  const projectId = useProjectStore(s => s.currentProjectId)
+  const [resumen, setResumen] = useState<ResumenRed | null>(null)
+  const [cargando, setCargando] = useState(false)
+
+  useEffect(() => {
+    let vigente = true
+    if (!projectId) {
+      setResumen(null)
+      return
+    }
+    setCargando(true)
+    window.electronAPI.networkRepository
+      .context(projectId)
+      .then((r: RespuestaContexto) => {
+        if (vigente) setResumen(r?.success ? r.data?.resumen ?? null : null)
+      })
+      .catch((e: unknown) => {
+        logger.warn('No se pudo leer la red en contexto:', e)
+        if (vigente) setResumen(null)
+      })
+      .finally(() => { if (vigente) setCargando(false) })
+    return () => { vigente = false }
+  }, [projectId])
+
+  if (cargando) return null
+
+  if (!resumen) {
+    return (
+      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground" title={t('chat.redEnContexto.ningunaAyuda')}>
+        <AlertCircle className="h-3 w-3" />
+        <span>{t('chat.redEnContexto.ninguna')}</span>
+      </div>
+    )
+  }
+
+  const km = (resumen.longitudTotalM / 1000).toFixed(2)
+  return (
+    <div
+      className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
+      title={t('chat.redEnContexto.detalle', { nudos: resumen.junctions, tuberias: resumen.pipes, km })}
+    >
+      <Network className="h-3 w-3 text-primary" />
+      <span>{t('chat.redEnContexto.viendo', { red: resumen.nombre })}</span>
+    </div>
+  )
+}

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -45,7 +45,13 @@
     "copyToClipboard": "Copiar al portapapers",
     "exportAsJSON": "Exportar com JSON",
     "deleteConversation": "Eliminar conversa",
-    "confirmDelete": "Estàs segur que vols eliminar aquesta conversa? Aquesta acció no es pot desfer."
+    "confirmDelete": "Estàs segur que vols eliminar aquesta conversa? Aquesta acció no es pot desfer.",
+    "redEnContexto": {
+      "viendo": "L'agent veu: {{red}}",
+      "ninguna": "L'agent no veu cap xarxa",
+      "ningunaAyuda": "Carrega un fitxer .inp al projecte perquè el xat pugui respondre sobre la teva xarxa.",
+      "detalle": "{{nudos}} nusos · {{tuberias}} canonades · {{km}} km de canonada"
+    }
   },
   "settings": {
     "title": "Configuració",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,13 @@
     "copyToClipboard": "Copy to Clipboard",
     "exportAsJSON": "Export as JSON",
     "deleteConversation": "Delete conversation",
-    "confirmDelete": "Are you sure you want to delete this conversation? This action cannot be undone."
+    "confirmDelete": "Are you sure you want to delete this conversation? This action cannot be undone.",
+    "redEnContexto": {
+      "viendo": "Agent sees: {{red}}",
+      "ninguna": "The agent sees no network",
+      "ningunaAyuda": "Load an .inp file into the project so the chat can answer about your network.",
+      "detalle": "{{nudos}} junctions · {{tuberias}} pipes · {{km}} km of pipe"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -45,7 +45,13 @@
     "copyToClipboard": "Copiar al portapapeles",
     "exportAsJSON": "Exportar como JSON",
     "deleteConversation": "Eliminar conversación",
-    "confirmDelete": "¿Estás seguro de que quieres eliminar esta conversación? Esta acción no se puede deshacer."
+    "confirmDelete": "¿Estás seguro de que quieres eliminar esta conversación? Esta acción no se puede deshacer.",
+    "redEnContexto": {
+      "viendo": "El agente ve: {{red}}",
+      "ninguna": "El agente no ve ninguna red",
+      "ningunaAyuda": "Carga un archivo .inp en el proyecto para que el chat pueda responder sobre tu red.",
+      "detalle": "{{nudos}} nudos · {{tuberias}} tuberías · {{km}} km de tubería"
+    }
   },
   "settings": {
     "title": "Configuración",

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -299,11 +299,13 @@ export const useChatStore = create<ChatState>()(
             // generalidades pasaría a depender de la disposición del modelo de
             // turno en lugar del prompt. Con llama3.2 la respuesta era pedir
             // más datos, pero incluía un «Ejemplo» con cifras inventadas.
+            let hayRedEnContexto = false
             try {
               const red = await window.electronAPI.networkRepository.context(proyectoParaContexto ?? '')
               if (red?.success && red.data?.texto) {
                 enhancedPrompt = red.data.texto + enhancedPrompt
               }
+              hayRedEnContexto = !!red?.data?.resumen
             } catch (error) {
               logger.warn('Failed to build network context:', error)
             }
@@ -349,7 +351,11 @@ export const useChatStore = create<ChatState>()(
             const MAX_RETRIES = 1
             let lastError: Error | null = null
 
-            const isOllama = conversation.provider.toLowerCase() === 'ollama'
+            // Ollama va por streaming salvo cuando hay red que consultar: las
+            // herramientas necesitan varias vueltas de peticion y respuesta, y
+            // eso vive en el handler IPC. Se cambia respuesta token a token por
+            // respuesta con datos de la red, que es el objeto de #34.
+            const isOllama = conversation.provider.toLowerCase() === 'ollama' && !hayRedEnContexto
 
             for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
               try {
@@ -378,7 +384,11 @@ export const useChatStore = create<ChatState>()(
                     provider: conversation.provider,
                     model: conversation.model,
                     messages: messages,
-                    apiKey: apiKey
+                    apiKey: apiKey,
+
+                    // Con proyecto el agente puede consultar la red por
+                    // herramientas, en vez de quedarse en el resumen (#34).
+                    projectId: proyectoParaContexto
                   })
                 }
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -301,7 +301,10 @@ export const useChatStore = create<ChatState>()(
             // más datos, pero incluía un «Ejemplo» con cifras inventadas.
             let hayRedEnContexto = false
             try {
-              const red = await window.electronAPI.networkRepository.context(proyectoParaContexto ?? '')
+              const red = await window.electronAPI.networkRepository.context(
+                proyectoParaContexto ?? '',
+                conversation.provider
+              )
               if (red?.success && red.data?.texto) {
                 enhancedPrompt = red.data.texto + enhancedPrompt
               }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -280,14 +280,41 @@ export const useChatStore = create<ChatState>()(
             const conversation = get().conversations.find(c => c.id === conversationId)
             if (!conversation) throw new Error('Conversation not found')
 
-            // Prepend hydraulic project context when the conversation is linked to a project
-            if (conversation.projectId) {
+            // El contexto sale del proyecto de la conversación o, si no tiene,
+            // del proyecto activo global (#31). Antes se exigía el enlace
+            // explícito, así que un chat «General» no recibía nada aunque
+            // hubiera una red cargada delante (#34).
+            // Import dinámico por la misma razón que arriba: evitar la
+            // dependencia circular entre stores.
+            const proyectoActivo = conversation.projectId
+              ? null
+              : await import('./projectStore')
+                  .then(({ useProjectStore }) => useProjectStore.getState().currentProjectId)
+                  .catch(() => null)
+            const proyectoParaContexto = conversation.projectId ?? proyectoActivo ?? undefined
+
+            // El contexto de red se inyecta SIEMPRE, haya proyecto o no. Si se
+            // omitiera al no haber proyecto, el modelo se quedaría sin la
+            // instrucción de no describir ninguna red, y responder con
+            // generalidades pasaría a depender de la disposición del modelo de
+            // turno en lugar del prompt. Con llama3.2 la respuesta era pedir
+            // más datos, pero incluía un «Ejemplo» con cifras inventadas.
+            try {
+              const red = await window.electronAPI.networkRepository.context(proyectoParaContexto ?? '')
+              if (red?.success && red.data?.texto) {
+                enhancedPrompt = red.data.texto + enhancedPrompt
+              }
+            } catch (error) {
+              logger.warn('Failed to build network context:', error)
+            }
+
+            if (proyectoParaContexto) {
               try {
                 const projectContextTimeout = new Promise<string>((resolve) =>
                   setTimeout(() => resolve(''), 10000)
                 )
                 const projectContext = await Promise.race([
-                  get().buildProjectContext(conversation.projectId),
+                  get().buildProjectContext(proyectoParaContexto),
                   projectContextTimeout
                 ])
                 if (projectContext) {
@@ -777,10 +804,6 @@ export const useChatStore = create<ChatState>()(
           if (project.status) context += `Status: ${project.status}\n`
           if (project.location?.country || project.location?.region) {
             context += `Location: ${[project.location?.city, project.location?.region, project.location?.country].filter(Boolean).join(', ')}\n`
-          }
-
-          if (project.network) {
-            context += `\nNetwork model: loaded (EPANET .inp data available for this project)\n`
           }
 
           if (project.calculations && project.calculations.length > 0) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}', 'backend/**/*.{test,spec}.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'backend/**/*.{test,spec}.ts', 'electron/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
Closes #34

## El problema

El contexto que recibía el agente decía esto sobre la red, y sólo esto:

```
Network model: loaded (EPANET .inp data available for this project)
```

Es peor que no decir nada: el modelo sabe que existe una red, no tiene una sola cifra sobre ella, y nada le impide rellenar el hueco. En la base de pruebas hay una conversación real que lo enseña: a «¿cómo puedo mejorar el flujo de agua en la junta 3?» el agente respondió consejos genéricos sobre limpiar una junta mecánica, sin enterarse de que J3 es un nudo de una red de cinco.

## Primer nivel: el resumen en el prompt

Se inyecta un resumen fijo de la red activa (≈12 líneas, no crece con el tamaño de la red):

```
=== RED HIDRÁULICA ACTIVA ===
Red: villa_100_casas.inp
Nudos de consumo: 5 · Depósitos: 1 · Embalses: 1
Tuberías: 6 · Bombas: 0 · Válvulas: 0
Longitud total de tubería: 1.03 km
Demanda base total: 1.16 L/s
Diámetros: de 50 a 100 mm
Coordenadas: geográficas (lat/lon)
Última simulación guardada: «Interrupción de Servicio (PDA): P2» (2026-08-18)
=== FIN RED HIDRÁULICA ===
```

Y la cabecera del chat indica qué red está viendo el agente, que es el criterio 3 del issue.

| Pieza | Fichero |
|---|---|
| Resumen y formato (módulo puro) | `backend/services/hydraulic/networkContext.ts` |
| Lectura de la red activa, compartida | `backend/services/hydraulic/redActiva.ts` |
| Lectura de datos y cita de simulación | `network-repo:context` en `networkRepository.handler.ts` |
| Inyección en el prompt | `chatStore.ts` |
| Indicador en la interfaz | `src/components/chat/RedEnContexto.tsx` |

## Tres decisiones que se apartan del issue

**La última simulación no sale de donde el issue decía.** El issue pide citar `HydraulicNetwork.simulationResults`. Esa columna está vacía en las cuatro redes guardadas, y la causa es concreta: el handler que la escribe, `network-repo:save-simulation`, está expuesto en el preload y no lo llama nadie. Los datos reales están en `HydraulicCalculation`, con el id de la red dentro del JSON de `inputs`, así que se cita lo que el usuario ha ejecutado de verdad.

**Longitud, demanda y CRS no existían como campo.** Se calculan sumando `networkData`. El `epsg` viene a `null` en las cuatro redes, así que se declara lo que se sabe («geográficas (lat/lon)») en vez de inventar un código.

**Sin proyecto no hay estado degradado: hay chat general.** El contexto se inyecta siempre, con proyecto o sin él, declarando las reglas del modo general. La primera versión sólo lo hacía con proyecto, y probándolo con `llama3.2` la respuesta a «resume mi red hidráulica» pedía más información —bien— pero incluía un «Ejemplo» con 5 tuberías y 500 metros que un usuario distraído puede leer como su red. Que se portara razonablemente era disposición del modelo, no garantía del prompt; de ahí la prohibición explícita de los ejemplos numéricos.

También se corrige que un chat «General» no recibía contexto aunque hubiera una red delante: tras #31 el proyecto es global, así que ahora se usa el de la conversación o, si no tiene, el proyecto activo.

## Segundo nivel: herramientas

El resumen son doce líneas fijas. Para responder sobre un nudo concreto de una red de 92 nudos hace falta consultar bajo demanda, así que el agente tiene dos herramientas:

- `consultar_elemento(id)` — un nudo con sus tramos conectados, o un tramo con sus dos extremos.
- `listar_elementos(tipo, ordenar_por, límite)` — agregados, con tope de 50 y aviso explícito cuando recorta, para que no presente diez tuberías como si fueran las 117.

Las unidades se convierten en la herramienta: WNTR normaliza a SI, y diámetros como `0.075` o demandas como `0.000231` los modelos los redondean a cero.

| Dialecto | Proveedores |
|---|---|
| Anthropic (`input_schema` / `tool_use` / `tool_result`) | Anthropic |
| OpenAI (`tools[].function` / `tool_calls` / `role:'tool'`) | OpenAI, OpenRouter, NVIDIA |
| El de OpenAI, con la respuesta colgando de `message` y los argumentos ya como objeto | Ollama |

Google queda fuera: usa `functionDeclarations`.

**El bucle se cierra dentro de una sola llamada a `chat:send-message`.** Los turnos intermedios viven en memoria y sólo se guarda el texto final, así que la conversación persistida sigue siendo texto plano y no hay que tocar Prisma, el render ni el tipo `ChatMessage`. El precio es que en el turno siguiente el modelo ya no ve los resultados salvo por lo que escribió.

**La capacidad no se declara, se descubre.** OpenRouter y NVIDIA sirven cientos de modelos y una lista blanca envejecería mal, así que si la API rechaza las herramientas se reintenta sin ellas. Con test de que un 400 por saldo insuficiente **no** dispara el reintento.

Ollama va por el handler IPC cuando hay red que consultar, porque el bucle vive allí; sin red sigue por la ruta de streaming de siempre.

**El texto del prompt sabe qué puede prometer.** El cierre del bloque cambia según el proveedor: con herramientas dice «no estimes lo que puedes mirar»; sin ellas, «no puedes consultar nudos ni tramos concretos». Prometerle a Google una consulta que no puede hacer le pide justo la invención que el resto del bloque evita. Lo decide `proveedorSoportaHerramientas`, **la misma función que usa el despacho del handler para cargar la red**, así que el texto y el código no pueden decir cosas distintas. Por defecto va a `false`: quien no sabe el proveedor, no promete.

## Verificación contra la app real

Con Ollama, `llama3.1:8b` y `Net3 2.inp` (92 nudos, 117 tuberías), preguntando por la cota del nudo 121:

> La cota del nudo 121 es **-0,6096 metros**

que es exactamente el valor de la red. El mismo nudo, antes, recibía «90» y «0.56». Se comprobaron las dos vueltas en los logs de Ollama (1m12s y 1m57s, ambas 200).

Cuatro cosas salieron de esa prueba y están arregladas en el código:

1. **`nemotron-mini` llama a una herramienta pero no a dos** (3/4 frente a 0/6). Aislado por ablación: la única variable que cambia el resultado es el número de herramientas, no el tamaño del prompt ni el historial. Es un modelo de 4B; no da para esto.
2. **Envuelve los argumentos dos veces** — `{"type":"consultar_elemento","arguments":{"id":"121"}}` en vez de `{"id":"121"}`, de forma consistente. Sin deshacerlo la herramienta responde «falta el argumento id» con el modelo convencido de que lo mandó.
3. **El ejemplo `"J3"` de la descripción inducía a pedir `J121`** para un nudo que se llama `121`. La descripción ahora desaconseja añadir o quitar prefijos.
4. **Los 120 s de Ollama se quedaban cortos**: con herramientas cada respuesta cuesta dos inferencias completas, y el primer intento murió con «The operation was aborted due to timeout». Ahora 300 s, sólo cuando hay herramientas en juego.

`nemotron-3-nano` no se pudo evaluar: son 24 GB de modelo para 15 GB de RAM, y acabó en swap a 3 tokens/s.

## Comprobaciones

- `npm test` → **181 pasan** (18 ficheros). Los del resumen y los de las herramientas se contrastan además contra las redes realmente guardadas en `prisma/hydraulic.db`; los del bucle, contra un `fetch` simulado que cubre las tres formas de respuesta, el reintento sin herramientas y el tope de vueltas.
- `npm run typecheck` y `tsc -p tsconfig.electron.json` → limpios.
- `npx eslint` sobre los ficheros nuevos → sin avisos.
- El canal `network-repo:context` se prueba por el lado del main: `window.electronAPI.networkRepository` no está declarado en `declarations.d.ts`, así que invertir sus argumentos no lo cazaría el compilador y dejaría al agente con el bloque de chat general teniendo una red delante.
- `vite.config.ts` pasa a incluir `electron/**` en Vitest; sin eso los tests del bucle no se ejecutaban.

## Fuera de alcance

Google, por el dialecto. Y las herramientas de escritura (lanzar una simulación desde el chat): aquí sólo se lee.

Diseño y decisiones completos en [`docs/CONTEXTO_RED_AGENTE.md`](docs/CONTEXTO_RED_AGENTE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
