### PR TITLE
feat(georreferenciación): reproyección geodésica real con EPSG declarado (#36)

### DIFF
--- a/backend/services/hydraulic/networkRepository.crs.test.ts
+++ b/backend/services/hydraulic/networkRepository.crs.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { NetworkRepositoryService } from './networkRepository'
+
+/**
+ * El sistema de coordenadas está escrito en dos sitios: la columna
+ * `coordinateSystem` y la copia que vive dentro de `networkData`. El mapa lee la
+ * segunda y el repositorio la primera, así que si `declararCRS` actualizara sólo
+ * una, la red se seguiría pintando con el sistema anterior (#36).
+ */
+function prismaFalso(inicial: { coordinateSystem?: string | null; networkData: string }) {
+  const fila: any = {
+    id: 'n1',
+    coordinateSystem: inicial.coordinateSystem ?? null,
+    networkData: inicial.networkData,
+    fileContent: '[COORDINATES]\n J1 842913.44 1151987.21\n',
+  }
+  return {
+    fila,
+    cliente: {
+      hydraulicNetwork: {
+        findUnique: async ({ where }: any) => (where.id === fila.id ? fila : null),
+        update: async ({ data }: any) => {
+          Object.assign(fila, data)
+          return fila
+        },
+      },
+    } as any,
+  }
+}
+
+describe('declararCRS', () => {
+  it('escribe el EPSG en la columna y en la copia de networkData', async () => {
+    const { fila, cliente } = prismaFalso({
+      coordinateSystem: JSON.stringify({ type: 'projected', units: 'meters', epsg: null }),
+      networkData: JSON.stringify({ name: 'red', coordinate_system: { type: 'projected', epsg: null } }),
+    })
+    const repo = new NetworkRepositoryService(cliente)
+
+    const resultado = await repo.declararCRS('n1', 'EPSG:32618')
+
+    expect(resultado.declared_epsg).toBe('EPSG:32618')
+    expect(JSON.parse(fila.coordinateSystem).declared_epsg).toBe('EPSG:32618')
+    expect(JSON.parse(fila.networkData).coordinate_system.declared_epsg).toBe('EPSG:32618')
+  })
+
+  it('conserva lo que ya sabía el lector del .inp', async () => {
+    const { fila, cliente } = prismaFalso({
+      coordinateSystem: JSON.stringify({
+        type: 'projected',
+        units: 'meters',
+        bounds: { minX: 842000, maxX: 843500, minY: 1151000, maxY: 1152500 },
+      }),
+      networkData: JSON.stringify({ name: 'red', nodes: [], coordinate_system: { type: 'projected' } }),
+    })
+    const repo = new NetworkRepositoryService(cliente)
+
+    await repo.declararCRS('n1', 'EPSG:32618')
+
+    const guardado = JSON.parse(fila.coordinateSystem)
+    expect(guardado.type).toBe('projected')
+    expect(guardado.units).toBe('meters')
+    expect(guardado.bounds.minX).toBe(842000)
+    // Los nudos y el nombre siguen ahí: declarar el CRS no reescribe la red.
+    expect(JSON.parse(fila.networkData).name).toBe('red')
+  })
+
+  it('no toca el .inp guardado: la exportación conserva las coordenadas originales', async () => {
+    const inp = '[COORDINATES]\n J1 842913.44 1151987.21\n'
+    const { fila, cliente } = prismaFalso({
+      networkData: JSON.stringify({ name: 'red', coordinate_system: { type: 'projected' } }),
+    })
+    const repo = new NetworkRepositoryService(cliente)
+
+    await repo.declararCRS('n1', 'EPSG:32618')
+
+    expect(fila.fileContent).toBe(inp)
+  })
+
+  it('declarar la red como no georreferenciada es un estado válido, no un borrado', async () => {
+    const { fila, cliente } = prismaFalso({
+      coordinateSystem: JSON.stringify({ type: 'projected', declared_epsg: 'EPSG:32618' }),
+      networkData: JSON.stringify({ name: 'red', coordinate_system: { declared_epsg: 'EPSG:32618' } }),
+    })
+    const repo = new NetworkRepositoryService(cliente)
+
+    const resultado = await repo.declararCRS('n1', null)
+
+    expect(resultado.declared_epsg).toBeNull()
+    expect(resultado.requires_user_crs).toBe(true)
+    expect(JSON.parse(fila.networkData).coordinate_system.declared_epsg).toBeNull()
+  })
+
+  it('una red que no existe falla en vez de crear una fila fantasma', async () => {
+    const { cliente } = prismaFalso({ networkData: '{}' })
+    const repo = new NetworkRepositoryService(cliente)
+
+    await expect(repo.declararCRS('no-existe', 'EPSG:32618')).rejects.toThrow(/no encontrada/i)
+  })
+})

--- a/backend/services/hydraulic/networkRepository.ts
+++ b/backend/services/hydraulic/networkRepository.ts
@@ -13,14 +13,29 @@ export interface NetworkData {
   nodes: any[]
   links: any[]
   options: any
-  coordinate_system?: {
-    type: 'geographic' | 'projected' | 'unknown'
-    bounds?: any
-    epsg?: string
-    units?: string
-    possible_system?: string
-    region_hint?: string
-  }
+  coordinate_system?: CoordinateSystemInfo
+}
+
+/**
+ * Sistema de coordenadas de la red (#36).
+ *
+ * `epsg` es lo que el lector del .inp pudo demostrar mirando las coordenadas —en
+ * la practica, solo reconoce las geograficas—. `declared_epsg` es lo que el
+ * ingeniero declaro en la interfaz, y es lo que manda al pintar: adivinar el huso
+ * a partir de la X es imposible, asi que sin declaracion la red no se dibuja.
+ */
+export interface CoordinateSystemInfo {
+  type: 'geographic' | 'projected' | 'unknown'
+  bounds?: any
+  epsg?: string | null
+  units?: string
+  possible_system?: string
+  region_hint?: string
+  /** EPSG confirmado por el usuario. `null` explicito = declarado como desconocido. */
+  declared_epsg?: string | null
+  declared_at?: string
+  /** El lector no pudo determinar el CRS y hace falta que lo declare el usuario. */
+  requires_user_crs?: boolean
 }
 
 export interface SavedNetwork {
@@ -192,6 +207,49 @@ export class NetworkRepositoryService {
       networkData,
       fileContent: network.fileContent
     }
+  }
+
+  /**
+   * Declara el sistema de coordenadas de la red (#36).
+   *
+   * Escribe en la columna `coordinateSystem` y dentro de `networkData`, que
+   * lleva su propia copia: el mapa lee la de `networkData` y el repositorio la
+   * de la columna, y si solo se actualizara una, la red se seguiria pintando con
+   * el sistema anterior hasta la siguiente recarga.
+   *
+   * No toca `fileContent`: el .inp guardado conserva sus coordenadas originales,
+   * que es lo que permite que un ciclo importar-exportar no pierda nada.
+   */
+  async declararCRS(networkId: string, epsg: string | null): Promise<CoordinateSystemInfo> {
+    const network = await this.prisma.hydraulicNetwork.findUnique({
+      where: { id: networkId }
+    })
+    if (!network) throw new Error('Red no encontrada')
+
+    const previo: CoordinateSystemInfo = network.coordinateSystem
+      ? JSON.parse(network.coordinateSystem)
+      : { type: 'unknown' }
+
+    const coordinateSystem: CoordinateSystemInfo = {
+      ...previo,
+      declared_epsg: epsg,
+      declared_at: new Date().toISOString(),
+      requires_user_crs: epsg === null
+    }
+
+    const networkData = JSON.parse(network.networkData || '{}')
+    networkData.coordinate_system = { ...(networkData.coordinate_system || {}), ...coordinateSystem }
+
+    await this.prisma.hydraulicNetwork.update({
+      where: { id: networkId },
+      data: {
+        coordinateSystem: JSON.stringify(coordinateSystem),
+        networkData: JSON.stringify(networkData),
+        updatedAt: new Date()
+      }
+    })
+
+    return coordinateSystem
   }
 
   /**

--- a/backend/services/hydraulic/wntrService.py
+++ b/backend/services/hydraulic/wntrService.py
@@ -416,10 +416,15 @@ class WNTRService:
             coord_info = {
                 'type': 'unknown',  # 'geographic' or 'projected'
                 'bounds': None,
+                # El lector no adivina el EPSG: solo lo afirma cuando las
+                # coordenadas lo demuestran (rango lon/lat). Para todo lo demas
+                # queda en None y lo declara el ingeniero desde la interfaz (#36).
                 'epsg': None,
+                'requires_user_crs': False,
+                'detection_note': '',
                 'units': 'feet'  # default EPANET units
             }
-            
+
             # Read the INP file to look for coordinate information
             with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                 lines = f.readlines()
@@ -467,6 +472,11 @@ class WNTRService:
                         except ValueError:
                             continue
             
+            if not coordinates:
+                coord_info['requires_user_crs'] = True
+                coord_info['detection_note'] = 'El fichero no trae seccion [COORDINATES]: la red no se puede situar en el mapa.'
+                return coord_info
+
             # Analyze coordinates to determine if they're geographic
             if coordinates:
                 x_coords = [c[0] for c in coordinates]
@@ -502,64 +512,32 @@ class WNTRService:
                         'maxY': max_y
                     }
                 
-                # Try to detect specific coordinate systems
-                # Check for UTM-like coordinates (large positive numbers)
+                # El sistema concreto no se deduce de las coordenadas.
+                #
+                # La X de una coordenada UTM es la distancia al meridiano central
+                # de su huso y vale lo mismo en los 60: 842.913 m es un punto
+                # valido en Cartagena, en Valencia y en Sidney. Hasta la v1.9
+                # aqui habia una escalera de rangos de X por pais, con un caso
+                # codificado a mano para Cartagena, que acertaba con las redes de
+                # prueba y fallaba en silencio con el resto (#48). Se retiro: lo
+                # que no se puede demostrar, se pregunta.
                 if coord_info['type'] == 'projected':
-                    if min_x > 100000 and min_x < 1000000:
+                    coord_info['requires_user_crs'] = True
+                    if 100000 < min_x < 1000000 and 0 <= min_y <= 10000000:
                         coord_info['possible_system'] = 'UTM'
-                        
-                        # Detect UTM zone based on X coordinate ranges
-                        # UTM zones for Latin America:
-                        # Zone 14N: Mexico Pacific (500,000-900,000)
-                        # Zone 15N: Mexico/Guatemala (200,000-800,000)
-                        # Zone 16N: Guatemala/Belize (200,000-800,000)
-                        # Zone 17N: Colombia west (200,000-800,000)
-                        # Zone 18N: Colombia Caribbean coast including Cartagena (200,000-800,000)
-                        # Zone 19N: Colombia interior (200,000-800,000)
-                        
-                        # Check for filename hints to help with detection
-                        filename_lower = file_path.lower()
-                        
-                        if 'cartagena' in filename_lower or 'tk-lomas' in filename_lower:
-                            # Cartagena is in UTM Zone 18N
-                            coord_info['possible_utm_zone'] = '18N'
-                            coord_info['region_hint'] = 'Colombia Caribbean (Cartagena)'
-                            coord_info['epsg'] = 'EPSG:32618'  # WGS84 UTM Zone 18N
-                        elif 200000 <= min_x <= 800000:
-                            # Standard UTM zone detection for the Americas
-                            if min_x < 350000:
-                                coord_info['possible_utm_zone'] = '17N'
-                                coord_info['region_hint'] = 'Colombia Pacific coast'
-                                coord_info['epsg'] = 'EPSG:32617'
-                            elif min_x < 650000:
-                                coord_info['possible_utm_zone'] = '18N'
-                                coord_info['region_hint'] = 'Colombia Caribbean (Cartagena, Barranquilla)'
-                                coord_info['epsg'] = 'EPSG:32618'
-                            else:
-                                coord_info['possible_utm_zone'] = '19N'
-                                coord_info['region_hint'] = 'Colombia interior (Bogotá)'
-                                coord_info['epsg'] = 'EPSG:32619'
-                        elif 160000 <= min_x <= 840000:
-                            # Mexico and Central America
-                            if min_x < 400000:
-                                coord_info['possible_utm_zone'] = '14N'
-                                coord_info['region_hint'] = 'Mexico Pacific'
-                                coord_info['epsg'] = 'EPSG:32614'
-                            elif min_x < 600000:
-                                coord_info['possible_utm_zone'] = '15N'
-                                coord_info['region_hint'] = 'Mexico/Guatemala'
-                                coord_info['epsg'] = 'EPSG:32615'
-                            else:
-                                coord_info['possible_utm_zone'] = '16N'
-                                coord_info['region_hint'] = 'Guatemala/Belize'
-                                coord_info['epsg'] = 'EPSG:32616'
-                        else:
-                            # Generic UTM zone calculation for other areas
-                            estimated_zone = int((min_x + 500000) / 1000000 * 6 + 31)
-                            if 1 <= estimated_zone <= 60:
-                                coord_info['possible_utm_zone'] = f'{estimated_zone}N'
-                                coord_info['epsg'] = f'EPSG:326{estimated_zone:02d}'
-                
+                        coord_info['detection_note'] = (
+                            'Las coordenadas encajan con una proyeccion UTM, pero el huso '
+                            'no se puede deducir de ellas. Declara el EPSG del proyecto.'
+                        )
+                    else:
+                        coord_info['detection_note'] = (
+                            'Coordenadas proyectadas de sistema desconocido. Declara el EPSG '
+                            'del proyecto para situar la red sobre el mapa.'
+                        )
+                else:
+                    coord_info['epsg'] = 'EPSG:4326'
+                    coord_info['detection_note'] = 'Coordenadas geograficas (longitud/latitud) WGS84.'
+
                 # print(f"Coordinate detection: type={coord_info['type']}, bounds={coord_info['bounds']}, system={coord_info.get('possible_system', 'unknown')}")  # Debug only
                 
             return coord_info

--- a/docs/REPROYECCION_CRS.md
+++ b/docs/REPROYECCION_CRS.md
@@ -1,0 +1,189 @@
+# Reproyección geodésica real de coordenadas (EPSG/UTM)
+
+Diseño y decisiones del issue [#36](https://github.com/Boorie-AI/boorie_cliente/issues/36).
+Cubre también el mínimo del bug hermano [#48](https://github.com/Boorie-AI/boorie_cliente/issues/48),
+que denuncia el mismo código desde el otro lado.
+
+## El problema
+
+Boorie enseñaba un EPSG para cada red cargada y la dibujaba sobre la ortofoto,
+dando la impresión de que la georreferenciación era correcta. El EPSG no salía de
+ningún dato: se adivinaba.
+
+Había dos escaleras de heurísticas independientes, una en cada lado de la
+aplicación:
+
+- `wntrService.py`, `_get_coordinate_info`: detectaba «coordenadas tipo UTM» por
+  magnitud y deducía el huso por rangos de X codificados a mano para América
+  Latina, con un caso especial por nombre de fichero para Cartagena.
+- `WNTRMapViewer.tsx`, `detectCoordinateSystem`: unas 200 líneas con la misma
+  idea y distintos umbrales, incluidos casos por nombre de fichero
+  (`tk-lomas`, `cartagena`, `mexico`) y un `else` final que asumía UTM 18N.
+
+Las dos podían dar respuestas distintas para la misma red. Y la del visor nunca
+devolvía «no lo sé»: su último `return` situaba en el Caribe colombiano cualquier
+red que no encajara en ningún rango.
+
+### Por qué adivinar no puede funcionar
+
+La X de una coordenada UTM es la distancia al meridiano central **de su huso**, y
+el mismo número es válido en los 60. `842.913 m` es un punto legítimo en
+Cartagena, en Valencia y en Sídney. No existe la heurística correcta: los rangos
+por país acertaban con las redes con las que se probaron porque *ya se sabía* de
+qué país eran.
+
+Esa es la causa de fondo de #48, y es la razón de que la solución no sea afinar
+la heurística sino sustituirla por una declaración del ingeniero.
+
+## Cómo queda
+
+```
+.inp  ──►  lector Python            ──►  tipo (geográfico/proyectado), límites,
+                                          unidades. EPSG sólo si es demostrable
+                                          (rango lon/lat → EPSG:4326).
+                                              │
+                                              ▼
+          HydraulicNetwork.coordinateSystem   declared_epsg  ◄── selector de la UI
+                                              │
+                                              ▼
+          @/services/geo/crs (proj4)     ──►  reproyección a WGS84 para pintar
+                                              │
+                                              ▼
+                                          validación de cordura contra el país
+                                          declarado en el proyecto
+```
+
+Lo declarado manda sobre lo detectado, siempre. Sin EPSG resuelto **la red no se
+dibuja**: la cabecera del visor explica por qué y ofrece el botón para
+declararlo.
+
+| Pieza | Fichero |
+|---|---|
+| Motor de reproyección y catálogo (módulo puro) | `src/services/geo/crs.ts` |
+| Selector explícito de EPSG | `src/components/hydraulic/CRSSelector.tsx` |
+| Visor de mapa: resolución, aviso y repintado | `src/components/hydraulic/WNTRMapViewer.tsx` |
+| Persistencia del EPSG declarado | `backend/services/hydraulic/networkRepository.ts` (`declararCRS`) |
+| Canal IPC | `network-repo:declare-crs` |
+| Lector del `.inp` sin heurísticas de huso | `backend/services/hydraulic/wntrService.py` |
+
+## Decisiones
+
+**proj4js, no pyproj.** El issue proponía añadir `pyproj` al entorno WNTR. Se
+descarta por dos motivos, uno funcional y otro de riesgo. El funcional manda: el
+criterio de aceptación pide que cambiar el EPSG recoloque la red *sin recargar el
+.inp*, y con `pyproj` cada cambio sería un viaje a Python más un reparseo del
+fichero. El de riesgo es el que ya estaba anotado en el propio issue — una
+dependencia Python nueva hay que validarla en macOS, Windows y Linux, y el
+proyecto arrastra incidencias conocidas con NumPy/SciPy en macOS. `proj4` ya era
+dependencia del proyecto (`package.json`) y ya se usaba en el visor. Python
+conserva el papel de *lector*: describe lo que ve en el fichero, no transforma.
+
+**Un solo motor, un solo sitio.** Las definiciones `proj4.defs(...)` estaban
+repartidas por los visores, cada uno con su lista. Dos visores podían tener
+definiciones distintas del mismo EPSG. Ahora viven en `src/services/geo/crs.ts` y
+se registran bajo demanda.
+
+**Los 120 husos UTM se generan, no se escriben.** La fórmula es la misma para
+todos (`+proj=utm +zone=N [+south] +datum=WGS84`); una tabla a mano sólo aporta
+ocasiones de equivocarse. A eso se añaden los sistemas nacionales con origen
+propio, que sí hay que declarar: MAGNA-SIRGAS (Colombia), ETRS89 y ED50 / UTM
+(España) e ITRF2008 / LCC (México).
+
+**El selector acepta cualquier EPSG, no sólo los del catálogo.** La lista es una
+comodidad para buscar; escribir `25830` o `EPSG:25830` funciona igual. Una lista
+cerrada volvería a ser el problema de los rangos codificados a mano, sólo que en
+la interfaz.
+
+**«No está georreferenciada» es una respuesta válida.** El selector la ofrece
+explícitamente y se persiste como `declared_epsg: null`. Una red de un modelo
+sintético con coordenadas locales no tiene EPSG, y forzar a inventarle uno sería
+volver al punto de partida.
+
+**Validación de cordura por envolvente del país, no por línea de costa.** Tras
+reproyectar se comprueba que el centroide cae dentro de la envolvente del país
+declarado en `HydraulicProject.location`. Es deliberadamente grosero: una
+envolvente incluye mar y países vecinos. Sirve para lo que importa —cazar el huso
+o el hemisferio equivocados, que desplazan la red cientos de kilómetros— sin
+arrastrar datos cartográficos. El aviso no bloquea: el ingeniero puede tener
+razón y el país del proyecto estar mal puesto.
+
+**El `.inp` guardado no se toca nunca.** `declararCRS` escribe metadatos, no
+coordenadas. La ida y vuelta sin pérdida del criterio de aceptación no se
+consigue reproyectando de vuelta al exportar, sino no habiendo reproyectado nunca
+el fichero: la reproyección existe sólo para pintar. Hay un test que lo fija.
+
+**El sistema se escribe en dos sitios a propósito, y se actualizan juntos.** La
+columna `coordinateSystem` y la copia dentro de `networkData` ya existían
+duplicadas antes de este cambio; el mapa lee una y el repositorio la otra.
+`declararCRS` escribe las dos en la misma transacción, porque actualizar sólo una
+dejaría la red pintándose con el sistema anterior hasta la siguiente recarga.
+
+**Sin migración de base de datos.** `HydraulicNetwork.coordinateSystem` ya existía
+como TEXT con JSON dentro; los campos nuevos (`declared_epsg`, `declared_at`,
+`requires_user_crs`) caben ahí. Las redes ya guardadas quedan sin declarar, que es
+la lectura correcta: nadie confirmó su EPSG.
+
+## Verificación
+
+Los puntos de control de `src/services/geo/crs.test.ts` **no salen de proj4**: se
+derivan de la definición de cada EPSG, que fija dónde cae su falso origen.
+Comprobar proj4 con proj4 no demostraría nada.
+
+- En el meridiano central de un huso UTM, `X = 500.000` tiene que devolver
+  exactamente su longitud (`-183 + 6n`: el huso 18 es `-75`, el 30 es `-3`).
+- El falso origen de MAGNA-SIRGAS Bogotá (`1.000.000, 1.000.000`) tiene que caer
+  en 4°35′46,3215″N / 74°04′39,0285″W, que es su origen oficial.
+- El falso este de México ITRF2008 / LCC (`2.500.000`) tiene que caer en el
+  meridiano `-102`.
+- Ida y vuelta en cuatro sistemas: error submilimétrico (el criterio pedía < 2 m).
+- La misma coordenada de Cartagena declarada en el huso 14 o en el hemisferio sur
+  dispara el aviso de cordura; declarada en el 18N, no.
+
+## Comprobado en la aplicación
+
+Ciclo completo con la base real, sobre `Net3 2.inp` (red sintética, coordenadas
+proyectadas de 8 a 45 unidades) y sobre una red geográfica:
+
+- Abrir la red proyectada → el mapa queda vacío y la cabecera avisa: «Esta red no
+  se puede situar en el mapa: las coordenadas están proyectadas. El valor de X no
+  identifica el huso…», con el enlace para declararlo. Antes de este cambio esa
+  misma red se dibujaba sin decir nada.
+- Declarar `EPSG:32615` → el selector previsualiza el centroide antes de aceptar
+  («el centro de la red cae en 0.00014, -97.48851»), la red se pinta y la
+  cabecera pasa a «Declarado: EPSG:32615 — WGS 84 / UTM 15N».
+- Cambiar a `EPSG:32718` sin volver a cargar el `.inp` → la red se recoloca y el
+  mapa se reencuadra (de -97,49 a -165,23).
+- Comprobado en SQLite que `declared_epsg` queda escrito **en las dos copias**,
+  la columna `coordinateSystem` y `networkData.coordinate_system`.
+- Red geográfica → se reconoce sola, sin declarar nada, y la cabecera lo etiqueta
+  «Sugerido: EPSG:4326 … (sin confirmar)», que es lo que es.
+
+## Estado de los criterios de aceptación
+
+| Criterio | Estado |
+|---|---|
+| Red en EPSG:32618 superpuesta con error < ~2 m | Reproyección exacta verificada contra puntos de control; el error de la ida y vuelta es submilimétrico. Falta el contraste sobre ortofoto con una red real con puntos de control — es lo que el issue pide a Javier. |
+| Cambiar el EPSG reposiciona sin recargar el `.inp` | Hecho y comprobado en la aplicación. La reproyección depende de los nudos ya en memoria y del EPSG, no del fichero. |
+| Red sin coordenadas o con EPSG desconocido informa en vez de dibujar | Hecho y comprobado en la aplicación. No se pintan capas y la cabecera explica el motivo con la acción para resolverlo. |
+| Ida y vuelta del `.inp` sin pérdida | Hecho por construcción: el `fileContent` guardado no se modifica al declarar el CRS. |
+| Retirar los casos codificados a mano | Hecho en los dos lados (Python y visor de mapa). |
+
+## Fuera de alcance
+
+**Los visores muertos.** `WNTRIntermediateViewer` y `WNTRSimulationViewer`
+conservan su propia detección heurística y, el primero, un posicionamiento por
+escalado de límites —justo lo que denuncia #48—. No se han tocado porque no los
+importa nadie: `WNTRMainInterface` → `WNTRAdvancedMapViewer` → `WNTRMapViewer` es
+la única cadena viva. Retirarlos es el issue #37, y arreglar código muerto para
+borrarlo después sería trabajo perdido.
+
+**EPSG por defecto a nivel de proyecto.** Hoy se declara por red. Un valor
+heredado del proyecto tiene sentido cuando un proyecto tenga varias redes de la
+misma zona, pero heredar un EPSG es otra forma de darlo por supuesto, y conviene
+verlo funcionar declarándolo explícitamente antes de añadir herencia.
+
+**Reproyección inversa al exportar.** El módulo expone
+`crearTransformadorInverso` y está probado, pero no hay ningún flujo de
+exportación de `.inp` en la aplicación que la necesite: el fichero se guarda y se
+devuelve tal cual. Se usará cuando exista una exportación que genere coordenadas
+nuevas.

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -192,6 +192,30 @@ export class NetworkRepositoryHandler {
       }
     })
 
+    /**
+     * Declara el sistema de coordenadas de una red (#36). `epsg: null` la marca
+     * como no georreferenciada, que es un estado legitimo: mejor decirlo que
+     * pintarla en un sitio inventado.
+     */
+    ipcMain.handle('network-repo:declare-crs', async (_, data: {
+      networkId: string
+      epsg: string | null
+    }) => {
+      try {
+        appLogger.info('Declaring network CRS', { networkId: data.networkId, epsg: data.epsg })
+
+        const coordinateSystem = await this.networkRepo.declararCRS(data.networkId, data.epsg)
+
+        return { success: true, data: coordinateSystem }
+      } catch (error) {
+        appLogger.error('Failed to declare network CRS', error as Error)
+        return {
+          success: false,
+          error: (error as Error).message
+        }
+      }
+    })
+
     // Get network details
     ipcMain.handle('network-repo:get', async (_, networkId: string) => {
       try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -178,6 +178,13 @@ const electronAPI = {
       description?: string
     }) => ipcRenderer.invoke('network-repo:update', data),
 
+    /**
+     * Declara el sistema de coordenadas de la red (#36). `epsg: null` la deja
+     * marcada como no georreferenciada.
+     */
+    declareCRS: (data: { networkId: string; epsg: string | null }) =>
+      ipcRenderer.invoke('network-repo:declare-crs', data),
+
     // Load and get networks
     load: (networkId: string) => ipcRenderer.invoke('network-repo:load', networkId),
     get: (networkId: string) => ipcRenderer.invoke('network-repo:get', networkId),

--- a/src/components/hydraulic/CRSSelector.tsx
+++ b/src/components/hydraulic/CRSSelector.tsx
@@ -1,0 +1,245 @@
+/**
+ * Selector explícito del sistema de coordenadas de la red (#36).
+ *
+ * El EPSG es un dato del proyecto, no una deducción: esta ventana es donde el
+ * ingeniero lo declara. La lista es una comodidad —cubre los 120 husos UTM y los
+ * sistemas nacionales habituales—, pero acepta cualquier código escrito a mano,
+ * porque la lista nunca va a estar completa.
+ */
+
+import { useMemo, useState } from 'react'
+import { AlertTriangle, Check, Globe2, Search } from 'lucide-react'
+import { logger } from '@/utils/logger'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useProjectStore } from '@/stores/projectStore'
+import {
+  catalogoCRS,
+  esEPSGSoportado,
+  nombreCRS,
+  normalizarEPSG,
+  reproyectarLimites,
+  validarCordura,
+  type LimitesProyectados,
+} from '@/services/geo/crs'
+
+interface CRSSelectorProps {
+  abierto: boolean
+  onCerrar: () => void
+  /** Límites de la red en sus coordenadas originales, para la previsualización. */
+  limites: LimitesProyectados | null
+  epsgActual: string | null
+  /**
+   * Red guardada sobre la que persistir. Sin ella la declaración vale sólo para
+   * la sesión: una red recién importada y todavía sin guardar puede situarse en
+   * el mapa, pero no hay dónde recordar el sistema hasta que se guarde.
+   */
+  networkId?: string | null
+  onDeclarado: (epsg: string | null) => void
+}
+
+export function CRSSelector({
+  abierto,
+  onCerrar,
+  limites,
+  epsgActual,
+  networkId,
+  onDeclarado,
+}: CRSSelectorProps) {
+  const [busqueda, setBusqueda] = useState('')
+  const [seleccion, setSeleccion] = useState<string | null>(epsgActual)
+  const [guardando, setGuardando] = useState(false)
+  const [errorGuardado, setErrorGuardado] = useState<string | null>(null)
+
+  const paisProyecto = useProjectStore(s => s.currentProject?.location?.country ?? null)
+
+  const catalogo = useMemo(() => catalogoCRS(), [])
+
+  const resultados = useMemo(() => {
+    const q = busqueda.trim().toLowerCase()
+    if (!q) {
+      // Sin búsqueda se enseñan los sistemas con nombre propio: los 120 husos de
+      // golpe no ayudan a nadie, y quien busca el suyo escribe «18N» o «32618».
+      return catalogo.filter(c => !/^EPSG:32[67]\d{2}$/.test(c.epsg)).slice(0, 40)
+    }
+    return catalogo
+      .filter(c => c.epsg.toLowerCase().includes(q) || c.nombre.toLowerCase().includes(q))
+      .slice(0, 60)
+  }, [busqueda, catalogo])
+
+  /** Código escrito a mano que no está en el catálogo pero sí se puede usar. */
+  const codigoLibre = useMemo(() => {
+    const normalizado = normalizarEPSG(busqueda)
+    if (!normalizado) return null
+    if (catalogo.some(c => c.epsg === normalizado)) return null
+    return esEPSGSoportado(normalizado) ? normalizado : null
+  }, [busqueda, catalogo])
+
+  /**
+   * Previsualización: dónde cae la red con el sistema elegido, antes de aceptar.
+   * Es la comprobación que convierte «EPSG:32614» en algo que un ingeniero puede
+   * juzgar de un vistazo.
+   */
+  const vistaPrevia = useMemo(() => {
+    if (!seleccion || !limites) return null
+    try {
+      const { centroide } = reproyectarLimites(limites, seleccion)
+      return { centroide, cordura: validarCordura(centroide, paisProyecto) }
+    } catch (e) {
+      return {
+        centroide: null,
+        cordura: { ok: false, aviso: e instanceof Error ? e.message : 'Reproyección fallida' },
+      }
+    }
+  }, [seleccion, limites, paisProyecto])
+
+  const declarar = async (epsg: string | null) => {
+    setGuardando(true)
+    setErrorGuardado(null)
+    try {
+      if (networkId) {
+        const res = await window.electronAPI.networkRepository.declareCRS({ networkId, epsg })
+        if (!res?.success) throw new Error(res?.error || 'No se pudo guardar el sistema de coordenadas')
+      }
+      onDeclarado(epsg)
+      onCerrar()
+    } catch (e) {
+      logger.error('Error declarando el CRS de la red:', e)
+      setErrorGuardado(e instanceof Error ? e.message : 'No se pudo guardar el sistema de coordenadas')
+    } finally {
+      setGuardando(false)
+    }
+  }
+
+  return (
+    <Dialog open={abierto} onOpenChange={v => !v && onCerrar()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Globe2 className="h-4 w-4" />
+            Sistema de coordenadas de la red
+          </DialogTitle>
+          <DialogDescription>
+            Declara el EPSG en el que están las coordenadas del .inp. Boorie reproyecta a WGS84
+            para situar la red sobre el mapa; el fichero original no se modifica.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              autoFocus
+              value={busqueda}
+              onChange={e => setBusqueda(e.target.value)}
+              placeholder="Busca por código o nombre: 32618, UTM 18N, MAGNA…"
+              className="pl-8"
+            />
+          </div>
+
+          <div className="max-h-56 overflow-y-auto rounded-md border border-border divide-y divide-border">
+            {codigoLibre && (
+              <button
+                type="button"
+                onClick={() => setSeleccion(codigoLibre)}
+                className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted"
+              >
+                <span>
+                  <span className="font-mono">{codigoLibre}</span>
+                  <span className="ml-2 text-muted-foreground">{nombreCRS(codigoLibre)}</span>
+                </span>
+                {seleccion === codigoLibre && <Check className="h-4 w-4 text-primary" />}
+              </button>
+            )}
+
+            {resultados.map(c => (
+              <button
+                key={c.epsg}
+                type="button"
+                onClick={() => setSeleccion(c.epsg)}
+                className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted"
+              >
+                <span>
+                  <span className="font-mono">{c.epsg}</span>
+                  <span className="ml-2 text-muted-foreground">{c.nombre}</span>
+                </span>
+                {seleccion === c.epsg && <Check className="h-4 w-4 text-primary" />}
+              </button>
+            ))}
+
+            {resultados.length === 0 && !codigoLibre && (
+              <p className="px-3 py-4 text-center text-sm text-muted-foreground">
+                Ningún sistema coincide con «{busqueda}».
+              </p>
+            )}
+          </div>
+
+          {vistaPrevia && (
+            <div
+              className={`rounded-md border px-3 py-2 text-xs ${
+                vistaPrevia.cordura.ok
+                  ? 'border-border bg-muted/50 text-muted-foreground'
+                  : 'border-yellow-500/50 bg-yellow-500/10 text-yellow-700 dark:text-yellow-400'
+              }`}
+            >
+              {vistaPrevia.centroide && (
+                <p>
+                  Con {seleccion} el centro de la red cae en{' '}
+                  <span className="font-mono">
+                    {vistaPrevia.centroide[1].toFixed(5)}, {vistaPrevia.centroide[0].toFixed(5)}
+                  </span>
+                  .
+                </p>
+              )}
+              {!vistaPrevia.cordura.ok && (
+                <p className="mt-1 flex gap-1.5">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  {vistaPrevia.cordura.aviso}
+                </p>
+              )}
+            </div>
+          )}
+
+          {!networkId && (
+            <p className="text-xs text-muted-foreground">
+              Esta red todavía no está guardada en el proyecto: el sistema se aplica ahora, pero
+              habrá que volver a declararlo si cierras sin guardarla.
+            </p>
+          )}
+
+          {errorGuardado && (
+            <p className="text-xs text-red-600 dark:text-red-400">{errorGuardado}</p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 pt-2">
+          {/* Declarar la red como no georreferenciada es una respuesta válida, no
+              un fallo: es preferible a dejarla dibujada en un sitio inventado. */}
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={guardando}
+            onClick={() => declarar(null)}
+          >
+            No está georreferenciada
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={onCerrar} disabled={guardando}>
+              Cancelar
+            </Button>
+            <Button size="sm" disabled={!seleccion || guardando} onClick={() => declarar(seleccion)}>
+              {guardando ? 'Guardando…' : 'Aplicar'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
+++ b/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
@@ -68,6 +68,8 @@ interface WNTRAdvancedMapViewerProps {
   onDataLoaded?: (data: NetworkData) => void;
   onSimulationCompleted?: (results: SimulationResults) => void;
   highlightedNodes?: string[];
+  /** Red guardada que se muestra; el visor persiste ahí el EPSG declarado (#36). */
+  networkId?: string | null;
 }
 
 export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
@@ -75,7 +77,8 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
   simulationResults: externalSimulationResults,
   onDataLoaded: _onDataLoaded,
   onSimulationCompleted: _onSimulationCompleted,
-  highlightedNodes
+  highlightedNodes,
+  networkId
 }) => {
   const [networkData, setNetworkData] = useState<NetworkData | null>(externalNetworkData || null);
   const [simulationResults, setSimulationResults] = useState<SimulationResults | null>(externalSimulationResults || null);
@@ -209,6 +212,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
             simulationResults={simulationResults}
             activeTimeStep={visualizationSettings.timeStep}
             highlightedNodes={highlightedNodes}
+            networkId={networkId}
           />
 
           {/* Overlay info - Empty for now as requested */}

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -327,6 +327,17 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
   // Core state
   const [networkData, setNetworkData] = useState<NetworkData | null>(null);
+
+  /**
+   * Red guardada que corresponde a lo que se está mostrando. La declaración del
+   * sistema de coordenadas se persiste sobre ella (#36); una red recién
+   * importada y todavía sin guardar no tiene dónde recordarlo.
+   */
+  const redGuardadaId = useMemo(
+    () => activeNetworks.find(n => n.name === networkData?.name)?.id ?? null,
+    [activeNetworks, networkData]
+  );
+
   /**
    * Ruta del .inp que el backend de WNTR tiene cargado. Antes se buscaba la red
    * guardada por nombre para recuperarla, lo que falla con dos redes homonimas o
@@ -1920,6 +1931,7 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
             {isLeftSidebarCollapsed ? ">>" : "<<"}
           </button >
           <WNTRAdvancedMapViewer
+            networkId={redGuardadaId}
             networkData={networkData}
             simulationResults={simulationResults?.hydraulic?.data}
             highlightedNodes={highlightedComponents}

--- a/src/components/hydraulic/WNTRMapViewer.tsx
+++ b/src/components/hydraulic/WNTRMapViewer.tsx
@@ -1,8 +1,7 @@
 import { logger } from '@/utils/logger'
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import proj4 from 'proj4'
 import {
   FileUp,
   Play,
@@ -11,23 +10,24 @@ import {
   Loader2,
   AlertCircle,
   MapPin,
+  Globe2,
   Settings2
 } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import * as Dialog from '@radix-ui/react-dialog'
 import { useMapboxToken } from '@/hooks/useMapboxToken'
-
-// Define coordinate systems for Latin America
-proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs') // WGS84 Geographic
-// Mexico
-proj4.defs('EPSG:32614', '+proj=utm +zone=14 +datum=WGS84 +units=m +no_defs') // UTM Zone 14N (Mexico City)
-proj4.defs('EPSG:32615', '+proj=utm +zone=15 +datum=WGS84 +units=m +no_defs') // UTM Zone 15N (Mexico)
-proj4.defs('EPSG:32616', '+proj=utm +zone=16 +datum=WGS84 +units=m +no_defs') // UTM Zone 16N (Mexico)
-// Colombia
-proj4.defs('EPSG:32617', '+proj=utm +zone=17 +datum=WGS84 +units=m +no_defs') // UTM Zone 17N
-proj4.defs('EPSG:32618', '+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs') // UTM Zone 18N (Cartagena)
-proj4.defs('EPSG:32619', '+proj=utm +zone=19 +datum=WGS84 +units=m +no_defs') // UTM Zone 19N
-proj4.defs('EPSG:3116', '+proj=tmerc +lat_0=4.596200416666666 +lon_0=-74.07750791666666 +k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs') // MAGNA-SIRGAS Bogotá
+import { useProjectStore } from '@/stores/projectStore'
+import { CRSSelector } from './CRSSelector'
+// Las definiciones proj4 viven en `@/services/geo/crs`, no aqui: cuando cada
+// visor registraba las suyas, dos visores podian pintar la misma red con
+// definiciones distintas del mismo EPSG (#36).
+import {
+  calcularLimites,
+  nombreCRS,
+  reproyectarLimites,
+  resolverCRS,
+  validarCordura,
+} from '@/services/geo/crs'
 
 interface NetworkData {
   name: string
@@ -54,9 +54,13 @@ interface NetworkData {
       minY?: number
       maxY?: number
     }
-    epsg?: string
+    epsg?: string | null
     units?: string
     possible_system?: string
+    /** EPSG confirmado por el ingeniero; manda sobre cualquier deteccion (#36). */
+    declared_epsg?: string | null
+    requires_user_crs?: boolean
+    detection_note?: string
   }
 }
 
@@ -84,6 +88,11 @@ interface WNTRMapViewerProps {
   activeTimeStep?: number
   /** IDs de nudos a destacar sobre el resto (p. ej. los afectados por una interrupción). */
   highlightedNodes?: string[]
+  /**
+   * Red guardada que se está mostrando. Es donde se persiste el EPSG declarado;
+   * sin ella la declaración vale sólo para la sesión en curso.
+   */
+  networkId?: string | null
 }
 
 // `in` sobre una lista literal: si está vacía la expresión es siempre falsa, así
@@ -104,7 +113,8 @@ export function WNTRMapViewer({
   networkData: propNetworkData,
   simulationResults: propSimulationResults,
   activeTimeStep: propActiveTimeStep,
-  highlightedNodes
+  highlightedNodes,
+  networkId
 }: WNTRMapViewerProps) {
   // Priority: token pasted in Settings → General (persisted, works in the
   // packaged app) over the VITE_MAPBOX_ACCESS_TOKEN build-time env var.
@@ -549,301 +559,52 @@ export function WNTRMapViewer({
     }
   }, [showSettingsDialog, networkData])
 
-  // Smart coordinate system detection and conversion
-  const detectCoordinateSystem = useCallback((networkData: NetworkData) => {
-    // Find bounds of network
-    const xCoords = networkData.nodes.map(n => n.x || n.coordinates?.[0] || 0)
-    const yCoords = networkData.nodes.map(n => n.y || n.coordinates?.[1] || 0)
+  // Sistema de coordenadas de la red (#36, #48)
+  //
+  // Lo declarado por el ingeniero manda sobre cualquier deteccion. La deteccion
+  // solo reconoce coordenadas geograficas, que es lo unico que las coordenadas
+  // demuestran por si solas: el huso de una UTM no se puede deducir de la X.
+  // Hasta la v1.9 aqui habia 200 lineas de rangos codificados a mano por pais y
+  // un `else` final que asumia UTM 18N, asi que una red de un pais no
+  // contemplado se pintaba en el Caribe colombiano sin avisar de nada.
+  const [epsgDeclarado, setEpsgDeclarado] = useState<string | null>(null)
+  const [mostrarSelectorCRS, setMostrarSelectorCRS] = useState(false)
+  const paisProyecto = useProjectStore(s => s.currentProject?.location?.country ?? null)
 
-    const minX = Math.min(...xCoords)
-    const maxX = Math.max(...xCoords)
-    const minY = Math.min(...yCoords)
-    const maxY = Math.max(...yCoords)
+  useEffect(() => {
+    setEpsgDeclarado(networkData?.coordinate_system?.declared_epsg ?? null)
+  }, [networkData])
 
-    // Get file name for detection
-    const fileName = networkData.name?.toLowerCase() || ''
+  const limitesRed = useMemo(
+    () => (networkData ? calcularLimites(networkData.nodes) : null),
+    [networkData]
+  )
 
-    logger.debug('=== COORDINATE ANALYSIS ===')
-    logger.debug('File name:', fileName)
-    logger.debug('Coordinate bounds:', { minX, maxX, minY, maxY })
-    logger.debug('Coordinate ranges:', { rangeX: maxX - minX, rangeY: maxY - minY })
-    logger.debug('First 5 node coordinates:', networkData.nodes.slice(0, 5).map(n => ({ id: n.id, x: n.x, y: n.y })))
-    logger.debug('Network coordinate_system from backend:', networkData.coordinate_system)
-    logger.debug('Sample coordinate values:', {
-      sampleX: [minX, (minX + maxX) / 2, maxX],
-      sampleY: [minY, (minY + maxY) / 2, maxY]
-    })
-    logger.debug('TK-Lomas detected:', fileName.includes('tk-lomas'))
-    logger.debug('Cartagena detected:', fileName.includes('cartagena'))
+  const crs = useMemo(() => resolverCRS(epsgDeclarado, limitesRed), [epsgDeclarado, limitesRed])
 
-    // Check if already geographic
-    if (minX >= -180 && maxX <= 180 && minY >= -90 && maxY <= 90 &&
-      Math.abs(maxX - minX) < 10 && Math.abs(maxY - minY) < 10) {
-      return {
-        isGeographic: true,
-        epsgCode: 'EPSG:4326',
-        region: 'Geographic coordinates'
-      }
-    }
-
-    // Analyze for UTM zones (multiple regions)
-    if (minX > 100000 && minX < 1000000) {
-
-      // Special handling for TK-Lomas Cartagena file (highest priority)
-      if (fileName.includes('tk-lomas') || fileName.includes('cartagena')) {
-        logger.debug('🎯 Detected TK-Lomas/Cartagena file')
-
-        // Test different coordinate systems for these specific coordinates
-        // Current coordinates: ~842913, 1641804
-        // These don't match typical Cartagena UTM coordinates
-
-        // Try MAGNA-SIRGAS Colombia Bogotá zone (EPSG:3116)
-        if (minX > 800000 && minX < 1200000 && minY > 1600000 && minY < 1700000) {
-          logger.debug('Using MAGNA-SIRGAS Bogotá zone for TK-Lomas')
-          return {
-            isGeographic: false,
-            epsgCode: 'EPSG:3116',
-            region: 'MAGNA-SIRGAS Colombia Bogotá zone (TK-Lomas)',
-            centerApprox: [-75.5, 10.4]
-          }
-        }
-
-        // Try UTM Zone 17N (western Colombia)
-        if (minX > 800000 && minX < 900000) {
-          logger.debug('Using UTM Zone 17N for TK-Lomas (western coordinates)')
-          return {
-            isGeographic: false,
-            epsgCode: 'EPSG:32617',
-            region: 'UTM Zone 17N - Colombia west (TK-Lomas)',
-            centerApprox: [-75.5, 10.4]
-          }
-        }
-
-        // Fallback to UTM Zone 18N
-        logger.debug('Using UTM Zone 18N for TK-Lomas (fallback)')
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32618',
-          region: 'UTM Zone 18N - Colombia Caribbean (Cartagena)',
-          centerApprox: [-75.5, 10.4]
-        }
-      }
-
-      // Colombia Caribbean coast (Cartagena zone) - typical coordinates
-      if (minX > 200000 && minX < 900000 && minY > 1000000 && minY < 1300000) {
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32618',
-          region: 'UTM Zone 18N - Colombia Caribbean (Cartagena)',
-          centerApprox: [-75.5, 10.4]
-        }
-      }
-
-      // Mexico zones (but NOT for TK-Lomas which is Cartagena)
-      if ((fileName.includes('mexico') || fileName.includes('mx')) ||
-        (minX > 200000 && minX < 900000 && minY > 1800000 && minY < 2600000)) {
-
-        // Mexico City area (Zone 14N)
-        if (minX > 400000 && minX < 700000 && minY > 2000000 && minY < 2300000) {
-          return {
-            isGeographic: false,
-            epsgCode: 'EPSG:32614',
-            region: 'UTM Zone 14N - Mexico (Mexico City area)',
-            centerApprox: [-99.1, 19.4] // Mexico City
-          }
-        }
-
-        // Generic Mexico
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32614',
-          region: 'UTM Zone 14N - Mexico',
-          centerApprox: [-99.1, 19.4]
-        }
-      }
-
-      // Colombia interior
-      if (minX > 200000 && minX < 900000 && minY > 400000 && minY < 700000) {
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32619',
-          region: 'UTM Zone 19N - Colombia interior (Bogotá)',
-          centerApprox: [-74.1, 4.6]
-        }
-      }
-
-      // MAGNA-SIRGAS Bogotá
-      if (minX > 900000 && minX < 1200000 && minY > 900000 && minY < 1200000) {
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:3116',
-          region: 'MAGNA-SIRGAS Bogotá zone',
-          centerApprox: [-74.1, 4.6]
-        }
-      }
-
-      // Generic UTM detection - try to guess by Y coordinate
-      if (minY > 1800000) {
-        // Likely Mexico/North America
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32614',
-          region: 'UTM (estimated Mexico Zone 14N)',
-          centerApprox: [-99.1, 19.4]
-        }
-      } else if (minY > 1400000 && minY < 1800000) {
-        // Likely Central America (Guatemala, Honduras, etc.) - Zone 15N or 16N
-        if (minX > 600000) {
-          // Zone 15N
-          return {
-            isGeographic: false,
-            epsgCode: 'EPSG:32615',
-            region: 'UTM Zone 15N - Central America (Guatemala, Honduras)',
-            centerApprox: [-90.0, 15.0] // Guatemala approximate
-          }
-        } else {
-          // Zone 16N
-          return {
-            isGeographic: false,
-            epsgCode: 'EPSG:32616',
-            region: 'UTM Zone 16N - Central America',
-            centerApprox: [-84.0, 15.0] // Central America
-          }
-        }
-      } else if (minY > 1000000) {
-        // Likely Colombia Caribbean
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32618',
-          region: 'UTM (estimated Colombia Zone 18N)',
-          centerApprox: [-75.5, 10.4]
-        }
-      } else {
-        // Likely Colombia interior
-        return {
-          isGeographic: false,
-          epsgCode: 'EPSG:32619',
-          region: 'UTM (estimated Colombia Zone 19N)',
-          centerApprox: [-74.1, 4.6]
-        }
-      }
-    }
-
-    // Fallback
-    return {
-      isGeographic: false,
-      epsgCode: 'EPSG:32618',
-      region: 'Unknown coordinate system, assuming UTM 18N',
-      centerApprox: [-75.5, 10.4]
-    }
-  }, [])
-
-  // Convert network coordinates to geographic coordinates using proj4
-  const convertToGeoCoordinates = useCallback((networkData: NetworkData) => {
-    const coordSystem = detectCoordinateSystem(networkData)
-
-    logger.debug('Detected coordinate system:', coordSystem)
-
-    // If already geographic, no conversion needed
-    if (coordSystem.isGeographic) {
-      const xCoords = networkData.nodes.map(n => n.x || n.coordinates?.[0] || 0)
-      const yCoords = networkData.nodes.map(n => n.y || n.coordinates?.[1] || 0)
-
-      return {
-        bounds: {
-          minLon: Math.min(...xCoords),
-          maxLon: Math.max(...xCoords),
-          minLat: Math.min(...yCoords),
-          maxLat: Math.max(...yCoords)
-        },
-        transform: (x: number, y: number) => [x, y],
-        coordinateSystem: coordSystem
-      }
-    }
-
-    // Use proj4 for accurate coordinate transformation
+  /**
+   * Reproyeccion a WGS84. `null` cuando no hay sistema con el que reproyectar:
+   * quien pinta comprueba esto y no dibuja, en lugar de recibir un transformador
+   * de mentira que devuelva un punto cualquiera.
+   *
+   * Depende del EPSG y de los nudos, no del .inp: cambiar el sistema en el
+   * selector recoloca la red sin volver a cargar el fichero.
+   */
+  const conversion = useMemo(() => {
+    if (!crs.epsg || !limitesRed) return null
     try {
-      const sourceProjection = coordSystem.epsgCode
-      const targetProjection = 'EPSG:4326' // WGS84
-
-      logger.debug(`Converting from ${sourceProjection} to ${targetProjection}`)
-
-      // Get sample coordinates to establish bounds
-      const sampleCoords = networkData.nodes.slice(0, Math.min(100, networkData.nodes.length))
-        .map(node => {
-          const x = node.x || node.coordinates?.[0] || 0
-          const y = node.y || node.coordinates?.[1] || 0
-
-          try {
-            const [lon, lat] = proj4(sourceProjection, targetProjection, [x, y])
-            return { lon, lat, valid: true }
-          } catch (e) {
-            logger.warn(`Failed to convert coordinate [${x}, ${y}]:`, e)
-            return { lon: 0, lat: 0, valid: false }
-          }
-        })
-        .filter(coord => coord.valid)
-
-      if (sampleCoords.length === 0) {
-        throw new Error('No valid coordinates could be converted')
-      }
-
-      // Calculate bounds from converted coordinates
-      const lons = sampleCoords.map(c => c.lon)
-      const lats = sampleCoords.map(c => c.lat)
-
-      const bounds = {
-        minLon: Math.min(...lons),
-        maxLon: Math.max(...lons),
-        minLat: Math.min(...lats),
-        maxLat: Math.max(...lats)
-      }
-
-      logger.debug('=== COORDINATE CONVERSION RESULTS ===')
-      logger.debug('Source projection:', sourceProjection)
-      logger.debug('Target projection:', targetProjection)
-      logger.debug('Geographic bounds after conversion:', bounds)
-      logger.debug('Sample original -> converted coordinates:')
-      networkData.nodes.slice(0, 3).forEach((node, i) => {
-        const original = [node.x || 0, node.y || 0]
-        const converted = sampleCoords[i]
-        logger.debug(`  Node ${node.id}: [${original[0]}, ${original[1]}] -> [${converted?.lon}, ${converted?.lat}]`)
-      })
-
+      const { transformar, limites, centroide } = reproyectarLimites(limitesRed, crs.epsg)
       return {
-        bounds,
-        transform: (x: number, y: number) => {
-          try {
-            return proj4(sourceProjection, targetProjection, [x, y])
-          } catch {
-            logger.warn(`Failed to convert [${x}, ${y}], using fallback`)
-            // Fallback to center of detected bounds
-            return [coordSystem.centerApprox?.[0] || -75.5, coordSystem.centerApprox?.[1] || 10.4]
-          }
-        },
-        coordinateSystem: coordSystem
+        transformar,
+        limites,
+        centroide,
+        cordura: validarCordura(centroide, paisProyecto),
       }
-
-    } catch (error) {
-      logger.error('Coordinate conversion failed:', error)
-
-      // Fallback to approximate conversion
-      const centerLon = coordSystem.centerApprox?.[0] || -75.5
-      const centerLat = coordSystem.centerApprox?.[1] || 10.4
-
-      return {
-        bounds: {
-          minLon: centerLon - 0.05,
-          maxLon: centerLon + 0.05,
-          minLat: centerLat - 0.05,
-          maxLat: centerLat + 0.05
-        },
-        transform: (_x: number, _y: number) => [centerLon, centerLat],
-        coordinateSystem: coordSystem,
-        error: `Coordinate conversion failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-      }
+    } catch (e) {
+      logger.error('No se pudo reproyectar la red:', e)
+      return null
     }
-  }, [detectCoordinateSystem])
+  }, [crs.epsg, limitesRed, paisProyecto])
 
   // En una ref, no en las dependencias de addNetworkToMap: si entrara ahí, cada
   // cambio de selección recrearía capas y fuentes (y con ellas el encuadre). La
@@ -878,14 +639,21 @@ export function WNTRMapViewer({
       }
     })
 
-    const geoConversion = convertToGeoCoordinates(networkData)
-    logger.debug('GeoConversion result:', geoConversion)
+    // Sin sistema de coordenadas no se pinta nada: dibujar la red en un sitio
+    // inventado es peor que no dibujarla, porque el ingeniero no tiene forma de
+    // saber que la posicion es falsa (#48). El aviso de la cabecera explica que
+    // falta declarar el EPSG.
+    if (!conversion) {
+      logger.warn('Red sin sistema de coordenadas resuelto: no se dibuja', { motivo: crs.motivo })
+      return
+    }
+    const geoConversion = conversion
 
     // Create GeoJSON for nodes
     const nodesGeoJSON: GeoJSON.FeatureCollection = {
       type: 'FeatureCollection',
       features: networkData.nodes.map(node => {
-        const coords = geoConversion.transform(
+        const coords = geoConversion.transformar(
           node.x || node.coordinates?.[0] || 0,
           node.y || node.coordinates?.[1] || 0
         )
@@ -946,11 +714,11 @@ export function WNTRMapViewer({
 
         if (!fromNode || !toNode) return null
 
-        const fromCoords = geoConversion.transform(
+        const fromCoords = geoConversion.transformar(
           fromNode.x || fromNode.coordinates?.[0] || 0,
           fromNode.y || fromNode.coordinates?.[1] || 0
         )
-        const toCoords = geoConversion.transform(
+        const toCoords = geoConversion.transformar(
           toNode.x || toNode.coordinates?.[0] || 0,
           toNode.y || toNode.coordinates?.[1] || 0
         )
@@ -1149,7 +917,7 @@ export function WNTRMapViewer({
       logger.warn('Could not fit bounds:', e)
     }
 
-  }, [networkData, simulationResults, mapSettings, convertToGeoCoordinates])
+  }, [networkData, simulationResults, mapSettings, conversion, crs.motivo])
 
   // Resaltar es sólo cambiar el paint de la capa ya montada: nada de rehacer
   // fuentes ni volver a encuadrar.
@@ -1159,6 +927,19 @@ export function WNTRMapViewer({
     map.current.setPaintProperty('network-nodes', 'circle-stroke-width', highlightStrokeWidth(highlightedNodes))
     map.current.setPaintProperty('network-nodes', 'circle-stroke-color', highlightStrokeColor(highlightedNodes))
   }, [highlightedNodes, mapSettings.nodeSize, networkData])
+
+  // Al perder el sistema de coordenadas hay que retirar lo pintado: si no, la
+  // red seguiria dibujada en su posicion anterior mientras el aviso dice que no
+  // se puede situar.
+  useEffect(() => {
+    if (conversion || !map.current) return
+    for (const capa of ['node-labels', 'network-nodes', 'network-links']) {
+      if (map.current.getLayer(capa)) map.current.removeLayer(capa)
+    }
+    for (const fuente of ['network-nodes', 'network-links']) {
+      if (map.current.getSource(fuente)) map.current.removeSource(fuente)
+    }
+  }, [conversion])
 
   // Update network overlay when data or settings change
   useEffect(() => {
@@ -1225,14 +1006,19 @@ export function WNTRMapViewer({
   const handleExportGeoJSON = () => {
     if (!networkData) return
 
-    const geoConversion = convertToGeoCoordinates(networkData)
-    logger.debug('GeoConversion result:', geoConversion)
+    // El GeoJSON es WGS84 por definicion, asi que exportar sin CRS declarado
+    // produciria un fichero con coordenadas falsas.
+    if (!conversion) {
+      setError('Declara el sistema de coordenadas de la red antes de exportar a GeoJSON.')
+      return
+    }
+    const geoConversion = conversion
 
     const exportData = {
       type: 'FeatureCollection',
       features: [
         ...networkData.nodes.map(node => {
-          const coords = geoConversion.transform(
+          const coords = geoConversion.transformar(
             node.x || node.coordinates?.[0] || 0,
             node.y || node.coordinates?.[1] || 0
           )
@@ -1255,11 +1041,11 @@ export function WNTRMapViewer({
 
           if (!fromNode || !toNode) return null
 
-          const fromCoords = geoConversion.transform(
+          const fromCoords = geoConversion.transformar(
             fromNode.x || fromNode.coordinates?.[0] || 0,
             fromNode.y || fromNode.coordinates?.[1] || 0
           )
-          const toCoords = geoConversion.transform(
+          const toCoords = geoConversion.transformar(
             toNode.x || toNode.coordinates?.[0] || 0,
             toNode.y || toNode.coordinates?.[1] || 0
           )
@@ -1350,21 +1136,21 @@ export function WNTRMapViewer({
               <>
                 <button
                   onClick={() => {
-                    if (map.current && networkData) {
-                      const geoConversion = convertToGeoCoordinates(networkData)
+                    if (map.current && networkData && conversion) {
+                      const geoConversion = conversion
 
                       // Get the first few nodes to check their coordinates
                       const firstNodes = networkData.nodes.slice(0, 5)
                       logger.debug('Checking first nodes:')
                       firstNodes.forEach(node => {
-                        const coords = geoConversion.transform(node.x, node.y)
+                        const coords = geoConversion.transformar(node.x, node.y)
                         logger.debug(`${node.id}: [${coords[0]}, ${coords[1]}]`)
                       })
 
                       // Try to fit bounds again
                       const bounds = new mapboxgl.LngLatBounds()
                       networkData.nodes.forEach(node => {
-                        const coords = geoConversion.transform(node.x, node.y)
+                        const coords = geoConversion.transformar(node.x, node.y)
                         bounds.extend(coords as [number, number])
                       })
 
@@ -1407,30 +1193,17 @@ export function WNTRMapViewer({
                 </button>
 
                 <button
-                  onClick={() => {
-                    if (networkData) {
-                      const coordSystem = detectCoordinateSystem(networkData)
-                      const geoConversion = convertToGeoCoordinates(networkData)
-                      logger.debug('=== DEBUG COORDINATE INFO ===')
-                      logger.debug('Network name:', networkData.name)
-                      logger.debug('Detected system:', coordSystem)
-                      logger.debug('Conversion result:', geoConversion)
-                      logger.debug('First 3 nodes with coordinates:')
-                      networkData.nodes.slice(0, 3).forEach(node => {
-                        const converted = geoConversion.transform(node.x || 0, node.y || 0)
-                        logger.debug(`${node.id}: [${node.x}, ${node.y}] -> [${converted[0]}, ${converted[1]}]`)
-                      })
-                      alert(`Debug info logged to console. Check F12 > Console for details.\n\nDetected: ${coordSystem.region}`)
-                    }
-                  }}
+                  onClick={() => setMostrarSelectorCRS(true)}
                   className={cn(
-                    "p-2 rounded-lg",
-                    "bg-yellow-500 text-white hover:bg-yellow-600",
-                    "transition-colors"
+                    "flex items-center gap-2 px-4 py-2 rounded-lg transition-colors",
+                    crs.epsg
+                      ? "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                      : "bg-yellow-500 text-white hover:bg-yellow-600"
                   )}
-                  title="Debug Coordinates"
+                  title="Sistema de coordenadas de la red"
                 >
-                  🐛
+                  <Globe2 className="w-4 h-4" />
+                  {crs.epsg ?? 'Declarar EPSG'}
                 </button>
 
                 <button
@@ -1473,31 +1246,58 @@ export function WNTRMapViewer({
               </span>
             </div>
 
-            {/* Coordinate System Info */}
-            {networkData && (
-              <div className="text-xs text-muted-foreground space-y-1">
-                <div className="flex items-center gap-2">
-                  <MapPin className="w-3 h-3" />
+            {/* Sistema de coordenadas: estado explícito, nunca un dato inventado (#36) */}
+            <div className="text-xs space-y-1">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <MapPin className="w-3 h-3" />
+                <span>
+                  Coordenadas del fichero:{' '}
+                  {networkData.coordinate_system?.type === 'geographic'
+                    ? 'geográficas (lon/lat)'
+                    : networkData.coordinate_system?.type === 'projected'
+                      ? 'proyectadas'
+                      : 'sin determinar'}
+                  {networkData.coordinate_system?.units && ` • unidades: ${networkData.coordinate_system.units}`}
+                </span>
+              </div>
+
+              {crs.epsg ? (
+                <div className="flex items-center gap-2 ml-5 text-muted-foreground">
+                  <Globe2 className="w-3 h-3" />
                   <span>
-                    Coordinate System: {networkData.coordinate_system?.type === 'geographic' ? 'Geographic (Lat/Lon)' :
-                      networkData.coordinate_system?.type === 'projected' ? 'Projected' : 'Auto-detected'}
-                    {networkData.coordinate_system?.units && ` • Units: ${networkData.coordinate_system.units}`}
+                    {crs.origen === 'declarado' ? 'Declarado' : 'Sugerido'}: {crs.epsg} —{' '}
+                    {nombreCRS(crs.epsg)}
+                    {crs.origen === 'sugerido' && ' (sin confirmar)'}
+                  </span>
+                  <button
+                    onClick={() => setMostrarSelectorCRS(true)}
+                    className="underline hover:text-foreground"
+                  >
+                    cambiar
+                  </button>
+                </div>
+              ) : (
+                <div className="ml-5 flex items-start gap-2 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2 text-yellow-700 dark:text-yellow-400">
+                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    Esta red no se puede situar en el mapa: {crs.motivo}{' '}
+                    <button
+                      onClick={() => setMostrarSelectorCRS(true)}
+                      className="font-medium underline"
+                    >
+                      Declarar sistema de coordenadas
+                    </button>
                   </span>
                 </div>
-                {(() => {
-                  const detectedSystem = detectCoordinateSystem(networkData)
-                  return (
-                    <div className="flex items-center gap-2 ml-5">
-                      <span className="text-green-600">🎯</span>
-                      <span>
-                        Detected: {detectedSystem.region}
-                        {detectedSystem.epsgCode && ` (${detectedSystem.epsgCode})`}
-                      </span>
-                    </div>
-                  )
-                })()}
-              </div>
-            )}
+              )}
+
+              {conversion && !conversion.cordura.ok && (
+                <div className="ml-5 flex items-start gap-2 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2 text-yellow-700 dark:text-yellow-400">
+                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{conversion.cordura.aviso}</span>
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>
@@ -1812,6 +1612,15 @@ export function WNTRMapViewer({
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
+
+      <CRSSelector
+        abierto={mostrarSelectorCRS}
+        onCerrar={() => setMostrarSelectorCRS(false)}
+        limites={limitesRed}
+        epsgActual={crs.epsg}
+        networkId={networkId}
+        onDeclarado={setEpsgDeclarado}
+      />
 
       {/* Error Display */}
       {error && (

--- a/src/services/geo/crs.test.ts
+++ b/src/services/geo/crs.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import {
+  WGS84,
+  calcularLimites,
+  catalogoCRS,
+  crearTransformador,
+  crearTransformadorInverso,
+  esEPSGSoportado,
+  nombreCRS,
+  normalizarEPSG,
+  pareceGeografico,
+  reproyectarLimites,
+  resolverCRS,
+  sugerirCRS,
+  validarCordura,
+} from './crs'
+
+/**
+ * Los puntos de control no salen de proj4: se derivan de la propia definicion
+ * del EPSG, que fija donde cae el falso origen. Comprobar proj4 con proj4 no
+ * demostraria nada.
+ */
+describe('reproyeccion contra puntos de control conocidos', () => {
+  it('en el meridiano central de un huso UTM, X=500.000 devuelve exactamente su longitud', () => {
+    // El meridiano central del huso n es -183 + 6n: el 18 es -75 y el 30 es -3.
+    const utm18 = crearTransformador('EPSG:32618')
+    const [lon18, lat18] = utm18(500000, 0)
+    expect(lon18).toBeCloseTo(-75, 9)
+    expect(lat18).toBeCloseTo(0, 9)
+
+    const utm30 = crearTransformador('EPSG:25830')
+    const [lon30] = utm30(500000, 4_500_000)
+    expect(lon30).toBeCloseTo(-3, 9)
+  })
+
+  it('el falso origen de MAGNA-SIRGAS Bogotá cae en su punto de origen oficial', () => {
+    // EPSG:3116 define el origen en 4°35'46.3215"N, 74°04'39.0285"W con
+    // desplazamiento (1.000.000, 1.000.000).
+    const [lon, lat] = crearTransformador('EPSG:3116')(1_000_000, 1_000_000)
+    expect(lon).toBeCloseTo(-74.07750791666666, 7)
+    expect(lat).toBeCloseTo(4.596200416666666, 7)
+  })
+
+  it('el falso este de México ITRF2008 / LCC cae en su meridiano de origen', () => {
+    const [lon] = crearTransformador('EPSG:6372')(2_500_000, 2_000_000)
+    expect(lon).toBeCloseTo(-102, 9)
+  })
+})
+
+describe('ida y vuelta sin pérdida', () => {
+  const puntos: Array<[string, number, number]> = [
+    ['EPSG:32618', 842913.44, 1151987.21],
+    ['EPSG:32718', 300100.5, 8_200_000.75],
+    ['EPSG:25830', 728123.9, 4_373_456.1],
+    ['EPSG:3116', 1_012_345.6, 998_765.4],
+  ]
+
+  it.each(puntos)('%s recupera la coordenada original con error submilimétrico', (epsg, x, y) => {
+    const ida = crearTransformador(epsg)
+    const vuelta = crearTransformadorInverso(epsg)
+    const [x2, y2] = vuelta(...ida(x, y))
+    // El criterio de aceptacion pide < 2 m; el error real del viaje es de micras.
+    expect(Math.abs(x2 - x)).toBeLessThan(0.001)
+    expect(Math.abs(y2 - y)).toBeLessThan(0.001)
+  })
+})
+
+describe('el EPSG se declara, no se adivina', () => {
+  it('unas coordenadas proyectadas no permiten sugerir ningún sistema', () => {
+    // Las mismas de la red de Cartagena que motivo los casos codificados a mano.
+    const sugerencia = sugerirCRS({ minX: 842000, maxX: 843500, minY: 1151000, maxY: 1152500 })
+    expect(sugerencia.epsg).toBeNull()
+    expect(sugerencia.origen).toBe('desconocido')
+    expect(sugerencia.motivo).toMatch(/huso/i)
+  })
+
+  it('unas coordenadas en rango lon/lat sí se reconocen como geográficas', () => {
+    const sugerencia = sugerirCRS({ minX: -75.52, maxX: -75.48, minY: 10.38, maxY: 10.42 })
+    expect(sugerencia.epsg).toBe(WGS84)
+    expect(sugerencia.origen).toBe('sugerido')
+  })
+
+  it('una red sin coordenadas se declara desconocida en vez de dibujarse', () => {
+    expect(sugerirCRS(null).epsg).toBeNull()
+    expect(calcularLimites([])).toBeNull()
+  })
+
+  it('lo declarado manda sobre lo que sugieren las coordenadas', () => {
+    const limites = { minX: -75.52, maxX: -75.48, minY: 10.38, maxY: 10.42 }
+    expect(resolverCRS('EPSG:3116', limites).epsg).toBe('EPSG:3116')
+    expect(resolverCRS('EPSG:3116', limites).origen).toBe('declarado')
+    expect(resolverCRS(null, limites).origen).toBe('sugerido')
+  })
+
+  it('un EPSG declarado que no se reconoce no se pinta a la brava', () => {
+    const r = resolverCRS('EPSG:999999', { minX: 1, maxX: 2, minY: 1, maxY: 2 })
+    expect(r.epsg).toBeNull()
+    expect(r.origen).toBe('desconocido')
+  })
+
+  it('una extensión enorme en rango lon/lat no se confunde con coordenadas geográficas', () => {
+    // Coordenadas locales de un modelo sintetico (metros desde un origen propio).
+    expect(pareceGeografico({ minX: 0, maxX: 150, minY: 0, maxY: 90 })).toBe(false)
+  })
+})
+
+describe('validación de cordura tras reproyectar', () => {
+  const cartagenaUTM = { minX: 842000, maxX: 843500, minY: 1151000, maxY: 1152500 }
+
+  it('acepta la red cuando el huso declarado la sitúa en el país del proyecto', () => {
+    const { centroide } = reproyectarLimites(cartagenaUTM, 'EPSG:32618')
+    expect(validarCordura(centroide, 'CO').ok).toBe(true)
+  })
+
+  it('caza el huso equivocado: el mismo X en el huso 14 se va fuera de Colombia', () => {
+    const { centroide } = reproyectarLimites(cartagenaUTM, 'EPSG:32614')
+    const cordura = validarCordura(centroide, 'CO')
+    expect(cordura.ok).toBe(false)
+    expect(cordura.aviso).toMatch(/CO/)
+  })
+
+  it('caza el hemisferio equivocado', () => {
+    const { centroide } = reproyectarLimites(cartagenaUTM, 'EPSG:32718')
+    expect(validarCordura(centroide, 'CO').ok).toBe(false)
+  })
+
+  it('sin país declarado en el proyecto no inventa un aviso', () => {
+    const { centroide } = reproyectarLimites(cartagenaUTM, 'EPSG:32614')
+    expect(validarCordura(centroide, null).ok).toBe(true)
+    expect(validarCordura(centroide, '').ok).toBe(true)
+  })
+})
+
+describe('catálogo y normalización', () => {
+  it('cubre los 120 husos UTM además de los sistemas con nombre propio', () => {
+    const catalogo = catalogoCRS()
+    const epsgs = catalogo.map(c => c.epsg)
+    expect(epsgs).toContain('EPSG:32601')
+    expect(epsgs).toContain('EPSG:32660')
+    expect(epsgs).toContain('EPSG:32701')
+    expect(epsgs).toContain('EPSG:32760')
+    expect(epsgs).toContain('EPSG:25830')
+    expect(new Set(epsgs).size).toBe(epsgs.length)
+  })
+
+  it('todo lo que ofrece el catálogo se puede usar de verdad', () => {
+    for (const { epsg } of catalogoCRS()) {
+      expect(esEPSGSoportado(epsg), epsg).toBe(true)
+    }
+  })
+
+  it('acepta el código con o sin prefijo y rechaza lo que no es un EPSG', () => {
+    expect(normalizarEPSG('32618')).toBe('EPSG:32618')
+    expect(normalizarEPSG(' epsg:32618 ')).toBe('EPSG:32618')
+    expect(normalizarEPSG('UTM 18N')).toBeNull()
+    expect(normalizarEPSG('')).toBeNull()
+  })
+
+  it('nombra los husos sin necesidad de tenerlos en una tabla', () => {
+    expect(nombreCRS('EPSG:32618')).toBe('WGS 84 / UTM 18N')
+    expect(nombreCRS('EPSG:32718')).toBe('WGS 84 / UTM 18S')
+    expect(nombreCRS('EPSG:3116')).toMatch(/MAGNA-SIRGAS/)
+  })
+
+  it('un EPSG no soportado falla al crear el transformador en vez de devolver algo falso', () => {
+    expect(() => crearTransformador('EPSG:999999')).toThrow(/no soportado/i)
+  })
+})
+
+describe('límites de la red', () => {
+  it('lee las coordenadas tanto de x/y como de coordinates', () => {
+    const limites = calcularLimites([
+      { x: 10, y: 20 },
+      { coordinates: [30, 5] },
+      { x: undefined, y: undefined },
+    ])
+    expect(limites).toEqual({ minX: 10, maxX: 30, minY: 5, maxY: 20 })
+  })
+})

--- a/src/services/geo/crs.ts
+++ b/src/services/geo/crs.ts
@@ -1,0 +1,397 @@
+/**
+ * Reproyeccion geodesica real de coordenadas (#36, #48).
+ *
+ * Un unico motor —proj4— para toda la aplicacion. Antes cada visor tenia su
+ * propia pila de heuristicas con husos codificados a mano (Cartagena, TK-Lomas,
+ * rangos de X por pais) y un `else` final que asumia UTM 18N: una red de un pais
+ * no contemplado se pintaba en el Caribe colombiano sin decir nada.
+ *
+ * La regla de este modulo es que el EPSG es un dato declarado, no adivinado.
+ * `sugerirCRS` solo afirma lo que se puede demostrar mirando las coordenadas
+ * (que son geograficas), y devuelve `null` en cuanto haria falta suponer.
+ */
+
+import proj4 from 'proj4'
+
+export const WGS84 = 'EPSG:4326'
+
+export interface LimitesProyectados {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+export interface LimitesGeograficos {
+  minLon: number
+  maxLon: number
+  minLat: number
+  maxLat: number
+}
+
+export interface EntradaCatalogo {
+  epsg: string
+  nombre: string
+  /** Codigo ISO del pais para el que este CRS es habitual. Vacio si es global. */
+  pais?: string
+}
+
+/**
+ * Origen del EPSG con el que se esta pintando. La interfaz lo enseña tal cual:
+ * un CRS `sugerido` no debe leerse como si el ingeniero lo hubiera confirmado.
+ */
+export type OrigenCRS = 'declarado' | 'sugerido' | 'desconocido'
+
+export interface CRSResuelto {
+  epsg: string | null
+  origen: OrigenCRS
+  /** Por que se llego a este EPSG, o por que no se pudo. Texto para la interfaz. */
+  motivo: string
+}
+
+/**
+ * Definiciones proj4 de los sistemas que no son UTM/WGS84 (esos se generan).
+ * proj4 trae de serie EPSG:4326 y EPSG:3857; el resto hay que declararlo.
+ */
+const DEFINICIONES: Record<string, string> = {
+  'EPSG:4326': '+proj=longlat +datum=WGS84 +no_defs',
+  'EPSG:3857': '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +no_defs',
+  // MAGNA-SIRGAS (Colombia), origenes nacionales
+  'EPSG:3115': '+proj=tmerc +lat_0=4.596200416666666 +lon_0=-77.07750791666666 +k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  'EPSG:3116': '+proj=tmerc +lat_0=4.596200416666666 +lon_0=-74.07750791666666 +k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  'EPSG:3117': '+proj=tmerc +lat_0=4.596200416666666 +lon_0=-71.07750791666666 +k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  'EPSG:3118': '+proj=tmerc +lat_0=4.596200416666666 +lon_0=-68.07750791666666 +k=1 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  // ETRS89 / UTM (España peninsular y Baleares)
+  'EPSG:25829': '+proj=utm +zone=29 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  'EPSG:25830': '+proj=utm +zone=30 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  'EPSG:25831': '+proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  // ED50 / UTM: cartografia española anterior a ETRS89, todavia habitual en catastro
+  'EPSG:23029': '+proj=utm +zone=29 +ellps=intl +towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs',
+  'EPSG:23030': '+proj=utm +zone=30 +ellps=intl +towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs',
+  'EPSG:23031': '+proj=utm +zone=31 +ellps=intl +towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs',
+  // Mexico ITRF2008 / LCC, sistema unico nacional
+  'EPSG:6372': '+proj=lcc +lat_0=12 +lon_0=-102 +lat_1=17.5 +lat_2=29.5 +x_0=2500000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+}
+
+const NOMBRES: Record<string, { nombre: string; pais?: string }> = {
+  'EPSG:4326': { nombre: 'WGS 84 — longitud/latitud' },
+  'EPSG:3857': { nombre: 'WGS 84 / Pseudo-Mercator (web)' },
+  'EPSG:3115': { nombre: 'MAGNA-SIRGAS / Colombia Oeste', pais: 'CO' },
+  'EPSG:3116': { nombre: 'MAGNA-SIRGAS / Colombia Bogotá', pais: 'CO' },
+  'EPSG:3117': { nombre: 'MAGNA-SIRGAS / Colombia Este Central', pais: 'CO' },
+  'EPSG:3118': { nombre: 'MAGNA-SIRGAS / Colombia Este', pais: 'CO' },
+  'EPSG:25829': { nombre: 'ETRS89 / UTM 29N', pais: 'ES' },
+  'EPSG:25830': { nombre: 'ETRS89 / UTM 30N', pais: 'ES' },
+  'EPSG:25831': { nombre: 'ETRS89 / UTM 31N', pais: 'ES' },
+  'EPSG:23029': { nombre: 'ED50 / UTM 29N', pais: 'ES' },
+  'EPSG:23030': { nombre: 'ED50 / UTM 30N', pais: 'ES' },
+  'EPSG:23031': { nombre: 'ED50 / UTM 31N', pais: 'ES' },
+  'EPSG:6372': { nombre: 'México ITRF2008 / LCC', pais: 'MX' },
+}
+
+/** `EPSG:32618` → `{ zona: 18, sur: false }`; `null` si no es un UTM/WGS84. */
+function leerZonaUTM(epsg: string): { zona: number; sur: boolean } | null {
+  const m = /^EPSG:32([67])(\d{2})$/.exec(epsg)
+  if (!m) return null
+  const zona = Number(m[2])
+  if (zona < 1 || zona > 60) return null
+  return { zona, sur: m[1] === '7' }
+}
+
+export function normalizarEPSG(valor: string): string | null {
+  const limpio = valor.trim().toUpperCase().replace(/\s+/g, '')
+  const m = /^(?:EPSG:)?(\d{4,6})$/.exec(limpio)
+  return m ? `EPSG:${m[1]}` : null
+}
+
+/**
+ * Registra la definicion en proj4 la primera vez que se pide. Los 120 husos UTM
+ * se generan en lugar de escribirse: la formula es la misma para todos y una
+ * tabla a mano solo aporta ocasiones de equivocarse.
+ */
+export function definirProyeccion(epsg: string): boolean {
+  if (proj4.defs(epsg)) return true
+
+  const fija = DEFINICIONES[epsg]
+  if (fija) {
+    proj4.defs(epsg, fija)
+    return true
+  }
+
+  const utm = leerZonaUTM(epsg)
+  if (utm) {
+    proj4.defs(epsg, `+proj=utm +zone=${utm.zona}${utm.sur ? ' +south' : ''} +datum=WGS84 +units=m +no_defs`)
+    return true
+  }
+
+  return false
+}
+
+export function esEPSGSoportado(epsg: string): boolean {
+  return definirProyeccion(epsg)
+}
+
+export function nombreCRS(epsg: string): string {
+  const conocido = NOMBRES[epsg]
+  if (conocido) return conocido.nombre
+  const utm = leerZonaUTM(epsg)
+  if (utm) return `WGS 84 / UTM ${utm.zona}${utm.sur ? 'S' : 'N'}`
+  return epsg
+}
+
+/**
+ * Catalogo para el selector: los sistemas con nombre propio primero y los 120
+ * husos UTM despues. El selector tambien acepta cualquier otro codigo escrito a
+ * mano, asi que esta lista es una comodidad, no un limite.
+ */
+export function catalogoCRS(): EntradaCatalogo[] {
+  const nombrados = Object.keys(NOMBRES).map(epsg => ({
+    epsg,
+    nombre: NOMBRES[epsg].nombre,
+    pais: NOMBRES[epsg].pais,
+  }))
+
+  const utm: EntradaCatalogo[] = []
+  for (const sur of [false, true]) {
+    for (let zona = 1; zona <= 60; zona++) {
+      const epsg = `EPSG:${sur ? 327 : 326}${String(zona).padStart(2, '0')}`
+      utm.push({ epsg, nombre: `WGS 84 / UTM ${zona}${sur ? 'S' : 'N'}` })
+    }
+  }
+
+  return [...nombrados, ...utm]
+}
+
+export type Transformador = (x: number, y: number) => [number, number]
+
+/**
+ * Transformador del CRS dado a WGS84. Lanza si el EPSG no se puede resolver:
+ * quien pinta debe enterarse, no recibir coordenadas silenciosamente falsas.
+ */
+export function crearTransformador(epsg: string): Transformador {
+  if (!definirProyeccion(epsg)) {
+    throw new Error(`Sistema de coordenadas no soportado: ${epsg}`)
+  }
+  if (epsg === WGS84) return (x, y) => [x, y]
+
+  return (x, y) => {
+    const [lon, lat] = proj4(epsg, WGS84, [x, y])
+    return [lon, lat]
+  }
+}
+
+/** Transformador inverso, de WGS84 al CRS original. Lo usa la exportacion. */
+export function crearTransformadorInverso(epsg: string): Transformador {
+  if (!definirProyeccion(epsg)) {
+    throw new Error(`Sistema de coordenadas no soportado: ${epsg}`)
+  }
+  if (epsg === WGS84) return (lon, lat) => [lon, lat]
+
+  return (lon, lat) => {
+    const [x, y] = proj4(WGS84, epsg, [lon, lat])
+    return [x, y]
+  }
+}
+
+/**
+ * Unica afirmacion que las coordenadas sostienen por si solas: si todas caen en
+ * el rango lon/lat y la red abarca menos de un grado, son geograficas. Una red
+ * de abastecimiento nunca mide cientos de kilometros, asi que el segundo
+ * criterio descarta un proyectado que por casualidad cayera en rango.
+ */
+export function pareceGeografico(limites: LimitesProyectados): boolean {
+  const { minX, maxX, minY, maxY } = limites
+  return (
+    minX >= -180 && maxX <= 180 &&
+    minY >= -90 && maxY <= 90 &&
+    Math.abs(maxX - minX) < 1 && Math.abs(maxY - minY) < 1
+  )
+}
+
+/**
+ * Sugerencia honesta: geografico se reconoce, proyectado no.
+ *
+ * La X de una coordenada UTM es la distancia al meridiano central de su huso, y
+ * vale lo mismo en los 60 husos: 842.913 m es un punto valido en Cartagena, en
+ * Valencia y en Sídney. Deducir el huso de la X es imposible, y esa imposibilidad
+ * es la causa de fondo de #48. Aqui se devuelve `null` en vez de suponer.
+ */
+export function sugerirCRS(limites: LimitesProyectados | null): CRSResuelto {
+  if (!limites) {
+    return { epsg: null, origen: 'desconocido', motivo: 'La red no trae coordenadas.' }
+  }
+  if (pareceGeografico(limites)) {
+    return {
+      epsg: WGS84,
+      origen: 'sugerido',
+      motivo: 'Las coordenadas están en rango de longitud/latitud.',
+    }
+  }
+  return {
+    epsg: null,
+    origen: 'desconocido',
+    motivo:
+      'Las coordenadas están proyectadas. El valor de X no identifica el huso —el mismo número es válido en los 60—, así que el sistema debe declararlo el ingeniero.',
+  }
+}
+
+/**
+ * CRS con el que hay que pintar: lo declarado manda sobre lo sugerido, siempre.
+ */
+export function resolverCRS(
+  epsgDeclarado: string | null | undefined,
+  limites: LimitesProyectados | null
+): CRSResuelto {
+  if (epsgDeclarado) {
+    const normalizado = normalizarEPSG(epsgDeclarado)
+    if (normalizado && esEPSGSoportado(normalizado)) {
+      return {
+        epsg: normalizado,
+        origen: 'declarado',
+        motivo: `Declarado en el proyecto: ${nombreCRS(normalizado)}.`,
+      }
+    }
+    return {
+      epsg: null,
+      origen: 'desconocido',
+      motivo: `El sistema declarado (${epsgDeclarado}) no se reconoce.`,
+    }
+  }
+  return sugerirCRS(limites)
+}
+
+/**
+ * Envolventes aproximadas de los paises con los que trabaja Boorie, para avisar
+ * cuando la red reproyectada cae lejos del pais declarado en el proyecto. Es una
+ * comprobacion de cordura, no una validacion cartografica: una envolvente incluye
+ * mar y paises vecinos, asi que solo caza el error grueso (huso equivocado, que
+ * desplaza la red cientos de kilometros o la manda al hemisferio contrario).
+ */
+const ENVOLVENTES_PAIS: Record<string, LimitesGeograficos> = {
+  MX: { minLon: -118.5, maxLon: -86.5, minLat: 14.5, maxLat: 32.8 },
+  CO: { minLon: -79.1, maxLon: -66.8, minLat: -4.3, maxLat: 13.5 },
+  ES: { minLon: -18.2, maxLon: 4.4, minLat: 27.6, maxLat: 43.9 },
+  PE: { minLon: -81.4, maxLon: -68.6, minLat: -18.4, maxLat: -0.03 },
+  CL: { minLon: -75.7, maxLon: -66.4, minLat: -56.0, maxLat: -17.5 },
+  AR: { minLon: -73.6, maxLon: -53.6, minLat: -55.1, maxLat: -21.8 },
+  EC: { minLon: -92.0, maxLon: -75.2, minLat: -5.0, maxLat: 1.7 },
+  BO: { minLon: -69.7, maxLon: -57.5, minLat: -22.9, maxLat: -9.7 },
+  BR: { minLon: -74.0, maxLon: -34.8, minLat: -33.8, maxLat: 5.3 },
+  CR: { minLon: -86.0, maxLon: -82.5, minLat: 8.0, maxLat: 11.3 },
+  GT: { minLon: -92.3, maxLon: -88.2, minLat: 13.7, maxLat: 17.9 },
+  PT: { minLon: -31.4, maxLon: -6.2, minLat: 32.4, maxLat: 42.2 },
+  US: { minLon: -125.0, maxLon: -66.9, minLat: 24.4, maxLat: 49.4 },
+}
+
+export interface Cordura {
+  ok: boolean
+  /** Texto para la interfaz cuando algo no cuadra; vacio cuando `ok`. */
+  aviso: string
+}
+
+/**
+ * Validacion posterior a reproyectar: el centroide debe caer en rango terrestre
+ * y, si el proyecto declara pais, dentro de su envolvente.
+ */
+export function validarCordura(
+  centroide: [number, number],
+  pais?: string | null
+): Cordura {
+  const [lon, lat] = centroide
+
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+    return { ok: false, aviso: 'La reproyección no produjo coordenadas válidas.' }
+  }
+  if (lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+    return { ok: false, aviso: 'La red reproyectada cae fuera del planeta: el sistema declarado no puede ser el correcto.' }
+  }
+
+  const codigo = pais?.trim().toUpperCase()
+  if (!codigo) return { ok: true, aviso: '' }
+
+  const envolvente = ENVOLVENTES_PAIS[codigo]
+  if (!envolvente) return { ok: true, aviso: '' }
+
+  const dentro =
+    lon >= envolvente.minLon && lon <= envolvente.maxLon &&
+    lat >= envolvente.minLat && lat <= envolvente.maxLat
+
+  if (dentro) return { ok: true, aviso: '' }
+
+  return {
+    ok: false,
+    aviso: `La red cae en ${lat.toFixed(4)}, ${lon.toFixed(4)}, fuera de ${codigo}, que es el país del proyecto. Revisa el sistema de coordenadas declarado.`,
+  }
+}
+
+export interface RedReproyectada {
+  transformar: Transformador
+  limites: LimitesGeograficos
+  centroide: [number, number]
+}
+
+/**
+ * Reproyecta las esquinas y el centro de la red para obtener el encuadre. No
+ * recorre todos los nudos a proposito: el mapa transforma cada uno al pintarlo y
+ * duplicar el trabajo en redes de decenas de miles de nudos se nota.
+ */
+export function reproyectarLimites(
+  limites: LimitesProyectados,
+  epsg: string
+): RedReproyectada {
+  const transformar = crearTransformador(epsg)
+
+  const esquinas: Array<[number, number]> = [
+    transformar(limites.minX, limites.minY),
+    transformar(limites.maxX, limites.minY),
+    transformar(limites.minX, limites.maxY),
+    transformar(limites.maxX, limites.maxY),
+  ]
+
+  const lons = esquinas.map(c => c[0])
+  const lats = esquinas.map(c => c[1])
+
+  if (lons.some(v => !Number.isFinite(v)) || lats.some(v => !Number.isFinite(v))) {
+    throw new Error(`La reproyección desde ${epsg} produjo coordenadas no finitas`)
+  }
+
+  return {
+    transformar,
+    limites: {
+      minLon: Math.min(...lons),
+      maxLon: Math.max(...lons),
+      minLat: Math.min(...lats),
+      maxLat: Math.max(...lats),
+    },
+    centroide: transformar(
+      (limites.minX + limites.maxX) / 2,
+      (limites.minY + limites.maxY) / 2
+    ),
+  }
+}
+
+/** Limites de una lista de nudos con coordenadas en el CRS original. */
+export function calcularLimites(
+  puntos: Array<{ x?: number; y?: number; coordinates?: number[] }>
+): LimitesProyectados | null {
+  const xs: number[] = []
+  const ys: number[] = []
+
+  for (const p of puntos) {
+    const x = p.x ?? p.coordinates?.[0]
+    const y = p.y ?? p.coordinates?.[1]
+    if (typeof x === 'number' && typeof y === 'number' && Number.isFinite(x) && Number.isFinite(y)) {
+      xs.push(x)
+      ys.push(y)
+    }
+  }
+
+  if (xs.length === 0) return null
+
+  return {
+    minX: Math.min(...xs),
+    maxX: Math.max(...xs),
+    minY: Math.min(...ys),
+    maxY: Math.max(...ys),
+  }
+}


### PR DESCRIPTION
## Qué cambia

Boorie enseñaba un EPSG para cada red y la dibujaba sobre la ortofoto, dando la impresión de que la georreferenciación era correcta. El EPSG no salía de ningún dato: se adivinaba, con **dos escaleras de heurísticas independientes** —una en `wntrService.py` y otra en `WNTRMapViewer`— que podían dar respuestas distintas para la misma red. La del visor nunca decía «no lo sé»: su último `return` situaba en el Caribe colombiano cualquier red que no encajara en ningún rango.

**Adivinar no puede funcionar, y no es una cuestión de afinar la heurística.** La X de una coordenada UTM es la distancia al meridiano central *de su huso*, y el mismo número es válido en los 60: `842.913 m` es un punto legítimo en Cartagena, en Valencia y en Sídney. Los rangos por país acertaban con las redes de prueba porque ya se sabía de qué país eran.

Ahora el EPSG es un dato declarado por el ingeniero. Sin él, **la red no se dibuja** y la cabecera explica por qué, con la acción para resolverlo.

| Pieza | Fichero |
|---|---|
| Motor de reproyección y catálogo (módulo puro) | `src/services/geo/crs.ts` |
| Selector explícito de EPSG | `src/components/hydraulic/CRSSelector.tsx` |
| Visor de mapa: resolución, aviso y repintado | `src/components/hydraulic/WNTRMapViewer.tsx` |
| Persistencia (`declararCRS`) | `backend/services/hydraulic/networkRepository.ts` |
| Canal IPC | `network-repo:declare-crs` |
| Lector del `.inp` sin heurísticas de huso | `backend/services/hydraulic/wntrService.py` |

## Decisión: proj4js, no pyproj

El issue proponía añadir `pyproj` al entorno WNTR. Se descarta por dos motivos, y manda el funcional: el criterio de aceptación pide que cambiar el EPSG recoloque la red **sin recargar el `.inp`**, y con `pyproj` cada cambio sería un viaje a Python más un reparseo del fichero. El segundo es el riesgo ya anotado en el propio issue — una dependencia Python nueva hay que validarla en macOS, Windows y Linux, con las incidencias conocidas de NumPy/SciPy en macOS. `proj4` ya era dependencia del proyecto y ya se usaba en el visor.

Python conserva el papel de **lector**: describe lo que ve en el fichero, no transforma.

La ida y vuelta sin pérdida sale gratis: el `.inp` guardado no se modifica nunca, la reproyección existe sólo para pintar.

## Verificación

**28 tests nuevos** (223 en total, verdes; typecheck y lint limpios). Los puntos de control **no salen de proj4**, se derivan de la definición de cada EPSG —comprobar proj4 con proj4 no demostraría nada:

- En el meridiano central de un huso UTM, `X = 500.000` devuelve exactamente su longitud (`-183 + 6n`).
- El falso origen de MAGNA-SIRGAS Bogotá cae en su origen oficial (4°35′46,3215″N / 74°04′39,0285″W).
- Ida y vuelta en cuatro sistemas: error submilimétrico (el criterio pedía < 2 m).
- La coordenada de Cartagena declarada en el huso 14 o en el hemisferio sur dispara el aviso de cordura; en el 18N, no.

**Comprobado en la aplicación real** con la base de datos local: red proyectada sin declarar → mapa vacío y aviso accionable; declarar `EPSG:32615` → se pinta reproyectada; cambiar a `EPSG:32718` → se recoloca sin recargar el `.inp`; el EPSG queda persistido en las dos copias (columna `coordinateSystem` y `networkData.coordinate_system`); red geográfica → se reconoce sola, etiquetada «sugerido (sin confirmar)».

## Fuera de alcance

- **Contraste sobre ortofoto con puntos de control reales**: es la red de prueba que el issue pide a Javier. Único punto del criterio 1 que queda por cerrar con datos externos.
- **`WNTRIntermediateViewer` y `WNTRSimulationViewer`** conservan su heurística y su posicionamiento por escalado. No los importa nadie —código muerto— y retirarlos es #37.

Diseño y decisiones completas en `docs/REPROYECCION_CRS.md`.

Closes #36
Closes #48