### PR TITLE
feat(navegacion): Proyectos como raíz de la navegación (#35)

### DIFF
--- a/docs/NAVEGACION_JERARQUICA.md
+++ b/docs/NAVEGACION_JERARQUICA.md
@@ -1,0 +1,109 @@
+# Navegación jerárquica con Proyectos como raíz
+
+Diseño y decisiones del issue [#35](https://github.com/Boorie-AI/boorie_cliente/issues/35).
+Continúa [`PROYECTO_ACTIVO_GLOBAL.md`](PROYECTO_ACTIVO_GLOBAL.md) (#31) y
+[`PRECONDICIONES_NAVEGACION.md`](PRECONDICIONES_NAVEGACION.md) (#33).
+
+## El problema
+
+El menú era una lista plana de seis elementos declarada dentro del propio
+componente: Chat → Proyectos → Calculadora → Red WNTR → Wisdom Center →
+Configuración. Nada decía qué pertenecía al proyecto y qué era global, así que
+«Red WNTR» —que sin proyecto no lleva a ninguna parte— estaba al mismo nivel que
+«Configuración».
+
+Además, la vista del Wisdom Center se llamaba `rag` en el enrutado mientras la
+etiqueta visible decía «Wisdom Center», y la vista por defecto era `chat`.
+
+## La jerarquía
+
+```
+PROYECTOS            ← raíz de la navegación y vista por defecto
+  └─ [proyecto activo]
+       ├─ Red WNTR
+       ├─ Simulaciones
+       └─ Chat del proyecto
+HERRAMIENTAS
+  ├─ Calculadora     ← independiente del proyecto
+  └─ Chat general
+SISTEMA
+  ├─ Wisdom Center
+  └─ Configuración
+```
+
+Los tres hijos sólo se pintan cuando hay proyecto activo; sin él, el bloque dice
+«Sin proyecto activo». El nombre del proyecto encabeza sus hijos, así que es
+visible desde cualquier vista sin abrir nada.
+
+| Pieza | Fichero |
+|---|---|
+| Modelo de navegación (módulo puro) | `src/config/navegacion.ts` |
+| Menú | `src/components/chat/Sidebar.tsx` |
+| Vista, ámbito del chat y sección de red | `src/stores/appStore.ts` |
+| Raíz de proyectos | `src/components/hydraulic/HydraulicProjectsPanel.tsx` |
+| Corrección de la vista al arrancar | `src/App.tsx` |
+
+## Decisiones
+
+**La raíz enseña siempre la lista de proyectos.** `HydraulicProjectsPanel` era un
+envoltorio de `WNTRMainInterface`, es decir, exactamente el mismo componente que
+«Red WNTR». Con un proyecto abierto, las dos entradas mostraban lo mismo y la
+lista de proyectos sólo se alcanzaba cerrando antes el proyecto desde un botón
+dentro de la vista de red. Ahora `WNTRMainInterface` recibe `modo`: en
+`'proyectos'` enseña siempre la lista —con el activo marcado— y en `'red'` sigue
+siendo la vista de trabajo de siempre. Elegir un proyecto en la lista no navega a
+ninguna parte: lo que cambia es el menú, que despliega sus hijos.
+
+**«Simulaciones» no es una vista nueva.** No hay pantalla de histórico de
+simulaciones, y fabricarla no es reorganizar un menú (eso está en #38 y #41). El
+ítem entra en la vista de red pidiendo su pestaña de simulación, mediante
+`seccionRed` en el store. Es el único ítem que exige red además de proyecto: la
+vista de red no la exige a propósito, porque es donde se importa el `.inp` (#33).
+
+**Los dos chats son la misma pantalla con distinto ámbito.** El chat general debe
+existir —criterio del Ing. Luis Mora recogido en el issue: Boorie también se usa
+como apoyo docente— y el del proyecto también, para interpretar la red y los
+resultados. No hacen falta dos vistas: `ambitoChat` decide qué conversaciones
+lista el menú y a qué proyecto queda atada la que se cree. En el chat general
+sólo se ven las conversaciones sin proyecto y el selector de proyecto no aparece;
+en el del proyecto, las del proyecto activo.
+
+**El árbol de proyectos del menú desaparece.** Listaba las conversaciones de
+todos los proyectos, que tras #31 es un atajo para trabajar fuera del proyecto
+activo. Para ver las de otro proyecto se cambia de proyecto.
+
+**Sin proyecto se arranca en Proyectos, pero no se pierde la vista guardada.** El
+issue pide las dos cosas: abrir en Proyectos sin proyecto activo y respetar la
+última vista de quien ya usaba la aplicación. `ajustarVistaInicial` sólo
+interviene cuando la vista restaurada tiene una precondición sin cumplir, y no
+persiste el cambio: con proyecto, la próxima sesión vuelve a abrir donde se
+quedó. La comprobación vive en `App.tsx` porque hasta que no terminan la carga de
+ajustes y la restauración del proyecto no se sabe si hay uno.
+
+**`rag` pasa a llamarse `wisdom`.** `migrarVista()` traduce el valor guardado por
+los usuarios que dejaron la aplicación en el Wisdom Center; sin eso arrancarían
+en la vista por defecto sin explicación, porque su valor ya no existiría.
+
+**`hayRed` era papel mojado.** Lo declaraba #33 pero ninguna vista lo usaba, y
+`hydraulic:get-project` no devolvía el contador: `currentProject.networkCount`
+llegaba siempre `undefined`. Se vio en cuanto «Simulaciones» empezó a usarlo —
+aparecía bloqueada con la red guardada delante—. El handler cuenta ahora las
+redes activas, con el mismo filtro `isActive` que la lista de proyectos, porque
+`deleteNetwork()` es un borrado lógico.
+
+## Fuera de alcance
+
+**Wisdom del proyecto.** La jerarquía del issue lo lista, pero separar el ámbito
+general del de proyecto en el Wisdom Center es el issue #39. Mientras tanto el
+Wisdom Center es global y vive en el bloque de sistema, que es lo que hoy es
+verdad.
+
+## Comprobado en la aplicación
+
+Ciclo completo con la base real: arranque con la vista guardada en `wntr` y sin
+proyecto activo → abre en Proyectos, con «Sin proyecto activo» y sin hijos;
+elegir un proyecto en la lista → tarjeta marcada «Activo» y los tres hijos
+aparecen bajo su nombre; «Simulaciones» → vista de red con la pestaña de
+simulación activa (verificado por `data-state` de las pestañas); «Chat del
+proyecto» → el menú lista sus conversaciones y la nueva queda atada al proyecto;
+«Chat general» → sólo las conversaciones sin proyecto.

--- a/electron/handlers/hydraulic.handler.ts
+++ b/electron/handlers/hydraulic.handler.ts
@@ -175,7 +175,10 @@ export class HydraulicHandler {
           include: {
             calculations: true,
             documents: true,
-            teamMembers: true
+            teamMembers: true,
+            // Mismo criterio que la lista: deleteNetwork() es borrado lógico, y
+            // sin filtrar isActive el contador incluiría redes ya borradas.
+            _count: { select: { networks: { where: { isActive: true } } } }
           }
         })
         
@@ -236,6 +239,7 @@ export class HydraulicHandler {
             joinedAt: tm.joinedAt
           })),
           status: project.status as any,
+          networkCount: project._count.networks,
           createdAt: project.createdAt,
           updatedAt: project.updatedAt
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,16 +22,22 @@ function App() {
   const [setupSkipped, setSetupSkipped] = useState(false)
   const [informeMigracion, setInformeMigracion] = useState<Awaited<ReturnType<typeof migrateProjectAssets>> | null>(null)
 
-  useEffect(() => {
-    initializeApp()
-  }, [initializeApp])
-
   // El proyecto activo se restaura aquí, y no en el store, porque hace falta
   // que window.electronAPI exista para releerlo de la base de datos. Si el
   // proyecto se borró entre sesiones, el store descarta el id sin romper nada.
+  //
+  // Las dos cargas van juntas porque la vista restaurada sólo se puede validar
+  // cuando ya se sabe si hay proyecto: sin él, arrancar en la red hidráulica
+  // dejaría al usuario en un aviso en vez de en Proyectos (#35).
   useEffect(() => {
-    restoreActiveProject()
-  }, [restoreActiveProject])
+    Promise.all([initializeApp(), restoreActiveProject()]).then(() => {
+      const proyecto = useProjectStore.getState()
+      useAppStore.getState().ajustarVistaInicial({
+        hayProyecto: proyecto.currentProjectId !== null,
+        hayRed: (proyecto.currentProject?.networkCount ?? 0) > 0,
+      })
+    })
+  }, [initializeApp, restoreActiveProject])
 
   // Las redes y calculos que vivian en localStorage pasan a la base de datos
   // (#31). Se hace despues de restaurar el proyecto y una sola vez: el modulo

--- a/src/components/chat/ChatArea.tsx
+++ b/src/components/chat/ChatArea.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from 'react'
 import { useChatStore } from '@/stores/chatStore'
 import { useProjectStore } from '@/stores/projectStore'
+import { useAppStore } from '@/stores/appStore'
 import { MessageList } from './MessageList'
 import { MessageInput } from './MessageInput'
 import { ChatHeader } from './ChatHeader'
@@ -17,6 +18,11 @@ export function ChatArea() {
   const selectedProjectId = useProjectStore(s => s.currentProjectId) ?? undefined
   const selectProject = useProjectStore(s => s.selectProject)
   const clearProject = useProjectStore(s => s.clearProject)
+  // El chat del proyecto y el chat general son la misma pantalla mirando a
+  // conversaciones distintas (#35): lo que cambia es a qué proyecto queda atada
+  // la conversación que se cree aquí.
+  const ambitoChat = useAppStore(s => s.ambitoChat)
+  const proyectoDeLaNueva = ambitoChat === 'proyecto' ? selectedProjectId : undefined
   const onProjectSelect = (projectId: string | undefined) => {
     if (projectId) selectProject(projectId)
     else clearProject()
@@ -55,14 +61,16 @@ export function ChatArea() {
             </div>
 
             <div className="space-y-4 flex flex-col items-center">
-              <ProjectSelector
-                selectedProjectId={selectedProjectId}
-                onProjectSelect={onProjectSelect}
-                className="justify-center"
-              />
+              {ambitoChat === 'proyecto' && (
+                <ProjectSelector
+                  selectedProjectId={selectedProjectId}
+                  onProjectSelect={onProjectSelect}
+                  className="justify-center"
+                />
+              )}
 
               <button
-                onClick={() => useChatStore.getState().createNewConversation(selectedProjectId)}
+                onClick={() => useChatStore.getState().createNewConversation(proyectoDeLaNueva)}
                 className={cn(
                   "px-8 py-3 bg-primary text-primary-foreground rounded-xl font-medium",
                   "hover:bg-primary/90 transition-all duration-200 shadow-lg hover:shadow-xl",
@@ -74,9 +82,9 @@ export function ChatArea() {
             </div>
 
             <div className="text-sm text-muted-foreground/70">
-              {selectedProjectId ?
+              {proyectoDeLaNueva ?
                 "This conversation will be linked to the selected project" :
-                "Select a project to link conversations or start without one"
+                "General chat: this conversation is not linked to any project"
               }
             </div>
           </div>

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -31,7 +31,7 @@ export function ChatLayout() {
         return <ChatArea />
       case 'settings':
         return <SettingsPanel />
-      case 'rag':
+      case 'wisdom':
         return <UnifiedWisdomPanel />
       case 'projects':
         return <HydraulicProjectsPanel />
@@ -40,7 +40,7 @@ export function ChatLayout() {
       case 'wntr':
         return <WNTRMainInterface />
       default:
-        return <ChatArea />
+        return <HydraulicProjectsPanel />
     }
   }
 

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -1,11 +1,11 @@
-import { logger } from '@/utils/logger'
 import { useAppStore } from '@/stores/appStore'
 import { useChatStore } from '@/stores/chatStore'
+import { useProjectStore } from '@/stores/projectStore'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 import { useTranslation } from 'react-i18next'
-import { useState, useEffect } from 'react'
 import {
   MessageSquare,
+  MessagesSquare,
   Settings,
   FileText,
   ChevronLeft,
@@ -13,71 +13,119 @@ import {
   FolderOpen,
   Calculator,
   Network,
-  ChevronDown,
+  Play,
   Lock
 } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import { usePrecondiciones } from '@/hooks/usePrecondiciones'
+import {
+  BLOQUES,
+  itemsDelBloque,
+  itemActivo,
+  pendientesItem,
+  type ItemNavegacion,
+} from '@/config/navegacion'
+import { claveMotivo } from '@/config/precondiciones'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import * as Collapsible from '@radix-ui/react-collapsible'
-import { hydraulicService } from '@/services/hydraulic/hydraulicService'
-import { HydraulicProject } from '@/types/hydraulic'
 import boorieIconDark from '@/assets/boorie_icon_dark.png'
 import boorieIconLight from '@/assets/boorie_icon_light.png'
 
+const ICONOS: Record<string, typeof MessageSquare> = {
+  projects: FolderOpen,
+  red: Network,
+  simulaciones: Play,
+  chatProyecto: MessageSquare,
+  calculator: Calculator,
+  chatGeneral: MessagesSquare,
+  wisdom: FileText,
+  settings: Settings,
+}
+
 export function Sidebar() {
   const { t } = useTranslation()
-  const precondiciones = usePrecondiciones()
+  const { estado } = usePrecondiciones()
   const {
     currentView,
+    ambitoChat,
+    seccionRed,
     setCurrentView,
     sidebarCollapsed,
     toggleSidebar
   } = useAppStore()
 
-  const { conversations, setActiveConversation } = useChatStore()
+  const { conversations, setActiveConversation, activeConversationId } = useChatStore()
+  const currentProjectId = useProjectStore(s => s.currentProjectId)
+  const nombreProyecto = useProjectStore(s => s.currentProject?.name)
   const { theme } = usePreferencesStore()
-  const [projects, setProjects] = useState<HydraulicProject[]>([])
-  const [projectsOpen, setProjectsOpen] = useState<Record<string, boolean>>({})
-  const [generalOpen, setGeneralOpen] = useState(true)
 
-  useEffect(() => {
-    if (currentView === 'chat') {
-      loadProjects()
-    }
-  }, [currentView])
+  const donde = { vista: currentView, ambitoChat, seccionRed }
 
-  const loadProjects = async () => {
-    try {
-      const projectList = await hydraulicService.listProjects()
-      setProjects(projectList)
-    } catch (error) {
-      logger.error('Failed to load projects:', error)
-    }
+  // Las conversaciones que se listan son las del ámbito en el que estás, no
+  // todas: el proyecto activo es global (#31), así que un árbol con todos los
+  // proyectos ofrecía un atajo para trabajar fuera del proyecto activo.
+  const conversacionesDelAmbito = conversations.filter(conv =>
+    ambitoChat === 'proyecto'
+      ? conv.projectId === currentProjectId
+      : !conv.projectId
+  )
+
+  const irA = (item: ItemNavegacion) => {
+    setCurrentView(item.vista, {
+      ambitoChat: item.ambitoChat,
+      seccionRed: item.seccion ?? null,
+    })
   }
 
-  // Group conversations by project
-  const conversationsByProject = conversations.reduce((acc, conv) => {
-    const projectId = conv.projectId || 'general'
-    if (!acc[projectId]) {
-      acc[projectId] = []
-    }
-    acc[projectId].push(conv)
-    return acc
-  }, {} as Record<string, typeof conversations>)
+  const ItemBoton = ({ item }: { item: ItemNavegacion }) => {
+    const Icono = ICONOS[item.id] ?? FileText
+    const activo = itemActivo(item, donde)
+    const etiqueta = t(item.etiqueta)
+    // Se atenúa, no se oculta ni se bloquea: ocultarlo haría la aplicación
+    // menos descubrible, y bloquearlo dejaría al usuario sin forma de llegar a
+    // la pantalla que le explica qué falta (#33).
+    const motivo = claveMotivo(pendientesItem(item, estado))
+    const bloqueada = motivo !== null
+    const ayuda = bloqueada ? `${etiqueta} — ${t(motivo)}` : etiqueta
 
-  const toggleProject = (projectId: string) => {
-    setProjectsOpen(prev => ({ ...prev, [projectId]: !prev[projectId] }))
+    return (
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            onClick={() => irA(item)}
+            // Sin aria-disabled: el ítem sigue siendo accionable a propósito y
+            // marcarlo como deshabilitado sería mentir al lector de pantalla.
+            title={bloqueada ? ayuda : undefined}
+            aria-label={bloqueada ? ayuda : undefined}
+            className={cn(
+              "w-full flex items-center rounded-lg transition-all duration-200",
+              "hover:bg-accent hover:text-accent-foreground",
+              item.hijoDelProyecto && !sidebarCollapsed ? "py-2 pl-6 pr-3" : "p-3",
+              activo
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "text-muted-foreground",
+              bloqueada && !activo && "opacity-50",
+              sidebarCollapsed && "justify-center"
+            )}
+          >
+            <Icono size={item.hijoDelProyecto ? 16 : 20} />
+            {!sidebarCollapsed && (
+              <span className={cn("ml-3", item.hijoDelProyecto ? "text-sm" : "font-medium")}>
+                {etiqueta}
+              </span>
+            )}
+            {!sidebarCollapsed && bloqueada && (
+              <Lock size={12} className="ml-auto opacity-70" aria-hidden />
+            )}
+          </button>
+        </Tooltip.Trigger>
+        {(sidebarCollapsed || bloqueada) && (
+          <Tooltip.Content side="right" className="px-2 py-1 bg-popover text-popover-foreground text-sm rounded-md border border-border shadow-md max-w-xs">
+            {ayuda}
+          </Tooltip.Content>
+        )}
+      </Tooltip.Root>
+    )
   }
-
-  const menuItems = [
-    { id: 'chat', icon: MessageSquare, label: t('sidebar.chat'), view: 'chat' as const },
-    { id: 'projects', icon: FolderOpen, label: t('sidebar.projects'), view: 'projects' as const },
-    { id: 'calculator', icon: Calculator, label: t('sidebar.calculator'), view: 'calculator' as const },
-    { id: 'wntr', icon: Network, label: t('sidebar.wntr'), view: 'wntr' as const },
-    { id: 'rag', icon: FileText, label: t('sidebar.wisdom'), view: 'rag' as const },
-    { id: 'settings', icon: Settings, label: t('sidebar.settings'), view: 'settings' as const },
-  ]
 
   return (
     <Tooltip.Provider>
@@ -130,159 +178,77 @@ export function Sidebar() {
           </Tooltip.Root>
         </div>
 
-        {/* Navigation */}
-        <div className="p-3 space-y-1 flex-shrink-0">
-          {menuItems.map((item) => {
-            const isActive = currentView === item.view
-            // Se atenúa, no se oculta ni se bloquea: ocultarlo haría la
-            // aplicación menos descubrible, y bloquearlo dejaría al usuario sin
-            // forma de llegar a la pantalla que le explica qué falta.
-            const motivo = precondiciones.motivo(item.view)
-            const bloqueada = motivo !== null
-            const ayuda = bloqueada ? `${item.label} — ${t(motivo)}` : item.label
-            return (
-              <Tooltip.Root key={item.id}>
-                <Tooltip.Trigger asChild>
-                  <button
-                    onClick={() => setCurrentView(item.view)}
-                    // Sin aria-disabled: el ítem sigue siendo accionable a
-                    // propósito y marcarlo como deshabilitado sería mentir al
-                    // lector de pantalla. El motivo va en el título accesible.
-                    title={bloqueada ? ayuda : undefined}
-                    aria-label={bloqueada ? ayuda : undefined}
-                    className={cn(
-                      "w-full flex items-center p-3 rounded-lg transition-all duration-200",
-                      "hover:bg-accent hover:text-accent-foreground",
-                      isActive
-                        ? "bg-primary text-primary-foreground shadow-sm"
-                        : "text-muted-foreground",
-                      bloqueada && !isActive && "opacity-50",
-                      sidebarCollapsed && "justify-center"
+        {/* Navegación en tres bloques: lo que pertenece al proyecto, lo que es
+            independiente de él y lo que es del sistema (#35). */}
+        <div className="p-3 space-y-4 flex-shrink-0">
+          {BLOQUES.map(bloque => (
+            <div key={bloque.id} className="space-y-1">
+              {!sidebarCollapsed && (
+                <h2 className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-wider px-3 pb-1">
+                  {t(bloque.titulo)}
+                </h2>
+              )}
+
+              {itemsDelBloque(bloque.id)
+                .filter(item => !item.hijoDelProyecto)
+                .map(item => <ItemBoton key={item.id} item={item} />)}
+
+              {bloque.id === 'proyectos' && (
+                currentProjectId ? (
+                  <>
+                    {/* El nombre del proyecto activo es visible desde cualquier
+                        vista, que es un criterio de aceptación del issue. */}
+                    {!sidebarCollapsed && (
+                      <div className="px-3 pt-1 pb-0.5 text-xs font-medium text-foreground/80 truncate"
+                        title={nombreProyecto}>
+                        {nombreProyecto ?? t('sidebar.proyectoActivo')}
+                      </div>
                     )}
-                  >
-                    <item.icon size={20} />
-                    {!sidebarCollapsed && <span className="ml-3 font-medium">{item.label}</span>}
-                    {!sidebarCollapsed && bloqueada && (
-                      <Lock size={12} className="ml-auto opacity-70" aria-hidden />
-                    )}
-                  </button>
-                </Tooltip.Trigger>
-                {(sidebarCollapsed || bloqueada) && (
-                  <Tooltip.Content side="right" className="px-2 py-1 bg-popover text-popover-foreground text-sm rounded-md border border-border shadow-md max-w-xs">
-                    {ayuda}
-                  </Tooltip.Content>
-                )}
-              </Tooltip.Root>
-            )
-          })}
+                    {itemsDelBloque('proyectos')
+                      .filter(item => item.hijoDelProyecto)
+                      .map(item => <ItemBoton key={item.id} item={item} />)}
+                  </>
+                ) : (
+                  !sidebarCollapsed && (
+                    <p className="px-3 py-1 text-xs text-muted-foreground/70">
+                      {t('sidebar.sinProyecto')}
+                    </p>
+                  )
+                )
+              )}
+            </div>
+          ))}
         </div>
 
-        {/* Chat History (only show when chat is active and sidebar is expanded) */}
+        {/* Conversaciones del ámbito en el que está el chat */}
         {currentView === 'chat' && !sidebarCollapsed && (
-          <div className="flex-1 flex flex-col p-3 overflow-hidden">
-            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide px-3 mb-3 flex-shrink-0">
-              {t('sidebar.recentChats')}
+          <div className="flex-1 flex flex-col p-3 overflow-hidden border-t border-border/50">
+            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide px-3 mb-3 mt-2 flex-shrink-0">
+              {t(ambitoChat === 'proyecto' ? 'sidebar.chatsDelProyecto' : 'sidebar.recentChats')}
             </h3>
             <div className="flex-1 overflow-y-auto pr-1 scrollbar-thin scrollbar-thumb-border">
-              <div className="space-y-2">
-                {/* General conversations (no project) */}
-                {conversationsByProject.general && conversationsByProject.general.length > 0 && (
-                  <Collapsible.Root open={generalOpen} onOpenChange={setGeneralOpen}>
-                    <Collapsible.Trigger className={cn(
-                      "w-full flex items-center justify-between p-2 rounded-lg",
-                      "text-sm font-medium text-muted-foreground",
-                      "hover:bg-accent/50 transition-colors"
-                    )}>
-                      <span>General Chats</span>
-                      <ChevronDown
-                        size={14}
-                        className={cn("transition-transform", generalOpen && "rotate-180")}
-                      />
-                    </Collapsible.Trigger>
-                    <Collapsible.Content className="mt-1">
-                      <div className="ml-2 space-y-1">
-                        {conversationsByProject.general.map((conversation) => (
-                          <button
-                            key={conversation.id}
-                            onClick={() => setActiveConversation(conversation.id)}
-                            className={cn(
-                              "w-full text-left p-2 pl-4 rounded-lg transition-all duration-200",
-                              "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                              "hover:shadow-sm text-sm"
-                            )}
-                          >
-                            <div className="truncate">
-                              {conversation.title || 'New Conversation'}
-                            </div>
-                            <div className="text-xs text-muted-foreground/70 mt-0.5">
-                              {new Date(conversation.updatedAt).toLocaleDateString()}
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    </Collapsible.Content>
-                  </Collapsible.Root>
-                )}
+              <div className="space-y-1">
+                {conversacionesDelAmbito.map((conversation) => (
+                  <button
+                    key={conversation.id}
+                    onClick={() => setActiveConversation(conversation.id)}
+                    className={cn(
+                      "w-full text-left p-2 pl-3 rounded-lg transition-all duration-200 text-sm",
+                      conversation.id === activeConversationId
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                    )}
+                  >
+                    <div className="truncate">
+                      {conversation.title || t('sidebar.nuevaConversacion')}
+                    </div>
+                    <div className="text-xs text-muted-foreground/70 mt-0.5">
+                      {new Date(conversation.updatedAt).toLocaleDateString()}
+                    </div>
+                  </button>
+                ))}
 
-                {/* Project-specific conversations */}
-                {projects.map((project) => {
-                  const projectConversations = conversationsByProject[project.id] || []
-                  if (projectConversations.length === 0) return null
-
-                  const isOpen = projectsOpen[project.id] ?? false
-
-                  return (
-                    <Collapsible.Root
-                      key={project.id}
-                      open={isOpen}
-                      onOpenChange={() => toggleProject(project.id)}
-                    >
-                      <Collapsible.Trigger className={cn(
-                        "w-full flex items-center justify-between p-2 rounded-lg",
-                        "text-sm font-medium text-muted-foreground",
-                        "hover:bg-accent/50 transition-colors"
-                      )}>
-                        <div className="flex items-center gap-2 min-w-0">
-                          <FolderOpen size={14} />
-                          <span className="truncate">{project.name}</span>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                            {projectConversations.length}
-                          </span>
-                          <ChevronDown
-                            size={14}
-                            className={cn("transition-transform", isOpen && "rotate-180")}
-                          />
-                        </div>
-                      </Collapsible.Trigger>
-                      <Collapsible.Content className="mt-1">
-                        <div className="ml-2 space-y-1">
-                          {projectConversations.map((conversation) => (
-                            <button
-                              key={conversation.id}
-                              onClick={() => setActiveConversation(conversation.id)}
-                              className={cn(
-                                "w-full text-left p-2 pl-8 rounded-lg transition-all duration-200",
-                                "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                                "hover:shadow-sm text-sm"
-                              )}
-                            >
-                              <div className="truncate">
-                                {conversation.title || 'New Conversation'}
-                              </div>
-                              <div className="text-xs text-muted-foreground/70 mt-0.5">
-                                {new Date(conversation.updatedAt).toLocaleDateString()}
-                              </div>
-                            </button>
-                          ))}
-                        </div>
-                      </Collapsible.Content>
-                    </Collapsible.Root>
-                  )
-                })}
-
-                {conversations.length === 0 && (
+                {conversacionesDelAmbito.length === 0 && (
                   <div className="px-3 py-6 text-center">
                     <div className="text-muted-foreground/60 text-sm">
                       {t('sidebar.noConversations')}

--- a/src/components/hydraulic/HydraulicProjectsPanel.tsx
+++ b/src/components/hydraulic/HydraulicProjectsPanel.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { WNTRMainInterface } from './WNTRMainInterface';
 
 /**
- * HydraulicProjectsPanel - Wrapper component for hydraulic simulation projects
- * This component integrates the full WNTR interface with project management
+ * Raíz de la navegación (#35): la lista de proyectos, siempre, haya proyecto
+ * activo o no. Con `modo="red"` este mismo componente es la vista de trabajo
+ * sobre el proyecto, que es lo que enseñaba también aquí y dejaba la lista
+ * inalcanzable sin cerrar antes el proyecto.
  */
 export const HydraulicProjectsPanel: React.FC = () => {
     return (
         <div className="h-full w-full">
-            <WNTRMainInterface />
+            <WNTRMainInterface modo="proyectos" />
         </div>
     );
 };

--- a/src/components/hydraulic/ProjectDashboard.tsx
+++ b/src/components/hydraulic/ProjectDashboard.tsx
@@ -9,13 +9,16 @@ interface ProjectDashboardProps {
     onSelectProject: (project: Project) => void;
     onCreateProject: (name: string, description: string) => void;
     onDeleteProject: (projectId: string) => void;
+    /** Marca cuál es el proyecto activo cuando la lista se ve desde la raíz (#35). */
+    activeProjectId?: string | null;
 }
 
 export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
     projects,
     onSelectProject,
     onCreateProject,
-    onDeleteProject
+    onDeleteProject,
+    activeProjectId
 }) => {
     const [isCreating, setIsCreating] = useState(false);
     const [newName, setNewName] = useState('');
@@ -211,13 +214,21 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
                         sortedProjects.map(project => (
                             <Card
                                 key={project.id}
-                                className="bg-slate-800 border-slate-700 hover:border-blue-500 transition-all cursor-pointer group flex flex-col"
+                                className={`bg-slate-800 transition-all cursor-pointer group flex flex-col ${project.id === activeProjectId
+                                    ? 'border-blue-500 ring-1 ring-blue-500/40'
+                                    : 'border-slate-700 hover:border-blue-500'
+                                    }`}
                                 onClick={() => onSelectProject(project)}
                             >
                                 <CardHeader className="pb-3">
                                     <div className="flex justify-between items-start">
                                         <CardTitle className="text-white text-xl group-hover:text-blue-400 transition-colors">
                                             {project.name}
+                                            {project.id === activeProjectId && (
+                                                <span className="ml-2 align-middle rounded bg-blue-500/20 px-1.5 py-0.5 text-[10px] font-medium text-blue-300">
+                                                    Activo
+                                                </span>
+                                            )}
                                         </CardTitle>
                                         <div className="flex gap-1 -mr-2 -mt-2">
                                             <Button

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -2,6 +2,7 @@ import { logger } from '@/utils/logger'
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { useClarity } from '@/components/ClarityProvider';
 import { useProjectStore } from '@/stores/projectStore';
+import { useAppStore } from '@/stores/appStore';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -49,6 +50,13 @@ interface WNTRMainInterfaceProps {
   onSimulationCompleted?: (results: any) => void;
   onAnalysisComplete?: (results: any) => void;
   onSimulationComplete?: (results: any) => void;
+  /**
+   * 'proyectos' es la raíz de la navegación y enseña siempre la lista de
+   * proyectos; 'red' es la vista de trabajo sobre el proyecto activo (#35).
+   * Antes las dos entradas del menú mostraban exactamente lo mismo, así que con
+   * un proyecto abierto no había forma de volver a la lista para cambiarlo.
+   */
+  modo?: 'red' | 'proyectos';
 }
 
 interface NetworkData {
@@ -101,7 +109,8 @@ const AvisoDuracion: React.FC<{ children: React.ReactNode }> = ({ children }) =>
 export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   projectId: _projectId,
   onAnalysisComplete,
-  onSimulationComplete
+  onSimulationComplete,
+  modo = 'red'
 }) => {
   // Clarity tracking
   const { trackEvent, isReady: clarityReady } = useClarity();
@@ -353,6 +362,12 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   const [simulationDuration, setSimulationDuration] = useState<number>(24);
   const [simulationTimestep, setSimulationTimestep] = useState<number>(60); // minutes
   const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] = useState(false);
+  // «Simulaciones» en el menú entra en esta vista pidiendo su pestaña (#35).
+  const seccionPedida = useAppStore(s => s.seccionRed);
+  const [pestana, setPestana] = useState('simulate');
+  useEffect(() => {
+    if (seccionPedida) setPestana(seccionPedida);
+  }, [seccionPedida]);
 
   // --- Resilience routines (epic #26): skeletonization, service interruption,
   // resilience indicators, fragility curve ---
@@ -853,14 +868,15 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
   // Dashboard Layout Render
   const renderDashboard = () => {
-    // 1. NO PROJECT SELECTED: Show Project Dashboard
-    if (!currentProject) {
+    // 1. RAÍZ DE PROYECTOS, O NINGUNO SELECCIONADO: la lista de proyectos
+    if (modo === 'proyectos' || !currentProject) {
       return (
         <ProjectDashboard
           projects={projects}
           onSelectProject={handleSelectProject}
           onCreateProject={handleCreateProject}
           onDeleteProject={handleDeleteProject}
+          activeProjectId={activeProjectId}
         />
       );
     }
@@ -1009,7 +1025,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
             </Button>
           </div>
 
-          <Tabs defaultValue="simulate" className="flex-1 flex flex-col min-h-0">
+          <Tabs value={pestana} onValueChange={setPestana} className="flex-1 flex flex-col min-h-0">
             <div className="px-4 pt-2 border-b bg-muted/10">
               <TabsList className="grid w-full grid-cols-5">
                 <TabsTrigger value="simulate" title="Simulation">

--- a/src/config/navegacion.test.ts
+++ b/src/config/navegacion.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NAVEGACION,
+  BLOQUES,
+  itemsDelBloque,
+  itemActivo,
+  pendientesItem,
+  requisitosItem,
+  type UbicacionActual,
+} from './navegacion'
+import { REQUISITOS_VISTA, type Vista } from './precondiciones'
+import es from '@/locales/es.json'
+import en from '@/locales/en.json'
+import ca from '@/locales/ca.json'
+
+const SIN_NADA = { hayProyecto: false, hayRed: false }
+const SOLO_PROYECTO = { hayProyecto: true, hayRed: false }
+const TODO = { hayProyecto: true, hayRed: true }
+
+const resolver = (dic: unknown, clave: string) =>
+  clave.split('.').reduce<any>((o, p) => o?.[p], dic)
+
+const item = (id: string) => {
+  const encontrado = NAVEGACION.find(i => i.id === id)
+  if (!encontrado) throw new Error(`no existe el ítem ${id}`)
+  return encontrado
+}
+
+describe('modelo de navegación', () => {
+  it('ninguna vista de la aplicación queda inalcanzable', () => {
+    // Criterio de aceptación del issue #35. Si alguien añade una vista y olvida
+    // su entrada en el menú, sólo se llegaría a ella por accidente.
+    const alcanzables = new Set(NAVEGACION.map(i => i.vista))
+    for (const vista of Object.keys(REQUISITOS_VISTA) as Vista[]) {
+      expect(alcanzables.has(vista), `vista sin entrada de menú: ${vista}`).toBe(true)
+    }
+  })
+
+  it('cada ítem pertenece a uno de los tres bloques declarados', () => {
+    const bloques = BLOQUES.map(b => b.id)
+    for (const i of NAVEGACION) expect(bloques).toContain(i.bloque)
+    expect(itemsDelBloque('proyectos').length).toBeGreaterThan(1)
+    expect(itemsDelBloque('herramientas').map(i => i.id)).toEqual(['calculator', 'chatGeneral'])
+    expect(itemsDelBloque('sistema').map(i => i.id)).toEqual(['wisdom', 'settings'])
+  })
+
+  it('sólo cuelgan del proyecto los ítems del bloque de proyectos', () => {
+    for (const i of NAVEGACION.filter(i => i.hijoDelProyecto)) {
+      expect(i.bloque).toBe('proyectos')
+    }
+    // La raíz no cuelga de sí misma: es la que se puede usar sin proyecto.
+    expect(item('projects').hijoDelProyecto).toBeUndefined()
+    expect(pendientesItem(item('projects'), SIN_NADA)).toEqual([])
+  })
+
+  it('la calculadora y el chat general no dependen del proyecto', () => {
+    // El chat general existe a propósito (criterio del Ing. Luis Mora en el
+    // issue): Boorie también se usa como apoyo docente, sin proyecto delante.
+    expect(pendientesItem(item('calculator'), SIN_NADA)).toEqual([])
+    expect(pendientesItem(item('chatGeneral'), SIN_NADA)).toEqual([])
+  })
+
+  it('simulaciones exige red además de proyecto, y la vista de red no', () => {
+    expect(pendientesItem(item('simulaciones'), SOLO_PROYECTO)).toEqual(['red'])
+    expect(pendientesItem(item('simulaciones'), TODO)).toEqual([])
+    // La vista de red es donde se importa el .inp: exigir red la haría
+    // inalcanzable, así que el ítem hereda los requisitos de la vista (#33).
+    expect(requisitosItem(item('red'))).toEqual(REQUISITOS_VISTA.wntr)
+    expect(pendientesItem(item('red'), SOLO_PROYECTO)).toEqual([])
+  })
+
+  it('nunca hay dos ítems encendidos a la vez', () => {
+    const ubicaciones: UbicacionActual[] = [
+      { vista: 'projects', ambitoChat: 'general', seccionRed: null },
+      { vista: 'chat', ambitoChat: 'general', seccionRed: null },
+      { vista: 'chat', ambitoChat: 'proyecto', seccionRed: null },
+      { vista: 'wntr', ambitoChat: 'general', seccionRed: null },
+      { vista: 'wntr', ambitoChat: 'general', seccionRed: 'simulate' },
+      { vista: 'calculator', ambitoChat: 'general', seccionRed: null },
+      { vista: 'wisdom', ambitoChat: 'general', seccionRed: null },
+      { vista: 'settings', ambitoChat: 'general', seccionRed: null },
+    ]
+    for (const donde of ubicaciones) {
+      const encendidos = NAVEGACION.filter(i => itemActivo(i, donde)).map(i => i.id)
+      expect(encendidos, JSON.stringify(donde)).toHaveLength(1)
+    }
+  })
+
+  it('distingue los dos chats y las dos entradas a la vista de red', () => {
+    const enChatGeneral: UbicacionActual = { vista: 'chat', ambitoChat: 'general', seccionRed: null }
+    expect(itemActivo(item('chatGeneral'), enChatGeneral)).toBe(true)
+    expect(itemActivo(item('chatProyecto'), enChatGeneral)).toBe(false)
+
+    const enSimulaciones: UbicacionActual = { vista: 'wntr', ambitoChat: 'general', seccionRed: 'simulate' }
+    expect(itemActivo(item('simulaciones'), enSimulaciones)).toBe(true)
+    expect(itemActivo(item('red'), enSimulaciones)).toBe(false)
+  })
+
+  it('todas las etiquetas y títulos de bloque están en los tres idiomas', () => {
+    const claves = [...NAVEGACION.map(i => i.etiqueta), ...BLOQUES.map(b => b.titulo)]
+    for (const clave of claves) {
+      for (const dic of [es, en, ca]) {
+        expect(resolver(dic, clave), clave).toBeTruthy()
+      }
+    }
+  })
+})

--- a/src/config/navegacion.ts
+++ b/src/config/navegacion.ts
@@ -1,0 +1,123 @@
+/**
+ * Modelo de navegación, en un único sitio (issue #35).
+ *
+ * El menú era una lista plana de seis elementos declarada dentro del propio
+ * componente, así que no había forma de saber qué pertenecía al proyecto y qué
+ * era global: «Chat» y «Red WNTR» estaban al mismo nivel que «Configuración».
+ * Aquí viven los tres bloques —proyecto, herramientas y sistema— y sus
+ * requisitos, para que el menú los pinte y las pruebas los puedan leer sin
+ * montar la interfaz.
+ */
+
+import type { Vista, Requisito, EstadoPrecondiciones } from './precondiciones'
+import { REQUISITOS_VISTA, pendientesDe } from './precondiciones'
+
+/** Pestaña de la vista de red a la que puede apuntar un ítem del menú. */
+export type SeccionRed = 'simulate' | 'analyze' | 'resilience' | 'layers'
+
+/**
+ * Con qué conversaciones trabaja el chat. No es una vista distinta: es la misma
+ * pantalla mirando a las conversaciones del proyecto activo o a las que no
+ * tienen proyecto. Los dos chats deben existir (criterio del Ing. Luis Mora
+ * recogido en el issue): el general para uso docente, el del proyecto para
+ * interpretar la red y sus resultados.
+ */
+export type AmbitoChat = 'proyecto' | 'general'
+
+export type Bloque = 'proyectos' | 'herramientas' | 'sistema'
+
+export interface ItemNavegacion {
+  id: string
+  bloque: Bloque
+  vista: Vista
+  /** Clave i18n de la etiqueta visible. */
+  etiqueta: string
+  /** Cuelga del proyecto activo: sólo se pinta cuando hay uno. */
+  hijoDelProyecto?: boolean
+  /**
+   * Requisitos propios, cuando el ítem pide más que la vista a la que lleva.
+   * Sin esto, «Simulaciones» heredaría los requisitos de la vista de red, que
+   * a propósito no exige red cargada porque es donde se importa el .inp.
+   */
+  requisitos?: Requisito[]
+  seccion?: SeccionRed
+  ambitoChat?: AmbitoChat
+}
+
+export const NAVEGACION: ItemNavegacion[] = [
+  { id: 'projects', bloque: 'proyectos', vista: 'projects', etiqueta: 'sidebar.projects' },
+  {
+    id: 'red',
+    bloque: 'proyectos',
+    vista: 'wntr',
+    etiqueta: 'sidebar.wntr',
+    hijoDelProyecto: true,
+  },
+  {
+    id: 'simulaciones',
+    bloque: 'proyectos',
+    vista: 'wntr',
+    etiqueta: 'sidebar.simulaciones',
+    hijoDelProyecto: true,
+    seccion: 'simulate',
+    requisitos: ['proyecto', 'red'],
+  },
+  {
+    id: 'chatProyecto',
+    bloque: 'proyectos',
+    vista: 'chat',
+    etiqueta: 'sidebar.chatProyecto',
+    hijoDelProyecto: true,
+    ambitoChat: 'proyecto',
+    requisitos: ['proyecto'],
+  },
+
+  { id: 'calculator', bloque: 'herramientas', vista: 'calculator', etiqueta: 'sidebar.calculator' },
+  {
+    id: 'chatGeneral',
+    bloque: 'herramientas',
+    vista: 'chat',
+    etiqueta: 'sidebar.chatGeneral',
+    ambitoChat: 'general',
+  },
+
+  { id: 'wisdom', bloque: 'sistema', vista: 'wisdom', etiqueta: 'sidebar.wisdom' },
+  { id: 'settings', bloque: 'sistema', vista: 'settings', etiqueta: 'sidebar.settings' },
+]
+
+export const BLOQUES: { id: Bloque; titulo: string }[] = [
+  { id: 'proyectos', titulo: 'sidebar.bloqueProyectos' },
+  { id: 'herramientas', titulo: 'sidebar.bloqueHerramientas' },
+  { id: 'sistema', titulo: 'sidebar.bloqueSistema' },
+]
+
+export function itemsDelBloque(bloque: Bloque): ItemNavegacion[] {
+  return NAVEGACION.filter(item => item.bloque === bloque)
+}
+
+export function requisitosItem(item: ItemNavegacion): Requisito[] {
+  return item.requisitos ?? REQUISITOS_VISTA[item.vista]
+}
+
+/** Lo que le falta a este ítem para estar disponible. */
+export function pendientesItem(item: ItemNavegacion, estado: EstadoPrecondiciones): Requisito[] {
+  return pendientesDe(requisitosItem(item), estado)
+}
+
+export interface UbicacionActual {
+  vista: Vista
+  ambitoChat: AmbitoChat
+  seccionRed: SeccionRed | null
+}
+
+/**
+ * Qué ítem se marca como activo. Tres ítems comparten vista con otro —los dos
+ * chats, y «Red hidráulica» con «Simulaciones»—, así que comparar sólo la vista
+ * encendería dos a la vez.
+ */
+export function itemActivo(item: ItemNavegacion, donde: UbicacionActual): boolean {
+  if (item.vista !== donde.vista) return false
+  if (item.vista === 'chat') return (item.ambitoChat ?? 'general') === donde.ambitoChat
+  if (item.vista === 'wntr') return (item.seccion ?? null) === donde.seccionRed
+  return true
+}

--- a/src/config/onboardingPasos.test.tsx
+++ b/src/config/onboardingPasos.test.tsx
@@ -26,7 +26,7 @@ describe('recorrido de primer uso', () => {
   })
 
   it('todos los pasos apuntan a una vista real de la aplicación', () => {
-    const vistas = ['chat', 'settings', 'rag', 'projects', 'calculator', 'wntr']
+    const vistas = ['chat', 'settings', 'wisdom', 'projects', 'calculator', 'wntr']
     for (const paso of ONBOARDING_STEPS) {
       if (paso.action) expect(vistas).toContain(paso.action)
     }

--- a/src/config/onboardingPasos.tsx
+++ b/src/config/onboardingPasos.tsx
@@ -32,7 +32,7 @@ export const ONBOARDING_STEPS = [
         description: 'onboarding.rag.desc',
         icon: <Database className="w-12 h-12 text-amber-500" />,
         color: 'from-amber-500/20 to-orange-500/20',
-        action: 'rag',
+        action: 'wisdom',
     },
     {
         title: 'onboarding.projects.title',

--- a/src/config/precondiciones.test.ts
+++ b/src/config/precondiciones.test.ts
@@ -13,7 +13,7 @@ const TODO = { hayProyecto: true, hayRed: true }
 
 describe('precondiciones de navegación', () => {
   it('deja pasar a chat, proyectos, wisdom y ajustes sin nada cargado', () => {
-    for (const vista of ['chat', 'projects', 'rag', 'settings'] as Vista[]) {
+    for (const vista of ['chat', 'projects', 'wisdom', 'settings'] as Vista[]) {
       expect(vistaDisponible(vista, SIN_NADA)).toBe(true)
     }
   })
@@ -53,7 +53,7 @@ describe('precondiciones de navegación', () => {
   it('cubre todas las vistas declaradas en el store', () => {
     // Si alguien añade una vista nueva y olvida su fila, la tabla deja de ser
     // la fuente única y volvemos a las guardas dispersas.
-    const vistas: Vista[] = ['chat', 'settings', 'rag', 'projects', 'calculator', 'wntr']
+    const vistas: Vista[] = ['chat', 'settings', 'wisdom', 'projects', 'calculator', 'wntr']
     for (const vista of vistas) {
       expect(REQUISITOS_VISTA[vista]).toBeDefined()
     }

--- a/src/config/precondiciones.ts
+++ b/src/config/precondiciones.ts
@@ -37,17 +37,22 @@ export const REQUISITOS_VISTA: Record<Vista, Requisito[]> = {
   projects: [],
   calculator: [],
   wntr: ['proyecto'],
-  rag: [],
+  wisdom: [],
   settings: [],
 }
 
-/** Requisitos que la vista declara y el estado actual no cumple. */
-export function requisitosPendientes(vista: Vista, estado: EstadoPrecondiciones): Requisito[] {
+/** De una lista de requisitos, los que el estado actual no cumple. */
+export function pendientesDe(requisitos: Requisito[], estado: EstadoPrecondiciones): Requisito[] {
   const cumple: Record<Requisito, boolean> = {
     proyecto: estado.hayProyecto,
     red: estado.hayRed,
   }
-  return REQUISITOS_VISTA[vista].filter(r => !cumple[r])
+  return requisitos.filter(r => !cumple[r])
+}
+
+/** Requisitos que la vista declara y el estado actual no cumple. */
+export function requisitosPendientes(vista: Vista, estado: EstadoPrecondiciones): Requisito[] {
+  return pendientesDe(REQUISITOS_VISTA[vista], estado)
 }
 
 export function vistaDisponible(vista: Vista, estado: EstadoPrecondiciones): boolean {

--- a/src/hooks/useClarityTracking.ts
+++ b/src/hooks/useClarityTracking.ts
@@ -96,7 +96,7 @@ export function useClarityTracking() {
 
   // Feature usage tracking
   const trackFeatureUsage = (
-    feature: 'calculator' | 'wntr' | 'chat' | 'rag' | 'projects' | 'settings',
+    feature: 'calculator' | 'wntr' | 'chat' | 'wisdom' | 'projects' | 'settings',
     action: 'open' | 'close' | 'use' | 'configure',
     details?: Record<string, any>
   ) => {

--- a/src/hooks/usePrecondiciones.ts
+++ b/src/hooks/usePrecondiciones.ts
@@ -15,10 +15,10 @@ import {
  *
  * `hayRed` cuenta las redes **guardadas** en el proyecto, no la que el visor
  * tenga abierta: esa vive en el estado local de WNTRMainInterface y el menú no
- * puede verla. Hoy ninguna vista se bloquea por este requisito —la de red es
- * justamente donde se importa el .inp—, así que sólo alimenta la tabla; cuando
- * el chat necesite contexto de red (#34) habrá que levantar el estado del visor
- * en lugar de deducirlo aquí.
+ * puede verla. Ninguna vista se bloquea por este requisito —la de red es
+ * justamente donde se importa el .inp—, pero sí el ítem «Simulaciones» del menú
+ * (#35), que es lo que destapó que `hydraulic:get-project` no devolvía el
+ * contador y lo dejaba siempre en 0.
  */
 export function usePrecondiciones() {
   const currentProjectId = useProjectStore(s => s.currentProjectId)

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -30,7 +30,17 @@
     "projects": "Projectes",
     "calculator": "Calculadora",
     "wntr": "Xarxa WNTR",
-    "wisdom": "Wisdom Center"
+    "wisdom": "Wisdom Center",
+    "bloqueProyectos": "Projectes",
+    "bloqueHerramientas": "Eines",
+    "bloqueSistema": "Sistema",
+    "simulaciones": "Simulacions",
+    "chatProyecto": "Xat del projecte",
+    "chatGeneral": "Xat general",
+    "sinProyecto": "Sense projecte actiu",
+    "proyectoActivo": "Projecte actiu",
+    "chatsDelProyecto": "Xats del projecte",
+    "nuevaConversacion": "Nova conversa"
   },
   "chat": {
     "newConversation": "Nova Conversa",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,7 +30,17 @@
     "projects": "Projects",
     "calculator": "Calculator",
     "wntr": "WNTR Network",
-    "wisdom": "Wisdom Center"
+    "wisdom": "Wisdom Center",
+    "bloqueProyectos": "Projects",
+    "bloqueHerramientas": "Tools",
+    "bloqueSistema": "System",
+    "simulaciones": "Simulations",
+    "chatProyecto": "Project chat",
+    "chatGeneral": "General chat",
+    "sinProyecto": "No active project",
+    "proyectoActivo": "Active project",
+    "chatsDelProyecto": "Project chats",
+    "nuevaConversacion": "New conversation"
   },
   "chat": {
     "newConversation": "New Conversation",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -30,7 +30,17 @@
     "projects": "Proyectos",
     "calculator": "Calculadora",
     "wntr": "Red WNTR",
-    "wisdom": "Wisdom Center"
+    "wisdom": "Wisdom Center",
+    "bloqueProyectos": "Proyectos",
+    "bloqueHerramientas": "Herramientas",
+    "bloqueSistema": "Sistema",
+    "simulaciones": "Simulaciones",
+    "chatProyecto": "Chat del proyecto",
+    "chatGeneral": "Chat general",
+    "sinProyecto": "Sin proyecto activo",
+    "proyectoActivo": "Proyecto activo",
+    "chatsDelProyecto": "Chats del proyecto",
+    "nuevaConversacion": "Nueva conversación"
   },
   "chat": {
     "newConversation": "Nueva Conversación",

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAppStore, migrarVista, VISTAS } from './appStore'
+
+describe('vista de la aplicación', () => {
+  beforeEach(() => {
+    useAppStore.setState({ currentView: 'projects', ambitoChat: 'general', seccionRed: null })
+  })
+
+  it('arranca en Proyectos, que es la raíz de la navegación', () => {
+    // Criterio de aceptación del issue #35.
+    expect(useAppStore.getState().currentView).toBe('projects')
+  })
+
+  it('traduce la vista guardada por los usuarios que ya tenían «rag»', () => {
+    // El enrutado la llamaba 'rag' y la etiqueta decía «Wisdom Center». Sin
+    // esto, quien dejó la aplicación en el Wisdom Center arrancaría en la vista
+    // por defecto sin explicación, porque su valor guardado ya no existe.
+    expect(migrarVista('rag')).toBe('wisdom')
+  })
+
+  it('acepta las vistas vigentes y descarta un valor desconocido', () => {
+    for (const vista of VISTAS) expect(migrarVista(vista)).toBe(vista)
+    expect(migrarVista('vista-que-no-existe')).toBeNull()
+  })
+
+  it('sin proyecto, la vista restaurada que exige uno cae en Proyectos', () => {
+    useAppStore.setState({ currentView: 'wntr' })
+    useAppStore.getState().ajustarVistaInicial({ hayProyecto: false, hayRed: false })
+    expect(useAppStore.getState().currentView).toBe('projects')
+  })
+
+  it('con proyecto, se respeta la vista que el usuario dejó abierta', () => {
+    useAppStore.setState({ currentView: 'wntr' })
+    useAppStore.getState().ajustarVistaInicial({ hayProyecto: true, hayRed: true })
+    expect(useAppStore.getState().currentView).toBe('wntr')
+  })
+
+  it('no toca las vistas que no dependen del proyecto', () => {
+    for (const vista of ['calculator', 'wisdom', 'settings', 'chat'] as const) {
+      useAppStore.setState({ currentView: vista })
+      useAppStore.getState().ajustarVistaInicial({ hayProyecto: false, hayRed: false })
+      expect(useAppStore.getState().currentView).toBe(vista)
+    }
+  })
+})

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -3,10 +3,31 @@ import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import { databaseService } from '@/services/database'
 import { useChatStore } from './chatStore'
+import type { AmbitoChat, SeccionRed } from '@/config/navegacion'
+import { requisitosPendientes } from '@/config/precondiciones'
+
+export const VISTAS = ['chat', 'settings', 'wisdom', 'projects', 'calculator', 'wntr'] as const
+
+/**
+ * La vista del Wisdom Center se llamaba 'rag' en el enrutado mientras la
+ * etiqueta visible decía «Wisdom Center» (issue #35). El valor viejo sigue
+ * guardado en la base de datos de quien ya usaba la aplicacion.
+ */
+const VISTAS_RENOMBRADAS: Record<string, AppState['currentView']> = { rag: 'wisdom' }
+
+export function migrarVista(valor: string): AppState['currentView'] | null {
+  const renombrada = VISTAS_RENOMBRADAS[valor]
+  if (renombrada) return renombrada
+  return (VISTAS as readonly string[]).includes(valor) ? (valor as AppState['currentView']) : null
+}
 
 export interface AppState {
   isInitialized: boolean
-  currentView: 'chat' | 'settings' | 'rag' | 'projects' | 'calculator' | 'wntr'
+  currentView: typeof VISTAS[number]
+  /** Con qué conversaciones trabaja el chat: las del proyecto activo o las generales. */
+  ambitoChat: AmbitoChat
+  /** Pestaña de la vista de red a la que se ha entrado desde el menú, si se pidió una. */
+  seccionRed: SeccionRed | null
   theme: 'dark' | 'light'
   sidebarCollapsed: boolean
   showOnboarding: boolean
@@ -25,7 +46,15 @@ export interface AppState {
 
   // Actions
   initializeApp: () => Promise<void>
-  setCurrentView: (view: AppState['currentView']) => void
+  setCurrentView: (
+    view: AppState['currentView'],
+    opciones?: { ambitoChat?: AmbitoChat; seccionRed?: SeccionRed | null }
+  ) => void
+  /**
+   * Corrige la vista restaurada cuando su precondición no se cumple al
+   * arrancar. La llama la raíz de la aplicación cuando ya sabe si hay proyecto.
+   */
+  ajustarVistaInicial: (estado: { hayProyecto: boolean; hayRed: boolean }) => void
   toggleSidebar: () => void
   setTheme: (theme: AppState['theme']) => void
   setActiveAIProvider: (provider: AppState['activeAIProvider']) => void
@@ -43,7 +72,11 @@ export const useAppStore = create<AppState>()(
     persist(
       (set, get) => ({
         isInitialized: false,
-        currentView: 'chat',
+        // La navegación empieza por Proyectos: todo lo demás cuelga de saber en
+        // qué proyecto estás (issue #35).
+        currentView: 'projects',
+        ambitoChat: 'general',
+        seccionRed: null,
         theme: 'light',
         sidebarCollapsed: false,
         showOnboarding: false,
@@ -106,11 +139,11 @@ export const useAppStore = create<AppState>()(
                     set({ theme: setting.value })
                   }
                   break
-                case 'currentView':
-                  if (['chat', 'settings', 'rag', 'projects', 'calculator', 'wntr'].includes(setting.value)) {
-                    set({ currentView: setting.value as any })
-                  }
+                case 'currentView': {
+                  const vista = migrarVista(setting.value)
+                  if (vista) set({ currentView: vista })
                   break
+                }
                 case 'sidebarCollapsed':
                   set({ sidebarCollapsed: setting.value === 'true' })
                   break
@@ -129,9 +162,24 @@ export const useAppStore = create<AppState>()(
           }
         },
 
-        setCurrentView: async (view) => {
-          set({ currentView: view })
+        setCurrentView: async (view, opciones) => {
+          set({
+            currentView: view,
+            ...(opciones?.ambitoChat !== undefined ? { ambitoChat: opciones.ambitoChat } : {}),
+            // La sección se limpia siempre que no se pida una: si no, entrar en
+            // la red desde el menú te dejaría en la pestaña del último enlace.
+            seccionRed: opciones?.seccionRed ?? null,
+          })
           await databaseService.setSetting('currentView', view, 'general')
+        },
+
+        // No se persiste: es una corrección de arranque, no una elección del
+        // usuario. Si mañana abre con proyecto, recupera la vista que dejó.
+        ajustarVistaInicial: (estado) => {
+          const vista = get().currentView
+          if (requisitosPendientes(vista, estado).length > 0) {
+            set({ currentView: 'projects' })
+          }
         },
 
         toggleSidebar: async () => {

--- a/src/types/hydraulic.ts
+++ b/src/types/hydraulic.ts
@@ -161,6 +161,12 @@ export interface HydraulicProject {
   timeline: Timeline
   team: TeamMember[]
   status: ProjectStatus
+  /**
+   * Redes activas del proyecto. Lo consumen las precondiciones de navegación:
+   * sin este contador, «Simulaciones» aparecía bloqueada aunque el proyecto
+   * tuviera redes guardadas (#33, #35).
+   */
+  networkCount?: number
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
Closes #35

## El problema

El menú era una lista plana de seis elementos declarada dentro del propio componente: Chat → Proyectos → Calculadora → Red WNTR → Wisdom Center → Configuración. Nada distinguía lo que pertenece al proyecto de lo que es global, así que «Red WNTR» —que sin proyecto no lleva a ninguna parte— estaba al mismo nivel que «Configuración». Y la vista del Wisdom Center se llamaba `rag` en el enrutado mientras la etiqueta visible decía «Wisdom Center».

## La jerarquía

```
PROYECTOS            ← raíz de la navegación y vista por defecto
  └─ [proyecto activo]
       ├─ Red WNTR
       ├─ Simulaciones
       └─ Chat del proyecto
HERRAMIENTAS
  ├─ Calculadora     ← independiente del proyecto
  └─ Chat general
SISTEMA
  ├─ Wisdom Center
  └─ Configuración
```

Los tres hijos sólo se pintan con proyecto activo; sin él, el bloque dice «Sin proyecto activo». El nombre del proyecto los encabeza, así que es visible desde cualquier vista sin abrir nada.

| Pieza | Fichero |
|---|---|
| Modelo de navegación (módulo puro) | `src/config/navegacion.ts` |
| Menú | `src/components/chat/Sidebar.tsx` |
| Vista, ámbito del chat y sección de red | `src/stores/appStore.ts` |
| Raíz de proyectos | `src/components/hydraulic/HydraulicProjectsPanel.tsx` |
| Corrección de la vista al arrancar | `src/App.tsx` |

## Cuatro decisiones

**La raíz enseña siempre la lista de proyectos.** `HydraulicProjectsPanel` era un envoltorio de `WNTRMainInterface`, es decir, exactamente el mismo componente que «Red WNTR». Con un proyecto abierto las dos entradas mostraban lo mismo, y la lista sólo se alcanzaba cerrando antes el proyecto desde un botón de dentro de la vista de red. Ahora ese componente recibe `modo`: en `'proyectos'` enseña siempre la lista, con el activo marcado; en `'red'` sigue siendo la vista de trabajo. Elegir un proyecto en la lista no navega a ninguna parte: lo que cambia es el menú, que despliega sus hijos.

**«Simulaciones» no es una vista nueva.** No hay pantalla de histórico de simulaciones, y fabricarla no es reorganizar un menú (eso está en #38 y #41). El ítem entra en la vista de red pidiendo su pestaña de simulación. Es el único que exige red además de proyecto: la vista de red no la exige a propósito, porque es donde se importa el `.inp` (#33).

**Los dos chats son la misma pantalla con distinto ámbito.** El chat general debe existir —criterio del Ing. Luis Mora recogido en el issue— y el del proyecto también. No hacen falta dos vistas: `ambitoChat` decide qué conversaciones lista el menú y a qué proyecto queda atada la que se cree. De paso desaparece el árbol con las conversaciones de todos los proyectos, que tras #31 era un atajo para trabajar fuera del proyecto activo.

**Sin proyecto se arranca en Proyectos, pero no se pierde la vista guardada.** El issue pide las dos cosas. `ajustarVistaInicial` sólo interviene cuando la vista restaurada tiene una precondición sin cumplir, y no persiste el cambio: con proyecto, la próxima sesión vuelve a abrir donde se quedó. Vive en `App.tsx` porque hasta que no terminan la carga de ajustes y la restauración del proyecto no se sabe si hay uno.

## Un fallo que esto destapó

`hayRed` era papel mojado desde #33: lo declaraba la tabla de precondiciones pero ninguna vista lo usaba, y `hydraulic:get-project` no devolvía el contador, así que `currentProject.networkCount` llegaba siempre `undefined`. Se vio en cuanto «Simulaciones» empezó a usarlo — aparecía bloqueada con la red guardada delante. El handler cuenta ahora las redes activas, con el mismo filtro `isActive` que la lista de proyectos, porque `deleteNetwork()` es un borrado lógico.

## Nomenclatura

`rag` pasa a llamarse `wisdom` en el enrutado. `migrarVista()` traduce el valor guardado por quien dejó la aplicación en el Wisdom Center; sin eso arrancaría en la vista por defecto sin explicación, porque su valor ya no existiría.

## Fuera de alcance

**Wisdom del proyecto.** La jerarquía del issue lo lista, pero separar el ámbito general del de proyecto en el Wisdom Center es el issue #39. Mientras tanto el Wisdom Center es global y vive en el bloque de sistema, que es lo que hoy es verdad.

## Comprobaciones

- `npm test` → **195 pasan** (eran 181). Los 14 nuevos cubren el modelo de navegación —que ninguna vista quede sin entrada de menú, que nunca haya dos ítems encendidos, los requisitos de cada ítem y las etiquetas en los tres idiomas— y la vista inicial del store con su migración.
- `npm run typecheck` y `tsc -p tsconfig.electron.json` limpios. `npx eslint` sin avisos nuevos (16 antes y 16 después).
- **Ciclo completo verificado contra la aplicación real**, con la base de datos de verdad: arranque con `currentView='wntr'` guardada y sin proyecto activo → abre en Proyectos, con «Sin proyecto activo» y sin hijos; elegir un proyecto en la lista → tarjeta marcada «Activo» y los tres hijos bajo su nombre; «Simulaciones» → vista de red con la pestaña de simulación activa (comprobado por el `data-state` de las pestañas); «Chat del proyecto» → el menú lista sus conversaciones y la nueva queda atada al proyecto; «Chat general» → sólo las conversaciones sin proyecto.

Diseño y decisiones completos en [`docs/NAVEGACION_JERARQUICA.md`](docs/NAVEGACION_JERARQUICA.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
