### PR TITLE
fix(tiempo, precondiciones): el reloj sale de la simulación y las pantallas dicen qué falta (#45, #46)

### DIFF
--- a/backend/services/hydraulic/agentTools.test.ts
+++ b/backend/services/hydraulic/agentTools.test.ts
@@ -154,8 +154,15 @@ it('una herramienta desconocida se responde con error, no lanza', () => {
  * Contraste con las redes guardadas: `Net3 2.inp` tiene 92 nudos y 117 tramos,
  * que es el caso que justifica las herramientas (no cabe en el resumen).
  */
-describe.skipIf(!fs.existsSync(DB))('contraste con las redes guardadas', () => {
-  const leerRedes = (): Array<{ nombre: string; datos: RedCompleta }> => {
+/**
+ * Recorre todos los elementos de todas las redes guardadas, asi que su coste
+ * crece con lo que el usuario tenga en su base: una red de 3.358 nudos lo
+ * multiplica por treinta. El limite por defecto de vitest se queda corto y el
+ * test empieza a fallar a ratos, que es peor que no tenerlo. Se le da margen y se
+ * lee la base una sola vez en lugar de una por prueba.
+ */
+describe.skipIf(!fs.existsSync(DB))('contraste con las redes guardadas', { timeout: 60_000 }, () => {
+  const leerDeLaBase = (): Array<{ nombre: string; datos: RedCompleta }> => {
     const salida = execFileSync('python3', ['-c', `
 import sqlite3, json, sys
 c = sqlite3.connect(${JSON.stringify(DB)})
@@ -164,6 +171,9 @@ json.dump(filas, sys.stdout)
 `], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
     return JSON.parse(salida)
   }
+
+  let cache: Array<{ nombre: string; datos: RedCompleta }> | null = null
+  const leerRedes = () => (cache ??= leerDeLaBase())
 
   it('todo id de la red se puede consultar y se encuentra', () => {
     for (const { nombre, datos } of leerRedes()) {

--- a/docs/TIEMPO_Y_ESTADOS_VACIOS.md
+++ b/docs/TIEMPO_Y_ESTADOS_VACIOS.md
@@ -123,15 +123,30 @@ explique.
 
 ## Lo que se rescató de los visores retirados
 
-Al revisar si los componentes que retiró #37 merecían volver, la respuesta fue que
-no —`WNTRSimulationViewer` era un segundo visor Mapbox con sus propias
-definiciones `proj4` codificadas a mano, y `WNTRNetworkVisualization` dibujaba a
-mano sobre un `canvas` 2D sin desplazamiento ni zoom—, pero sí tenían **una
-capacidad que faltaba**: colorear por más magnitudes que presión y caudal.
+### La lección, primero
 
-Vuelve como `src/services/network/simbologia.ts`, con cinco opciones —tipo de
-elemento, presión, demanda, caudal y velocidad— compartidas por el mapa, el
-esquema y la leyenda del panel.
+La auditoría de #37 clasificó los nueve visores por si alguien los importaba, y
+esa pregunta estaba bien: ninguno se renderizaba. Pero **clasificar un componente
+no es inventariar lo que sabe hacer**, y se borraron 4.700 líneas sin repasar
+capacidad por capacidad qué se iba con ellas. Que fueran inalcanzables para el
+usuario no significa que no tuvieran nada dentro.
+
+Se vio porque el issue #45 nombraba cinco componentes y dos ya no existían, y al
+ir a mirar qué hacían aparecieron dos capacidades que el visor canónico no tenía.
+La regla que queda: antes de retirar código muerto, listar sus capacidades y
+decidir una por una, no en bloque.
+
+### El resultado
+
+Al revisar si los componentes merecían volver, la respuesta fue que no —`WNTRSimulationViewer` era un segundo visor Mapbox con sus propias
+definiciones `proj4` codificadas a mano, y `WNTRNetworkVisualization` dibujaba a
+mano sobre un `canvas` 2D sin desplazamiento ni zoom—, pero sí tenían **capacidades que
+faltaban**.
+
+Vuelven dos: la **simbología** (`src/services/network/simbologia.ts`), con cinco
+opciones —tipo de elemento, presión, demanda, caudal y velocidad— compartidas por
+el mapa, el esquema y la leyenda del panel; y el **filtrado por tipo de elemento**
+(`src/services/network/capas.ts`).
 
 **Lo que no vuelve es cómo calculaban la escala.** Usaban máximos fijos escritos a
 mano: caudal 0–200 L/s, velocidad 0–2 m/s, demanda 0–50 L/s. Es el mismo defecto
@@ -141,6 +156,18 @@ del paso mostrado, y la leyenda declara el rango real —comprobado con `Net3 2`
 «Escala de esta red en este paso: 0.00 a 2.84 m/s», que con el máximo fijo de 2
 habría quedado plana por arriba—.
 
+**Filtrar por tipo de elemento vuelve también.** `src/services/network/capas.ts`
+enciende y apaga nudos de consumo, depósitos, embalses, tuberías, bombas y
+válvulas, con el contador de cada tipo al lado; un tipo que la red no tiene sale
+deshabilitado en vez de escondido, para que se vea que existe y que esta red no
+lo usa. Con miles de nudos es lo que permite mirar sólo las bombas, o el trazado
+sin la nube de acometidas.
+
+En el mapa, nudos y tramos se filtran de forma independiente. En el esquema no
+puede ser: un tramo necesita sus dos extremos para dibujarse, así que ocultar un
+tipo de nudo se lleva los tramos que lo tocan. El panel lo dice cuando estás en
+esa vista, en lugar de dejar que parezca un fallo.
+
 **La presión es la excepción, a propósito.** Sus cortes siguen siendo absolutos
 —20 y 80 m— porque tienen un criterio de servicio que no depende de la red:
 escalarla al máximo de cada modelo escondería justamente los nudos por debajo del
@@ -148,12 +175,7 @@ mínimo. La leyenda distingue los dos casos.
 
 ## Fuera de alcance
 
-****Filtrar capas por tipo de elemento** (bombas, válvulas, depósitos…), que
-`WNTRNetworkVisualization` ofrecía y aquí no vuelve. Con una red de 3.358 nudos es
-la capacidad más útil de las que tenía, pero es funcionalidad nueva, no un
-rescate, y no cabe dentro de un cambio de dos bugs.
-
-**El acumulado de retraso en el repintado.**** El issue #45 lo dejaba como
+****El acumulado de retraso en el repintado.**** El issue #45 lo dejaba como
 «revisión adicional pendiente». La reproducción por reloj real lo elimina como
 causa —el paso ya no depende de cuántos ticks se hayan podido servir—, pero no se
 ha medido el coste de repintar una red grande paso a paso. Si aparece, es un

--- a/docs/TIEMPO_Y_ESTADOS_VACIOS.md
+++ b/docs/TIEMPO_Y_ESTADOS_VACIOS.md
@@ -1,0 +1,129 @@
+# Eje temporal real y estados vacíos que se explican
+
+Diseño y decisiones de los bugs [#45](https://github.com/Boorie-AI/boorie_cliente/issues/45)
+y [#46](https://github.com/Boorie-AI/boorie_cliente/issues/46). Continúa
+[`VISOR_CANONICO.md`](VISOR_CANONICO.md) (#37) y
+[`PRECONDICIONES_NAVEGACION.md`](PRECONDICIONES_NAVEGACION.md) (#33).
+
+## #45 — El reloj no era el de la simulación
+
+El eje temporal salía de dos constantes escritas a mano:
+
+```js
+const baseTime = new Date('2025-10-09T00:00:00')   // una fecha inventada
+const hoursToAdd = visualizationSettings.timeStep   // una hora fija por paso
+```
+
+Para un modelo que reporta cada 15 minutos, el reloj de la interfaz avanzaba
+**cuatro veces más rápido que la simulación**, y la fecha no correspondía a nada
+—se mostraba además con zona horaria australiana—. Las marcas del eje eran
+`00:00` a `22:00` fijas, al margen de la duración y del paso del modelo.
+
+Y el dato bueno estaba delante todo el tiempo: `timestamps` es el índice de los
+resultados de WNTR, **en segundos** desde el arranque, y el `.inp` declara su
+propia hora de inicio en `start_clocktime`. Criterio del Ing. Luis Mora recogido
+en el issue: «eso se define en EPANET; Boorie sólo debe leer ese paso temporal».
+
+| Pieza | Fichero |
+|---|---|
+| Eje temporal (módulo puro) | `src/services/network/lineaTiempo.ts` |
+| Hook único, con la reproducción | `src/hooks/useSimulationTimeline.ts` |
+| Barra de transporte | `src/components/hydraulic/WNTRAdvancedMapViewer.tsx` |
+| Gráficas y estado de bombas | `src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx` |
+
+### Decisiones
+
+**Sin hora declarada se muestra tiempo transcurrido, con su signo: `+04:15:00`.**
+Es lo que pedía el criterio de aceptación, y es lo honesto. Un `start_clocktime`
+a cero no significa «medianoche»: significa que nadie puso una hora. Enseñar
+`00:15` sería indistinguible de una hora real del día.
+
+**No se añade una fecha de proyecto configurable.** El criterio la menciona, pero
+el del Ing. Luis Mora la contradice y manda: el valor lo define el `.inp`. Añadir
+un campo de fecha en el proyecto sería inventarse un dato que el modelo ya trae o
+deliberadamente no trae. Si aparece la necesidad, es una funcionalidad aparte.
+
+**La reproducción va por reloj real, no por `setInterval`.** El bucle anterior
+sumaba un paso cada `1000/velocidad` ms; cada repintado lento se comía tiempo y
+el retraso se acumulaba, así que la velocidad efectiva dependía de lo cargada que
+estuviera la red. Ahora el paso se calcula a partir del tiempo transcurrido de
+verdad, con `requestAnimationFrame`. Se mantiene la convención de un segundo de
+reloj por paso de reporte a 1×.
+
+**Un modelo de un solo paso no enseña reproductor.** Es lo que devuelve WNTR en
+modo `single`: `timestamps = [0]`. La barra desaparece entera en vez de ofrecer
+un transporte que no lleva a ninguna parte.
+
+**La duración se lee del último paso, no de la opción declarada.** Una simulación
+que se corta antes de tiempo debe decir lo que duró, no lo que pretendía durar.
+
+### El repintado, que era la mitad del bug
+
+`addNetworkToMap` no tenía `currentTimeStep` entre sus dependencias, así que la
+simbología se calculaba con el paso capturado cuando se creó el callback: mover
+la barra cambiaba el reloj y **no repintaba el mapa**. Estaba anotado como aviso
+de `react-hooks/exhaustive-deps` desde antes. Las escalas de color se conservan
+—son las mismas franjas de presión y el mismo grosor por caudal, con su leyenda
+en el panel—, que es lo que pedía Luis Mora al redefinir los datos cargados.
+
+### El hook único
+
+El issue pedía extraerlo y consumirlo desde los cinco componentes que duplicaban
+la lógica temporal. Tres de esos cinco —`WNTRSimulationViewer`,
+`WNTRNetworkVisualization` y `WNTRMapViewer` en su parte temporal— ya
+desaparecieron o se simplificaron con #37, que retiró los visores muertos. Quedan
+la barra de transporte y el panel, y los dos leen del mismo `useSimulationTimeline`.
+
+### Verificación
+
+`src/services/network/lineaTiempo.test.ts` cubre el caso exacto del criterio de
+aceptación: 24 h con paso de reporte de 15 minutos, comprobando los **97 pasos uno
+a uno** contra el valor esperado. Además: paso de reporte no redondo (7 min),
+reconstrucción del eje cuando no llegan `timestamps`, hora de reloj declarada,
+cruce de medianoche con indicación de día, y estado estacionario.
+
+Comprobado en la aplicación con `Net3 2.inp`, 24 h y paso de 15 min: la barra dice
+`+00:00:00 · paso 1 de 97 · cada 15 min · duración 24:00:00 · tiempo transcurrido`,
+y avanzar cuatro pasos da `+01:00:00 · paso 5 de 97` —antes habrían sido cuatro
+horas—.
+
+## #46 — Pantallas que no explicaban qué faltaba
+
+La infraestructura de precondiciones existía desde #33: una tabla central de
+requisitos, el menú que atenúa lo que no se puede usar y un aviso accionable
+encima de la vista. La auditoría de este bug encontró **un hueco concreto**, y el
+resto de las vistas cumpliendo.
+
+**El hueco.** El aviso se resolvía por *vista*, y «Simulaciones» y «Red WNTR»
+llevan a la misma vista. Sólo la primera exige red cargada —la de red no la exige
+a propósito: es donde se importa el `.inp`—. Resultado: quien pulsaba
+«Simulaciones» sin red, que sale con candado pero sigue siendo accionable a
+propósito para que pueda llegar a la explicación, aterrizaba en la pantalla de
+importar sin que nada dijera qué había pasado ni por qué no estaba en
+simulaciones. Ahora el aviso se resuelve por el **ítem** que el usuario pulsó, y
+dice «"Simulaciones" necesita una red cargada» con el botón que lo resuelve.
+
+**Lo que ya estaba bien**, comprobado recorriendo la aplicación:
+
+| Situación | Resultado |
+|---|---|
+| Sin proyecto activo | Abre en Proyectos con la lista; el menú dice «Sin proyecto activo» y no pinta los hijos del proyecto |
+| Calculadora sin proyecto | Funciona, como pedía el criterio explícito de Luis Mora |
+| Chat general sin proyecto | Bienvenida con «Start New Chat» y la nota de que la conversación no se ata a ningún proyecto |
+| Wisdom Center sin proyecto | Funciona: es global |
+| Red WNTR con proyecto y sin red | Tarjeta del proyecto con el área de importar |
+
+### Decisión
+
+**Los ítems bloqueados siguen siendo pulsables.** Es la decisión de #33 y se
+mantiene: bloquear el botón dejaría al usuario sin forma de llegar a la pantalla
+que le explica qué falta. Lo que se arregla es que esa pantalla, ahora sí,
+explique.
+
+## Fuera de alcance
+
+**El acumulado de retraso en el repintado.** El issue #45 lo dejaba como
+«revisión adicional pendiente». La reproducción por reloj real lo elimina como
+causa —el paso ya no depende de cuántos ticks se hayan podido servir—, pero no se
+ha medido el coste de repintar una red grande paso a paso. Si aparece, es un
+problema de rendimiento del mapa, no del eje temporal.

--- a/docs/TIEMPO_Y_ESTADOS_VACIOS.md
+++ b/docs/TIEMPO_Y_ESTADOS_VACIOS.md
@@ -69,10 +69,11 @@ en el panel—, que es lo que pedía Luis Mora al redefinir los datos cargados.
 ### El hook único
 
 El issue pedía extraerlo y consumirlo desde los cinco componentes que duplicaban
-la lógica temporal. Tres de esos cinco —`WNTRSimulationViewer`,
-`WNTRNetworkVisualization` y `WNTRMapViewer` en su parte temporal— ya
-desaparecieron o se simplificaron con #37, que retiró los visores muertos. Quedan
-la barra de transporte y el panel, y los dos leen del mismo `useSimulationTimeline`.
+la lógica temporal. **Dos de esos cinco ya no existen**: `WNTRSimulationViewer` y
+`WNTRNetworkVisualization`, que retiró #37 por muertos. De los tres que quedan, la
+barra de transporte y el panel leen del mismo `useSimulationTimeline`, y
+`WNTRMapViewer` recibe el paso vigente por props: no tiene eje propio, sólo pinta
+el paso que le dan.
 
 ### Verificación
 

--- a/docs/TIEMPO_Y_ESTADOS_VACIOS.md
+++ b/docs/TIEMPO_Y_ESTADOS_VACIOS.md
@@ -120,9 +120,39 @@ mantiene: bloquear el botón dejaría al usuario sin forma de llegar a la pantal
 que le explica qué falta. Lo que se arregla es que esa pantalla, ahora sí,
 explique.
 
+## Lo que se rescató de los visores retirados
+
+Al revisar si los componentes que retiró #37 merecían volver, la respuesta fue que
+no —`WNTRSimulationViewer` era un segundo visor Mapbox con sus propias
+definiciones `proj4` codificadas a mano, y `WNTRNetworkVisualization` dibujaba a
+mano sobre un `canvas` 2D sin desplazamiento ni zoom—, pero sí tenían **una
+capacidad que faltaba**: colorear por más magnitudes que presión y caudal.
+
+Vuelve como `src/services/network/simbologia.ts`, con cinco opciones —tipo de
+elemento, presión, demanda, caudal y velocidad— compartidas por el mapa, el
+esquema y la leyenda del panel.
+
+**Lo que no vuelve es cómo calculaban la escala.** Usaban máximos fijos escritos a
+mano: caudal 0–200 L/s, velocidad 0–2 m/s, demanda 0–50 L/s. Es el mismo defecto
+que los husos codificados de #48: funciona con las redes con las que se probó y
+satura en el color más alto para cualquier otra. Aquí la escala sale de los datos
+del paso mostrado, y la leyenda declara el rango real —comprobado con `Net3 2`:
+«Escala de esta red en este paso: 0.00 a 2.84 m/s», que con el máximo fijo de 2
+habría quedado plana por arriba—.
+
+**La presión es la excepción, a propósito.** Sus cortes siguen siendo absolutos
+—20 y 80 m— porque tienen un criterio de servicio que no depende de la red:
+escalarla al máximo de cada modelo escondería justamente los nudos por debajo del
+mínimo. La leyenda distingue los dos casos.
+
 ## Fuera de alcance
 
-**El acumulado de retraso en el repintado.** El issue #45 lo dejaba como
+****Filtrar capas por tipo de elemento** (bombas, válvulas, depósitos…), que
+`WNTRNetworkVisualization` ofrecía y aquí no vuelve. Con una red de 3.358 nudos es
+la capacidad más útil de las que tenía, pero es funcionalidad nueva, no un
+rescate, y no cabe dentro de un cambio de dos bugs.
+
+**El acumulado de retraso en el repintado.**** El issue #45 lo dejaba como
 «revisión adicional pendiente». La reproducción por reloj real lo elimina como
 causa —el paso ya no depende de cuántos ticks se hayan podido servir—, pero no se
 ha medido el coste de repintar una red grande paso a paso. Si aparece, es un

--- a/src/components/PrecondicionAviso.tsx
+++ b/src/components/PrecondicionAviso.tsx
@@ -3,6 +3,7 @@ import { FolderOpen, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/stores/appStore'
 import { usePrecondiciones } from '@/hooks/usePrecondiciones'
+import { NAVEGACION, itemActivo, pendientesItem } from '@/config/navegacion'
 import type { Vista } from '@/config/precondiciones'
 
 /**
@@ -16,10 +17,22 @@ import type { Vista } from '@/config/precondiciones'
  */
 export function PrecondicionAviso({ vista }: { vista: Vista }) {
   const { t } = useTranslation()
-  const { pendientes } = usePrecondiciones()
+  const { estado, pendientes } = usePrecondiciones()
   const setCurrentView = useAppStore(s => s.setCurrentView)
+  const ambitoChat = useAppStore(s => s.ambitoChat)
+  const seccionRed = useAppStore(s => s.seccionRed)
 
-  const faltan = pendientes(vista)
+  /**
+   * Se mira lo que pidió el usuario, no sólo la vista a la que llegó (#46).
+   *
+   * «Simulaciones» y «Red WNTR» llevan a la misma vista, y sólo la primera exige
+   * una red. Como el aviso miraba la vista, quien pulsaba «Simulaciones» sin red
+   * —el ítem sale con candado, pero sigue siendo accionable a propósito para que
+   * pueda llegar a la explicación— aterrizaba en la pantalla de importar sin que
+   * nada dijera qué había pasado ni por qué no estaba en simulaciones.
+   */
+  const item = NAVEGACION.find(i => itemActivo(i, { vista, ambitoChat, seccionRed }))
+  const faltan = item ? pendientesItem(item, estado) : pendientes(vista)
   if (faltan.length === 0) return null
 
   const faltaProyecto = faltan.includes('proyecto')
@@ -29,7 +42,9 @@ export function PrecondicionAviso({ vista }: { vista: Vista }) {
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div className="min-w-0">
           <h2 className="text-sm font-semibold text-foreground">
-            {t(faltaProyecto ? 'precondiciones.tituloProyecto' : 'precondiciones.tituloRed')}
+            {faltaProyecto
+              ? t('precondiciones.tituloProyecto')
+              : t('precondiciones.tituloRedDe', { modulo: t(item?.etiqueta ?? 'precondiciones.esteModulo') })}
           </h2>
           <p className="text-xs text-muted-foreground mt-0.5">
             {t(faltaProyecto ? 'precondiciones.descProyecto' : 'precondiciones.descRed')}

--- a/src/components/hydraulic/NetworkTopologyView.tsx
+++ b/src/components/hydraulic/NetworkTopologyView.tsx
@@ -21,6 +21,7 @@ interface NetworkTopologyViewProps {
   showLabels?: boolean
   /** Escala de color vigente, para pintar la misma magnitud que el mapa. */
   escala?: Parameters<typeof construirGrafo>[3]
+  capas?: Parameters<typeof construirGrafo>[4]
 }
 
 export function NetworkTopologyView({
@@ -30,13 +31,14 @@ export function NetworkTopologyView({
   highlightedNodes,
   showLabels = false,
   escala,
+  capas,
 }: NetworkTopologyViewProps) {
   const visRef = useRef<{ fit: () => void } | null>(null)
   const [seleccion, setSeleccion] = useState<{ tipo: 'nudo' | 'tramo'; texto: string } | null>(null)
 
   const grafo = useMemo(
-    () => construirGrafo(networkData, simulationResults, activeTimeStep, escala),
-    [networkData, simulationResults, activeTimeStep, escala]
+    () => construirGrafo(networkData, simulationResults, activeTimeStep, escala, capas),
+    [networkData, simulationResults, activeTimeStep, escala, capas]
   )
 
   const datosVis = useMemo(() => {

--- a/src/components/hydraulic/NetworkTopologyView.tsx
+++ b/src/components/hydraulic/NetworkTopologyView.tsx
@@ -19,6 +19,8 @@ interface NetworkTopologyViewProps {
   /** IDs de nudos a destacar (p. ej. los afectados por una interrupción). */
   highlightedNodes?: string[]
   showLabels?: boolean
+  /** Escala de color vigente, para pintar la misma magnitud que el mapa. */
+  escala?: Parameters<typeof construirGrafo>[3]
 }
 
 export function NetworkTopologyView({
@@ -27,13 +29,14 @@ export function NetworkTopologyView({
   activeTimeStep = 0,
   highlightedNodes,
   showLabels = false,
+  escala,
 }: NetworkTopologyViewProps) {
   const visRef = useRef<{ fit: () => void } | null>(null)
   const [seleccion, setSeleccion] = useState<{ tipo: 'nudo' | 'tramo'; texto: string } | null>(null)
 
   const grafo = useMemo(
-    () => construirGrafo(networkData, simulationResults, activeTimeStep),
-    [networkData, simulationResults, activeTimeStep]
+    () => construirGrafo(networkData, simulationResults, activeTimeStep, escala),
+    [networkData, simulationResults, activeTimeStep, escala]
   )
 
   const datosVis = useMemo(() => {

--- a/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
+++ b/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { WNTRMapViewer } from './WNTRMapViewer';
 import { NetworkTopologyView } from './NetworkTopologyView';
 import { WNTRAdvancedVisualizerPanel } from './WNTRAdvancedVisualizerPanel';
 import { AJUSTES_INICIALES, soloAjustesDelMapa, type AjustesVisor } from './ajustesVisor';
 import type { MapSettings } from './WNTRMapViewer';
 import { tieneCoordenadasUtiles } from '@/services/network/topologia';
+import { useSimulationTimeline } from '@/hooks/useSimulationTimeline';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
@@ -16,7 +17,7 @@ import {
   SkipForward,
   ChevronLeft,
   ChevronRight,
-  Calendar
+  Clock
 } from 'lucide-react';
 
 interface NetworkData {
@@ -80,8 +81,6 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
   // aquí. Antes cada uno tenía su copia y el panel no llegaba al mapa (#37).
   const [visualizationSettings, setVisualizationSettings] = useState<AjustesVisor>(AJUSTES_INICIALES);
 
-  const [currentTime, setCurrentTime] = useState(new Date('2025-10-09T05:42:00'));
-  const playbackIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Handle external data changes
   useEffect(() => {
@@ -96,45 +95,42 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
     }
   }, [externalSimulationResults]);
 
-  // Handle playback
+  const irAPaso = useCallback((paso: number) => {
+    setVisualizationSettings(prev => ({ ...prev, timeStep: paso }));
+  }, []);
+
+  /**
+   * El eje temporal sale de los datos: los `timestamps` que devuelve WNTR —en
+   * segundos— y la hora de arranque que declara el `.inp`. Antes salía de una
+   * fecha base inventada y de una hora fija por paso, así que un modelo que
+   * reporta cada 15 minutos veía correr su reloj cuatro veces más rápido (#45).
+   */
+  const timeline = useSimulationTimeline({
+    timestamps: simulationResults?.timestamps,
+    opcionesTiempo: networkData?.options?.time,
+    paso: visualizationSettings.timeStep,
+    reproduciendo: visualizationSettings.isPlaying,
+    velocidad: visualizationSettings.playbackSpeed,
+    onPaso: irAPaso,
+  });
+
+  // Un modelo de un solo paso no tiene nada que reproducir: la barra desaparece
+  // en lugar de ofrecer un reproductor inútil.
+  const hayLineaTiempo = !timeline.linea.estacionaria;
+
+  // Un paso que ya no existe —cambio de red, o simulación más corta— se recorta
+  // en lugar de dejar la barra apuntando fuera de los resultados.
   useEffect(() => {
-    if (visualizationSettings.isPlaying && simulationResults) {
-      const maxSteps = simulationResults.timestamps?.length || 1;
-      const interval = 1000 / visualizationSettings.playbackSpeed;
-
-      playbackIntervalRef.current = setInterval(() => {
-        setVisualizationSettings(prev => {
-          const nextStep = prev.timeStep + 1;
-          if (nextStep >= maxSteps) {
-            return { ...prev, timeStep: 0 }; // Loop back to start
-          }
-          return { ...prev, timeStep: nextStep };
-        });
-      }, interval);
-
-      return () => {
-        if (playbackIntervalRef.current) {
-          clearInterval(playbackIntervalRef.current);
-          playbackIntervalRef.current = null;
-        }
-      };
-    } else {
-      if (playbackIntervalRef.current) {
-        clearInterval(playbackIntervalRef.current);
-        playbackIntervalRef.current = null;
-      }
+    if (visualizationSettings.timeStep >= timeline.linea.pasos) {
+      irAPaso(timeline.linea.pasos - 1);
     }
-  }, [visualizationSettings.isPlaying, visualizationSettings.playbackSpeed, simulationResults]);
+  }, [timeline.linea.pasos, visualizationSettings.timeStep, irAPaso]);
 
-  // Update time based on time step
   useEffect(() => {
-    if (simulationResults?.timestamps) {
-      const baseTime = new Date('2025-10-09T00:00:00');
-      const hoursToAdd = visualizationSettings.timeStep;
-      const newTime = new Date(baseTime.getTime() + hoursToAdd * 60 * 60 * 1000);
-      setCurrentTime(newTime);
+    if (!hayLineaTiempo && visualizationSettings.isPlaying) {
+      setVisualizationSettings(prev => ({ ...prev, isPlaying: false }));
     }
-  }, [visualizationSettings.timeStep, simulationResults]);
+  }, [hayLineaTiempo, visualizationSettings.isPlaying]);
 
   const handleSettingsChange = useCallback((settings: AjustesVisor) => {
     setVisualizationSettings(settings);
@@ -184,42 +180,9 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
     setVisualizationSettings(prev => ({ ...prev, isPlaying: false, timeStep: 0 }));
   };
 
-  const skipToStart = () => {
-    setVisualizationSettings(prev => ({ ...prev, timeStep: 0 }));
-  };
+  const skipToStart = () => irAPaso(0);
 
-  const skipToEnd = () => {
-    const maxSteps = simulationResults?.timestamps?.length || 1;
-    setVisualizationSettings(prev => ({ ...prev, timeStep: maxSteps - 1 }));
-  };
-
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('es-ES', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false
-    });
-  };
-
-  const formatDate = (date: Date) => {
-    return date.toLocaleDateString('es-ES', {
-      weekday: 'long',
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric'
-    });
-  };
-
-  const generateTimeLabels = () => {
-    const labels = [];
-    for (let i = 0; i <= 22; i += 2) {
-      labels.push(`${i.toString().padStart(2, '0')}:00`);
-    }
-    return labels;
-  };
-
-  const timeLabels = generateTimeLabels();
-  const maxTimeSteps = simulationResults?.timestamps?.length || 24;
+  const skipToEnd = () => irAPaso(timeline.linea.pasos - 1);
 
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] = useState(false);
 
@@ -258,22 +221,24 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
 
         </div>
 
-        {/* Timeline Control Bar */}
+        {/* Barra de transporte. Sólo aparece si la simulación tiene más de un
+            paso: un estado estacionario no tiene nada que reproducir (#45). */}
+        {hayLineaTiempo && (
         <Card className="m-0 rounded-none bg-slate-800 border-t border-slate-600 z-10">
           <CardContent className="p-4">
             <div className="space-y-3">
-              {/* Date and Time Display */}
-              <div className="flex items-center justify-center gap-4 text-white">
-                <div className="flex items-center gap-2">
-                  <ChevronLeft className="h-4 w-4 cursor-pointer hover:text-blue-400" />
-                  <div className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4" />
-                    <span className="text-sm font-medium">
-                      {formatDate(currentTime).charAt(0).toUpperCase() + formatDate(currentTime).slice(1)}, {formatTime(currentTime)} AEST
-                    </span>
-                  </div>
-                  <ChevronRight className="h-4 w-4 cursor-pointer hover:text-blue-400" />
-                </div>
+              {/* Momento de la simulación. Antes decía una fecha fija con zona
+                  horaria australiana, que no salía de ningún dato. */}
+              <div className="flex items-center justify-center gap-3 text-white">
+                <Clock className="h-4 w-4" />
+                <span className="text-sm font-medium tabular-nums">{timeline.etiqueta}</span>
+                <span className="text-xs text-gray-400">
+                  paso {visualizationSettings.timeStep + 1} de {timeline.linea.pasos}
+                  {' · '}
+                  {timeline.linea.intervalo > 0 && `cada ${Math.round(timeline.linea.intervalo / 60)} min · `}
+                  duración {timeline.duracion}
+                  {!timeline.linea.conReloj && ' · tiempo transcurrido'}
+                </span>
               </div>
 
               {/* Controls and Timeline */}
@@ -323,34 +288,24 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
                   <div className="relative">
                     <Slider
                       value={[visualizationSettings.timeStep]}
-                      onValueChange={([value]) =>
-                        setVisualizationSettings(prev => ({ ...prev, timeStep: value }))
-                      }
-                      max={maxTimeSteps - 1}
+                      onValueChange={([value]) => irAPaso(value)}
+                      max={timeline.linea.pasos - 1}
                       step={1}
                       className="w-full"
                     />
-                    {/* Time position indicator */}
-                    <div
-                      className="absolute top-0 w-2 h-6 bg-blue-500 rounded transform -translate-x-1/2 -translate-y-1"
-                      style={{
-                        left: `${(visualizationSettings.timeStep / (maxTimeSteps - 1)) * 100}%`
-                      }}
-                    />
                   </div>
 
-                  {/* Time Labels */}
-                  <div className="flex justify-between text-xs text-gray-400 px-1">
-                    {timeLabels.map((label, index) => (
-                      <span key={index}>{label}</span>
+                  {/* Marcas del eje, repartidas sobre los pasos que hay de
+                      verdad. Antes eran 00:00 a 22:00 fijas, al margen de la
+                      duración y del paso de reporte del modelo. */}
+                  <div className="flex justify-between text-xs text-gray-400 px-1 tabular-nums">
+                    {timeline.marcas.map(marca => (
+                      <span key={marca.paso}>{marca.texto}</span>
                     ))}
                   </div>
                 </div>
 
-                {/* Current Time Display */}
-                <div className="text-white text-sm font-mono min-w-[60px] text-right">
-                  {formatTime(currentTime)}
-                </div>
+
 
                 {/* Velocidad de reproducción: estaba sólo en la tarjeta que el
                     panel duplicaba, y al retirarla baja aquí, junto al resto de
@@ -371,6 +326,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
             </div>
           </CardContent>
         </Card>
+        )}
       </div>
 
       {/* Right Sidebar Panel */}
@@ -398,6 +354,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
             ajustes={visualizationSettings}
             onCambio={handleSettingsChange}
             mapaDisponible={mapaDisponible}
+            timeline={timeline}
           />
         </div>
       </div>

--- a/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
+++ b/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
@@ -5,6 +5,7 @@ import { WNTRAdvancedVisualizerPanel } from './WNTRAdvancedVisualizerPanel';
 import { AJUSTES_INICIALES, soloAjustesDelMapa, type AjustesVisor } from './ajustesVisor';
 import type { MapSettings } from './WNTRMapViewer';
 import { tieneCoordenadasUtiles } from '@/services/network/topologia';
+import { construirEscala } from '@/services/network/simbologia';
 import { useSimulationTimeline } from '@/hooks/useSimulationTimeline';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -142,6 +143,17 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
     setVisualizationSettings(prev => ({ ...prev, ...mapSettings }));
   }, []);
 
+  /** Una sola escala para el mapa, el esquema y la leyenda del panel. */
+  const escala = useMemo(
+    () => construirEscala(
+      visualizationSettings.simbologia,
+      networkData,
+      simulationResults,
+      visualizationSettings.timeStep
+    ),
+    [visualizationSettings.simbologia, visualizationSettings.timeStep, networkData, simulationResults]
+  );
+
   const ajustesDelMapa = useMemo(
     () => soloAjustesDelMapa(visualizationSettings),
     [visualizationSettings]
@@ -214,6 +226,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
               activeTimeStep={visualizationSettings.timeStep}
               highlightedNodes={highlightedNodes}
               showLabels={visualizationSettings.showLabels}
+              escala={escala}
             />
           )}
 
@@ -355,6 +368,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
             onCambio={handleSettingsChange}
             mapaDisponible={mapaDisponible}
             timeline={timeline}
+            escala={escala}
           />
         </div>
       </div>

--- a/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
+++ b/src/components/hydraulic/WNTRAdvancedMapViewer.tsx
@@ -227,6 +227,7 @@ export const WNTRAdvancedMapViewer: React.FC<WNTRAdvancedMapViewerProps> = ({
               highlightedNodes={highlightedNodes}
               showLabels={visualizationSettings.showLabels}
               escala={escala}
+              capas={visualizationSettings.capas}
             />
           )}
 

--- a/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
+++ b/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/utils/cn';
 import type { AjustesVisor, VistaVisor } from './ajustesVisor';
 import { comprobarSoporteSatelite } from '@/utils/webgl';
 import { etiquetaCorta, type Timeline } from '@/hooks/useSimulationTimeline';
+import { ETIQUETAS_SIMBOLOGIA, type Escala } from '@/services/network/simbologia';
 
 // Función pura del entorno, no estado: se resuelve una vez al cargar el módulo.
 const SOPORTE_SATELITE = comprobarSoporteSatelite();
@@ -109,6 +110,8 @@ interface WNTRAdvancedVisualizerPanelProps {
    * así que un modelo de 24 h salía con marcas de «86400:00» (#45).
    */
   timeline: Timeline;
+  /** Escala vigente; su leyenda sale de los datos, no de umbrales escritos a mano. */
+  escala: Escala | null;
 }
 
 export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelProps> = ({
@@ -117,7 +120,8 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
   ajustes,
   onCambio,
   mapaDisponible = true,
-  timeline
+  timeline,
+  escala
 }) => {
   const settings = ajustes;
 
@@ -277,11 +281,7 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
           ) : (
             <>
               <div className="space-y-1">
-                {([
-                  { valor: 'ninguna' as const, etiqueta: 'Por tipo de elemento' },
-                  { valor: 'presion' as const, etiqueta: 'Presión en los nudos' },
-                  { valor: 'caudal' as const, etiqueta: 'Caudal en los tramos' },
-                ]).map(op => (
+                {ETIQUETAS_SIMBOLOGIA.map(op => (
                   <button
                     key={op.valor}
                     onClick={() => handleSettingChange('simbologia', op.valor)}
@@ -292,31 +292,37 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
                         : 'bg-slate-700 text-gray-300 hover:bg-slate-600'
                     )}
                   >
-                    {op.etiqueta}
+                    {op.texto}
                   </button>
                 ))}
               </div>
 
-              {settings.simbologia === 'presion' && (
+              {/* La leyenda declara los tramos que hay en esta red y en este
+                  paso. Los visores retirados los tenían escritos a mano —caudal
+                  0-200 L/s, velocidad 0-2 m/s—, así que mentían en cuanto la red
+                  se salía de ese rango. */}
+              {escala && (
                 <div className="space-y-1 text-xs text-gray-400">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2 w-4 rounded" style={{ background: '#DC2626' }} />
-                    Menos de 20 m
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2 w-4 rounded" style={{ background: '#3B82F6' }} />
-                    Entre 20 y 80 m
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2 w-4 rounded" style={{ background: '#F97316' }} />
-                    Más de 80 m
-                  </div>
+                  {escala.leyenda.map(tramo => (
+                    <div key={tramo.etiqueta} className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2 w-4 shrink-0 rounded"
+                        style={{ background: tramo.color }}
+                      />
+                      {tramo.etiqueta}
+                    </div>
+                  ))}
+                  <p className="pt-1 text-[11px] text-gray-500">
+                    {escala.absoluta
+                      ? 'Cortes de servicio, iguales en cualquier red.'
+                      : `Escala de esta red en este paso: ${escala.min.toFixed(2)} a ${escala.max.toFixed(2)} ${escala.unidad}.`}
+                  </p>
                 </div>
               )}
 
-              {settings.simbologia === 'caudal' && (
+              {settings.simbologia !== 'ninguna' && !escala && (
                 <p className="text-xs text-gray-400">
-                  El grosor del tramo crece con el caudal que circula por él en el paso mostrado.
+                  La simulación no trae esa magnitud, así que la red se dibuja por tipo de elemento.
                 </p>
               )}
             </>

--- a/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
+++ b/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/utils/cn';
 import type { AjustesVisor, VistaVisor } from './ajustesVisor';
 import { comprobarSoporteSatelite } from '@/utils/webgl';
+import { etiquetaCorta, type Timeline } from '@/hooks/useSimulationTimeline';
 
 // Función pura del entorno, no estado: se resuelve una vez al cargar el módulo.
 const SOPORTE_SATELITE = comprobarSoporteSatelite();
@@ -102,6 +103,12 @@ interface WNTRAdvancedVisualizerPanelProps {
   onCambio: (ajustes: AjustesVisor) => void;
   /** `false` cuando la red no se puede situar en el mapa: el esquema es la única vista posible. */
   mapaDisponible?: boolean;
+  /**
+   * Eje temporal de la simulación. Lo construye el armazón y se comparte: las
+   * gráficas rotulaban sus etiquetas tratando los segundos de WNTR como horas,
+   * así que un modelo de 24 h salía con marcas de «86400:00» (#45).
+   */
+  timeline: Timeline;
 }
 
 export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelProps> = ({
@@ -109,7 +116,8 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
   simulationResults,
   ajustes,
   onCambio,
-  mapaDisponible = true
+  mapaDisponible = true,
+  timeline
 }) => {
   const settings = ajustes;
 
@@ -354,10 +362,9 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
             <CardContent className="h-40">
               <Line
                 data={{
-                  labels: simulationResults.timestamps.map((t: number) => {
-                    const hours = Math.floor(t);
-                    return `${hours}:00`;
-                  }),
+                  labels: timeline.linea.segundos.map((_, i) =>
+                    etiquetaCorta(timeline.linea, i)
+                  ),
                   datasets: [
                     {
                       label: 'Demanda Total (L/s)',
@@ -408,10 +415,9 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
               <CardContent className="h-40">
                 <Line
                   data={{
-                    labels: simulationResults.timestamps.map((t: number) => {
-                      const hours = Math.floor(t);
-                      return `${hours}:00`;
-                    }),
+                    labels: timeline.linea.segundos.map((_, i) =>
+                      etiquetaCorta(timeline.linea, i)
+                    ),
                     datasets: networkData.links
                       .filter((l: any) => l.type?.toLowerCase() === 'pump')
                       .map((pump: any, idx: number) => ({
@@ -443,7 +449,9 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
               </CardContent>
               {/* Pump Status List */}
               <div className="px-4 pb-4 border-t border-slate-700 pt-3">
-                <div className="text-xs font-semibold text-gray-400 mb-2">Estado Actual (Paso {settings.timeStep})</div>
+                <div className="text-xs font-semibold text-gray-400 mb-2">
+                  Estado en {timeline.etiqueta}
+                </div>
                 <div className="space-y-2">
                   {networkData.links
                     .filter((l: any) => l.type?.toLowerCase() === 'pump')

--- a/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
+++ b/src/components/hydraulic/WNTRAdvancedVisualizerPanel.tsx
@@ -9,6 +9,7 @@ import type { AjustesVisor, VistaVisor } from './ajustesVisor';
 import { comprobarSoporteSatelite } from '@/utils/webgl';
 import { etiquetaCorta, type Timeline } from '@/hooks/useSimulationTimeline';
 import { ETIQUETAS_SIMBOLOGIA, type Escala } from '@/services/network/simbologia';
+import { CAPAS, CAPAS_TODAS, contarPorTipo, hayCapasOcultas } from '@/services/network/capas';
 
 // Función pura del entorno, no estado: se resuelve una vez al cargar el módulo.
 const SOPORTE_SATELITE = comprobarSoporteSatelite();
@@ -124,6 +125,7 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
   escala
 }) => {
   const settings = ajustes;
+  const cuentas = React.useMemo(() => contarPorTipo(networkData), [networkData]);
 
   const handleSettingChange = <K extends keyof AjustesVisor>(key: K, value: AjustesVisor[K]) => {
     onCambio({ ...ajustes, [key]: value });
@@ -258,6 +260,62 @@ export const WNTRAdvancedVisualizerPanel: React.FC<WNTRAdvancedVisualizerPanelPr
                 step={1}
               />
             </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Capas. La ofrecía uno de los visores que retiró el #37 y se fue con él
+          sin que nadie la portara; con miles de nudos es lo que permite mirar
+          sólo las bombas, o el trazado sin la nube de acometidas. */}
+      <Card className="bg-slate-800 border-slate-700">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-white text-base flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Layers className="h-4 w-4" />
+              Capas
+            </div>
+            {hayCapasOcultas(settings.capas) && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-auto px-2 py-0.5 text-xs text-blue-400 hover:text-blue-300"
+                onClick={() => handleSettingChange('capas', CAPAS_TODAS)}
+              >
+                Ver todo
+              </Button>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {CAPAS.map(capa => (
+            <div key={capa.tipo} className="flex items-center justify-between">
+              <span
+                className={cn(
+                  'text-sm',
+                  cuentas[capa.tipo] === 0 && 'text-gray-500'
+                )}
+              >
+                {capa.etiqueta}
+                <span className="ml-2 text-xs text-gray-500">{cuentas[capa.tipo]}</span>
+              </span>
+              <Switch
+                // Un tipo que la red no tiene se deshabilita en vez de esconderse:
+                // así se ve que existe y que esta red no lo usa.
+                disabled={cuentas[capa.tipo] === 0}
+                checked={settings.capas[capa.tipo]}
+                onCheckedChange={checked =>
+                  handleSettingChange('capas', { ...settings.capas, [capa.tipo]: checked })
+                }
+              />
+            </div>
+          ))}
+
+          {hayCapasOcultas(settings.capas) && (
+            <p className="pt-1 text-[11px] text-yellow-500/90">
+              No estás viendo la red completa.
+              {settings.vista === 'topologia' &&
+                ' En el esquema, ocultar un tipo de nudo se lleva también los tramos que lo tocan: un tramo necesita sus dos extremos para dibujarse.'}
+            </p>
           )}
         </CardContent>
       </Card>

--- a/src/components/hydraulic/WNTRMapViewer.tsx
+++ b/src/components/hydraulic/WNTRMapViewer.tsx
@@ -877,7 +877,10 @@ export function WNTRMapViewer({
       logger.warn('Could not fit bounds:', e)
     }
 
-  }, [networkData, simulationResults, mapSettings, conversion, crs.motivo])
+  // `currentTimeStep` en las dependencias: sin él, la simbología se quedaba
+  // congelada en el paso que hubiera cuando se creó el callback y mover la barra
+  // no repintaba el mapa (#45).
+  }, [networkData, simulationResults, mapSettings, conversion, crs.motivo, currentTimeStep])
 
   useEffect(() => { repintarRedRef.current = addNetworkToMap }, [addNetworkToMap])
 
@@ -931,7 +934,7 @@ export function WNTRMapViewer({
         })
       }
     }
-  }, [networkData, simulationResults, showNetworkOverlay, mapSettings, addNetworkToMap])
+  }, [networkData, simulationResults, showNetworkOverlay, mapSettings, currentTimeStep, addNetworkToMap])
 
   const handleFileUpload = async () => {
     try {

--- a/src/components/hydraulic/WNTRMapViewer.tsx
+++ b/src/components/hydraulic/WNTRMapViewer.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/utils/cn'
 import { useMapboxToken } from '@/hooks/useMapboxToken'
 import { comprobarSoporteSatelite } from '@/utils/webgl'
 import { construirEscala, type Simbologia } from '@/services/network/simbologia'
+import { nudoVisible, tramoVisible, type CapasVisibles } from '@/services/network/capas'
 import { valorEnPaso } from '@/services/network/topologia'
 import { useProjectStore } from '@/stores/projectStore'
 import { CRSSelector } from './CRSSelector'
@@ -85,6 +86,8 @@ export interface MapSettings {
   linkWidth: number
   /** Qué magnitud de la simulación colorea la red. */
   simbologia: Simbologia
+  /** Qué tipos de elemento se dibujan. */
+  capas: CapasVisibles
 }
 
 interface WNTRMapViewerProps {
@@ -619,7 +622,7 @@ export function WNTRMapViewer({
     // Create GeoJSON for nodes
     const nodesGeoJSON: GeoJSON.FeatureCollection = {
       type: 'FeatureCollection',
-      features: networkData.nodes.map(node => {
+      features: networkData.nodes.filter(node => nudoVisible(node, mapSettings.capas)).map(node => {
         const coords = geoConversion.transformar(
           node.x || node.coordinates?.[0] || 0,
           node.y || node.coordinates?.[1] || 0
@@ -671,7 +674,7 @@ export function WNTRMapViewer({
     // Create GeoJSON for links
     const linksGeoJSON: GeoJSON.FeatureCollection = {
       type: 'FeatureCollection',
-      features: networkData.links.map(link => {
+      features: networkData.links.filter(link => tramoVisible(link, mapSettings.capas)).map(link => {
         const fromNode = networkData.nodes.find(n => n.id === link.from)
         const toNode = networkData.nodes.find(n => n.id === link.to)
 

--- a/src/components/hydraulic/WNTRMapViewer.tsx
+++ b/src/components/hydraulic/WNTRMapViewer.tsx
@@ -15,6 +15,8 @@ import {
 import { cn } from '@/utils/cn'
 import { useMapboxToken } from '@/hooks/useMapboxToken'
 import { comprobarSoporteSatelite } from '@/utils/webgl'
+import { construirEscala, type Simbologia } from '@/services/network/simbologia'
+import { valorEnPaso } from '@/services/network/topologia'
 import { useProjectStore } from '@/stores/projectStore'
 import { CRSSelector } from './CRSSelector'
 // Las definiciones proj4 viven en `@/services/geo/crs`, no aqui: cuando cada
@@ -82,7 +84,7 @@ export interface MapSettings {
   nodeSize: number
   linkWidth: number
   /** Qué magnitud de la simulación colorea la red. */
-  simbologia: 'ninguna' | 'presion' | 'caudal'
+  simbologia: Simbologia
 }
 
 interface WNTRMapViewerProps {
@@ -538,6 +540,16 @@ export function WNTRMapViewer({
   const crs = useMemo(() => resolverCRS(epsgDeclarado, limitesRed), [epsgDeclarado, limitesRed])
 
   /**
+   * Escala de color del paso que se está mostrando. Sale de los datos: los
+   * visores retirados usaban máximos fijos escritos a mano y saturaban en
+   * cuanto la red se salía del rango con el que se probaron.
+   */
+  const escala = useMemo(
+    () => construirEscala(mapSettings.simbologia, networkData, simulationResults, currentTimeStep),
+    [mapSettings.simbologia, networkData, simulationResults, currentTimeStep]
+  )
+
+  /**
    * Reproyeccion a WGS84. `null` cuando no hay sistema con el que reproyectar:
    * quien pinta comprueba esto y no dibuja, en lugar de recibir un transformador
    * de mentira que devuelva un punto cualquiera.
@@ -622,20 +634,14 @@ export function WNTRMapViewer({
         if (node.type === 'tank') color = '#EF4444'
         else if (node.type === 'reservoir') color = '#10B981'
 
-        // La presión colorea los nudos sólo cuando el panel lo pide. Antes lo
-        // hacía siempre y el interruptor «mapa de presiones» no llegaba al mapa:
-        // encendido o apagado, se pintaba igual (#37).
-        if (mapSettings.simbologia === 'presion' && simulationResults?.node_results?.[node.id]) {
-          const pressureArray = simulationResults.node_results[node.id].pressure
-          // Access specific time step if it exists, otherwise use 0 or default
-          const pressure = Array.isArray(pressureArray) && currentTimeStep !== undefined
-            ? pressureArray[currentTimeStep] ?? pressureArray[0]
-            : pressureArray
-
-          if (typeof pressure === 'number') {
-            if (pressure < 20) color = '#DC2626' // Red for low pressure
-            else if (pressure > 80) color = '#F97316' // Orange for high pressure
-          }
+        // El color de la magnitud elegida manda sobre el del tipo. Un nudo sin
+        // dato en este paso conserva el suyo en vez de recibir uno inventado.
+        if (escala?.aplicaA === 'nudos') {
+          const valor = valorEnPaso(
+            simulationResults?.node_results?.[node.id]?.[escala.parametro === 'presion' ? 'pressure' : 'demand'],
+            currentTimeStep
+          )
+          color = escala.color(valor) ?? color
         }
 
         return {
@@ -691,16 +697,17 @@ export function WNTRMapViewer({
           width = mapSettings.linkWidth * 1.5
         }
 
-        // Igual que con la presión: el caudal engorda el tramo sólo si es la
-        // simbología elegida.
-        if (mapSettings.simbologia === 'caudal' && simulationResults?.link_results?.[link.id]) {
-          const flowArray = simulationResults.link_results[link.id].flowrate
-          const flowValue = Array.isArray(flowArray) && currentTimeStep !== undefined
-            ? flowArray[currentTimeStep] ?? flowArray[0]
-            : flowArray
-
-          const flow = Math.abs(flowValue || 0)
-          width = Math.min(flow * 0.5 + mapSettings.linkWidth, mapSettings.linkWidth * 4)
+        if (escala?.aplicaA === 'tramos') {
+          const valor = valorEnPaso(
+            simulationResults?.link_results?.[link.id]?.[escala.parametro === 'caudal' ? 'flowrate' : 'velocity'],
+            currentTimeStep
+          )
+          color = escala.color(valor) ?? color
+          // El caudal, además del color, engorda el tramo: es la lectura que un
+          // ingeniero espera de un esquema de red.
+          if (escala.parametro === 'caudal' && typeof valor === 'number' && escala.max > 0) {
+            width = mapSettings.linkWidth * (1 + (3 * Math.abs(valor)) / escala.max)
+          }
         }
 
         return {
@@ -880,7 +887,7 @@ export function WNTRMapViewer({
   // `currentTimeStep` en las dependencias: sin él, la simbología se quedaba
   // congelada en el paso que hubiera cuando se creó el callback y mover la barra
   // no repintaba el mapa (#45).
-  }, [networkData, simulationResults, mapSettings, conversion, crs.motivo, currentTimeStep])
+  }, [networkData, simulationResults, mapSettings, conversion, crs.motivo, currentTimeStep, escala])
 
   useEffect(() => { repintarRedRef.current = addNetworkToMap }, [addNetworkToMap])
 

--- a/src/components/hydraulic/ajustesVisor.ts
+++ b/src/components/hydraulic/ajustesVisor.ts
@@ -7,6 +7,7 @@
  * en un estado propio del panel lateral que no llegaba al mapa.
  */
 
+import { CAPAS_TODAS } from '@/services/network/capas'
 import type { MapSettings } from './WNTRMapViewer'
 
 export type VistaVisor = 'mapa' | 'topologia'
@@ -33,6 +34,7 @@ export function soloAjustesDelMapa(ajustes: AjustesVisor): MapSettings {
     nodeSize: ajustes.nodeSize,
     linkWidth: ajustes.linkWidth,
     simbologia: ajustes.simbologia,
+    capas: ajustes.capas,
   }
 }
 
@@ -44,6 +46,7 @@ export const AJUSTES_INICIALES: AjustesVisor = {
   nodeSize: 8,
   linkWidth: 2,
   simbologia: 'presion',
+  capas: CAPAS_TODAS,
   timeStep: 0,
   isPlaying: false,
   playbackSpeed: 1,

--- a/src/config/navegacion.test.ts
+++ b/src/config/navegacion.test.ts
@@ -104,4 +104,29 @@ describe('modelo de navegación', () => {
       }
     }
   })
+
+  it('el aviso mira lo que pidió el usuario, no sólo la vista a la que llega (#46)', () => {
+    // «Simulaciones» y «Red WNTR» llevan a la misma vista y sólo la primera
+    // exige red. Resolviendo por vista, quien pulsaba «Simulaciones» sin red
+    // aterrizaba en la pantalla de importar sin que nada lo explicara.
+    const sinRed = { hayProyecto: true, hayRed: false }
+    const enSimulaciones: UbicacionActual = { vista: 'wntr', ambitoChat: 'general', seccionRed: 'simulate' }
+
+    const activo = NAVEGACION.find(i => itemActivo(i, enSimulaciones))!
+    expect(activo.id).toBe('simulaciones')
+    expect(pendientesItem(activo, sinRed)).toEqual(['red'])
+
+    // La vista de red por sí misma no exige red: es donde se importa el .inp.
+    const enRed: UbicacionActual = { vista: 'wntr', ambitoChat: 'general', seccionRed: null }
+    const activoRed = NAVEGACION.find(i => itemActivo(i, enRed))!
+    expect(activoRed.id).toBe('red')
+    expect(pendientesItem(activoRed, sinRed)).toEqual([])
+  })
+
+  it('con red cargada, «Simulaciones» deja de reclamar nada', () => {
+    const conRed = { hayProyecto: true, hayRed: true }
+    const enSimulaciones: UbicacionActual = { vista: 'wntr', ambitoChat: 'general', seccionRed: 'simulate' }
+    const activo = NAVEGACION.find(i => itemActivo(i, enSimulaciones))!
+    expect(pendientesItem(activo, conRed)).toEqual([])
+  })
 })

--- a/src/hooks/useSimulationTimeline.ts
+++ b/src/hooks/useSimulationTimeline.ts
@@ -1,0 +1,114 @@
+/**
+ * Eje temporal y reproducción de una simulación (#45).
+ *
+ * Un único sitio donde vive el tiempo: la barra de transporte, el panel y sus
+ * gráficas leen de aquí. El issue pedía extraer este hook porque la lógica
+ * temporal estaba repetida en cinco componentes; con el #37 tres de ellos ya
+ * desaparecieron —eran visores muertos—, así que quedan la barra y el panel.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  construirLineaTiempo,
+  duracionTotal,
+  etiquetaCorta,
+  etiquetaPaso,
+  marcasEje,
+  type LineaTiempo,
+  type OpcionesTiempo,
+} from '@/services/network/lineaTiempo'
+
+/** Milisegundos de reloj real por paso de reporte a velocidad 1x. */
+const MS_POR_PASO = 1000
+
+interface Parametros {
+  timestamps?: number[] | null
+  opcionesTiempo?: OpcionesTiempo | null
+  paso: number
+  reproduciendo: boolean
+  velocidad: number
+  onPaso: (paso: number) => void
+}
+
+export interface Timeline {
+  linea: LineaTiempo
+  /** Etiqueta completa del paso actual. */
+  etiqueta: string
+  /** Duración total de la simulación, en formato HH:MM:SS. */
+  duracion: string
+  marcas: Array<{ paso: number; texto: string }>
+  etiquetaDe: (paso: number) => string
+}
+
+export function useSimulationTimeline({
+  timestamps,
+  opcionesTiempo,
+  paso,
+  reproduciendo,
+  velocidad,
+  onPaso,
+}: Parametros): Timeline {
+  const linea = useMemo(
+    () => construirLineaTiempo(timestamps, opcionesTiempo),
+    [timestamps, opcionesTiempo]
+  )
+
+  const pasoRef = useRef(paso)
+  useEffect(() => { pasoRef.current = paso }, [paso])
+
+  /**
+   * Último paso que emitió la reproducción. Sirve para distinguir un avance
+   * propio de un salto del usuario: si el paso vigente no es el que emitimos, es
+   * que alguien ha arrastrado la barra y hay que recolocar el origen del reloj.
+   */
+  const emitidoRef = useRef(paso)
+
+  useEffect(() => {
+    if (!reproduciendo || linea.estacionaria) return
+
+    let animacion = 0
+    let origen = performance.now()
+    let pasoOrigen = pasoRef.current
+
+    /**
+     * El avance se calcula con el reloj real, no sumando uno por tick. Con un
+     * `setInterval` fijo —lo que había— cada repintado lento se comía tiempo y la
+     * reproducción se retrasaba de forma acumulativa: la velocidad dependía de lo
+     * cargada que estuviera la red, no de lo que pidiera el usuario.
+     */
+    const avanzar = (ahora: number) => {
+      if (pasoRef.current !== emitidoRef.current) {
+        origen = ahora
+        pasoOrigen = pasoRef.current
+      }
+
+      const transcurridos = Math.floor(((ahora - origen) * velocidad) / MS_POR_PASO)
+      const siguiente = (pasoOrigen + transcurridos) % linea.pasos
+
+      if (siguiente !== pasoRef.current) {
+        emitidoRef.current = siguiente
+        onPaso(siguiente)
+      }
+
+      animacion = requestAnimationFrame(avanzar)
+    }
+
+    animacion = requestAnimationFrame(avanzar)
+    return () => cancelAnimationFrame(animacion)
+  }, [reproduciendo, velocidad, linea.pasos, linea.estacionaria, onPaso])
+
+  const etiquetaDe = useCallback(
+    (n: number) => etiquetaPaso(linea, n, opcionesTiempo),
+    [linea, opcionesTiempo]
+  )
+
+  return {
+    linea,
+    etiqueta: etiquetaDe(paso),
+    duracion: duracionTotal(linea),
+    marcas: useMemo(() => marcasEje(linea, 9, opcionesTiempo), [linea, opcionesTiempo]),
+    etiquetaDe,
+  }
+}
+
+export { etiquetaCorta }

--- a/src/hooks/useSimulationTimeline.ts
+++ b/src/hooks/useSimulationTimeline.ts
@@ -106,7 +106,7 @@ export function useSimulationTimeline({
     linea,
     etiqueta: etiquetaDe(paso),
     duracion: duracionTotal(linea),
-    marcas: useMemo(() => marcasEje(linea, 9, opcionesTiempo), [linea, opcionesTiempo]),
+    marcas: useMemo(() => marcasEje(linea, 7, opcionesTiempo), [linea, opcionesTiempo]),
     etiquetaDe,
   }
 }

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -251,6 +251,8 @@
     "accionCrearProyecto": "Crear un projecte",
     "tituloRed": "Aquest mòdul necessita una xarxa carregada",
     "descRed": "Importa un fitxer .inp d'EPANET per poder simular i analitzar.",
-    "accionImportarRed": "Importar .inp"
+    "accionImportarRed": "Importar .inp",
+    "tituloRedDe": "«{{modulo}}» necessita una xarxa carregada",
+    "esteModulo": "Aquest mòdul"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -251,6 +251,8 @@
     "accionCrearProyecto": "Create a project",
     "tituloRed": "This module needs a loaded network",
     "descRed": "Import an EPANET .inp file to run simulations and analyses.",
-    "accionImportarRed": "Import .inp"
+    "accionImportarRed": "Import .inp",
+    "tituloRedDe": "«{{modulo}}» needs a loaded network",
+    "esteModulo": "This module"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -251,6 +251,8 @@
     "accionCrearProyecto": "Crear un proyecto",
     "tituloRed": "Este módulo necesita una red cargada",
     "descRed": "Importa un archivo .inp de EPANET para poder simular y analizar.",
-    "accionImportarRed": "Importar .inp"
+    "accionImportarRed": "Importar .inp",
+    "tituloRedDe": "«{{modulo}}» necesita una red cargada",
+    "esteModulo": "Este módulo"
   }
 }

--- a/src/services/network/capas.test.ts
+++ b/src/services/network/capas.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CAPAS_TODAS,
+  contarPorTipo,
+  hayCapasOcultas,
+  nudoVisible,
+  tipoNudo,
+  tipoTramo,
+  tramoVisible,
+} from './capas'
+
+const RED = {
+  nodes: [
+    { id: 'J1', type: 'junction' },
+    { id: 'J2', type: 'Junction' },
+    { id: 'T1', type: 'tank' },
+    { id: 'R1', type: 'RESERVOIR' },
+  ],
+  links: [
+    { id: 'P1', from: 'J1', to: 'J2', type: 'pipe' },
+    { id: 'P2', from: 'J2', to: 'T1', type: 'Pipe' },
+    { id: 'B1', from: 'R1', to: 'J1', type: 'PUMP' },
+    { id: 'V1', from: 'T1', to: 'J2', type: 'valve' },
+  ],
+}
+
+describe('clasificación por tipo', () => {
+  it('no depende de las mayúsculas, que cada servicio escribe a su manera', () => {
+    expect(tipoNudo({ id: 'a', type: 'Junction' })).toBe('junction')
+    expect(tipoNudo({ id: 'b', type: 'RESERVOIR' })).toBe('reservoir')
+    expect(tipoTramo({ id: 'c', from: 'a', to: 'b', type: 'Pipe' })).toBe('pipe')
+    expect(tipoTramo({ id: 'd', from: 'a', to: 'b', type: 'PUMP' })).toBe('pump')
+  })
+
+  it('un tipo desconocido se agrupa con el común, no desaparece', () => {
+    // Un elemento invisible por no saber clasificarlo sería peor que uno mal
+    // agrupado: el ingeniero no tendría forma de notar que le falta.
+    expect(tipoNudo({ id: 'x', type: 'no-existe' })).toBe('junction')
+    expect(tipoNudo({ id: 'y' })).toBe('junction')
+    expect(tipoTramo({ id: 'z', from: 'a', to: 'b' })).toBe('pipe')
+  })
+})
+
+describe('filtrado', () => {
+  it('con todas las capas encendidas no se oculta nada', () => {
+    expect(RED.nodes.every(n => nudoVisible(n, CAPAS_TODAS))).toBe(true)
+    expect(RED.links.every(l => tramoVisible(l, CAPAS_TODAS))).toBe(true)
+    expect(hayCapasOcultas(CAPAS_TODAS)).toBe(false)
+  })
+
+  it('apagar los nudos de consumo deja los depósitos y los embalses', () => {
+    const capas = { ...CAPAS_TODAS, junction: false }
+    const visibles = RED.nodes.filter(n => nudoVisible(n, capas)).map(n => n.id)
+    expect(visibles).toEqual(['T1', 'R1'])
+    expect(hayCapasOcultas(capas)).toBe(true)
+  })
+
+  it('dejar sólo bombas y válvulas es el caso que motivó rescatar esto', () => {
+    const capas = { ...CAPAS_TODAS, pipe: false }
+    const visibles = RED.links.filter(l => tramoVisible(l, capas)).map(l => l.id)
+    expect(visibles).toEqual(['B1', 'V1'])
+  })
+
+  it('apagarlo todo no revienta: deja la red vacía', () => {
+    const nada = { junction: false, tank: false, reservoir: false, pipe: false, pump: false, valve: false }
+    expect(RED.nodes.filter(n => nudoVisible(n, nada))).toHaveLength(0)
+    expect(RED.links.filter(l => tramoVisible(l, nada))).toHaveLength(0)
+  })
+})
+
+describe('contadores', () => {
+  it('cuenta cada tipo, respetando las mayúsculas dispares', () => {
+    expect(contarPorTipo(RED)).toEqual({
+      junction: 2, tank: 1, reservoir: 1, pipe: 2, pump: 1, valve: 1,
+    })
+  })
+
+  it('sin red, todo a cero en vez de fallar', () => {
+    expect(contarPorTipo(null).pump).toBe(0)
+  })
+})

--- a/src/services/network/capas.ts
+++ b/src/services/network/capas.ts
@@ -1,0 +1,78 @@
+/**
+ * Visibilidad de la red por tipo de elemento (#37, rescate).
+ *
+ * La ofrecía `WNTRNetworkVisualization`, uno de los visores que se retiraron por
+ * muertos, y se fue con él sin que nadie la portara: la auditoría clasificó los
+ * componentes pero no inventarió sus capacidades una por una antes de borrar.
+ * Con una red de miles de nudos es lo que permite mirar sólo las bombas, o el
+ * trazado sin la nube de acometidas.
+ *
+ * Módulo puro: sabe de tipos de elemento, no de mapas ni de grafos.
+ */
+
+import type { DatosRed, NodoRed, TramoRed } from './topologia'
+
+export type TipoNudo = 'junction' | 'tank' | 'reservoir'
+export type TipoTramo = 'pipe' | 'pump' | 'valve'
+export type TipoElemento = TipoNudo | TipoTramo
+
+export type CapasVisibles = Record<TipoElemento, boolean>
+
+export const CAPAS_TODAS: CapasVisibles = {
+  junction: true,
+  tank: true,
+  reservoir: true,
+  pipe: true,
+  pump: true,
+  valve: true,
+}
+
+export const CAPAS: Array<{ tipo: TipoElemento; etiqueta: string; de: 'nudos' | 'tramos' }> = [
+  { tipo: 'junction', etiqueta: 'Nudos de consumo', de: 'nudos' },
+  { tipo: 'tank', etiqueta: 'Depósitos', de: 'nudos' },
+  { tipo: 'reservoir', etiqueta: 'Embalses', de: 'nudos' },
+  { tipo: 'pipe', etiqueta: 'Tuberías', de: 'tramos' },
+  { tipo: 'pump', etiqueta: 'Bombas', de: 'tramos' },
+  { tipo: 'valve', etiqueta: 'Válvulas', de: 'tramos' },
+]
+
+/**
+ * Tipo normalizado de un elemento. Los `.inp` y los distintos servicios de WNTR
+ * no coinciden en mayúsculas —`Pipe`, `pipe`, `PIPE`—, y un tipo que no se
+ * reconoce se trata como el común de su familia en lugar de desaparecer: un
+ * elemento invisible por no saber clasificarlo sería peor que uno mal agrupado.
+ */
+export function tipoNudo(n: NodoRed): TipoNudo {
+  const t = String(n.type ?? '').toLowerCase()
+  return t === 'tank' || t === 'reservoir' ? t : 'junction'
+}
+
+export function tipoTramo(l: TramoRed): TipoTramo {
+  const t = String(l.type ?? '').toLowerCase()
+  return t === 'pump' || t === 'valve' ? t : 'pipe'
+}
+
+export function nudoVisible(n: NodoRed, capas: CapasVisibles): boolean {
+  return capas[tipoNudo(n)]
+}
+
+export function tramoVisible(l: TramoRed, capas: CapasVisibles): boolean {
+  return capas[tipoTramo(l)]
+}
+
+/** Cuántos elementos hay de cada tipo, para que los interruptores digan algo. */
+export function contarPorTipo(datos: DatosRed | null | undefined): Record<TipoElemento, number> {
+  const cuenta: Record<TipoElemento, number> = {
+    junction: 0, tank: 0, reservoir: 0, pipe: 0, pump: 0, valve: 0,
+  }
+  if (!datos) return cuenta
+
+  for (const n of datos.nodes) cuenta[tipoNudo(n)]++
+  for (const l of datos.links) cuenta[tipoTramo(l)]++
+  return cuenta
+}
+
+/** `true` si algo está oculto, para poder avisar de que no se está viendo todo. */
+export function hayCapasOcultas(capas: CapasVisibles): boolean {
+  return CAPAS.some(c => !capas[c.tipo])
+}

--- a/src/services/network/lineaTiempo.test.ts
+++ b/src/services/network/lineaTiempo.test.ts
@@ -114,6 +114,16 @@ describe('marcas del eje', () => {
     expect(etiquetaCorta(linea, 1, OPCIONES_15)).toBe('+00:15')
   })
 
+  it('una simulación de días también pierde los segundos en el eje', () => {
+    // 168 h son tres dígitos de hora: con el recorte anterior el eje mezclaba
+    // «+21:00» con «+105:00:00».
+    const semana = Array.from({ length: 673 }, (_, i) => i * 900)
+    const linea = construirLineaTiempo(semana, { report_timestep: 900 })
+
+    expect(etiquetaCorta(linea, 672)).toBe('+168:00')
+    expect(marcasEje(linea, 9).every(m => !/:\d{2}:\d{2}$/.test(m.texto))).toBe(true)
+  })
+
   it('la duración total sale del último paso, no de la opción declarada', () => {
     // Una simulación que se corta antes de tiempo debe decir lo que duró.
     const linea = construirLineaTiempo([0, 3600, 7200], { duration: 86400 })

--- a/src/services/network/lineaTiempo.test.ts
+++ b/src/services/network/lineaTiempo.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import {
+  construirLineaTiempo,
+  duracionTotal,
+  etiquetaCorta,
+  etiquetaPaso,
+  marcasEje,
+} from './lineaTiempo'
+
+/** 24 h reportando cada 15 min: 96 pasos más el instante inicial. */
+const CADA_15_MIN = Array.from({ length: 97 }, (_, i) => i * 900)
+const OPCIONES_15 = { duration: 86400, report_timestep: 900, start_clocktime: 0 }
+
+describe('el eje sale de los datos, no de constantes', () => {
+  it('un modelo que reporta cada 15 minutos avanza 15 minutos por paso', () => {
+    // El caso del issue: antes cada paso sumaba una hora fija, así que el reloj
+    // corría cuatro veces más rápido que la simulación.
+    const linea = construirLineaTiempo(CADA_15_MIN, OPCIONES_15)
+
+    expect(linea.pasos).toBe(97)
+    expect(linea.intervalo).toBe(900)
+    expect(etiquetaPaso(linea, 1, OPCIONES_15)).toBe('+00:15:00')
+    expect(etiquetaPaso(linea, 4, OPCIONES_15)).toBe('+01:00:00')
+    expect(etiquetaPaso(linea, 96, OPCIONES_15)).toBe('+24:00:00')
+  })
+
+  it('el reloj coincide con los 96 pasos de WNTR, uno a uno', () => {
+    const linea = construirLineaTiempo(CADA_15_MIN, OPCIONES_15)
+    for (let i = 0; i < linea.pasos; i++) {
+      const segundos = i * 900
+      const h = String(Math.floor(segundos / 3600)).padStart(2, '0')
+      const m = String(Math.floor((segundos % 3600) / 60)).padStart(2, '0')
+      expect(etiquetaPaso(linea, i, OPCIONES_15)).toBe(`+${h}:${m}:00`)
+    }
+  })
+
+  it('respeta un paso de reporte cualquiera, no sólo los redondos', () => {
+    const cada7 = [0, 420, 840, 1260]
+    const linea = construirLineaTiempo(cada7, { report_timestep: 420 })
+    expect(linea.intervalo).toBe(420)
+    expect(etiquetaPaso(linea, 3, {})).toBe('+00:21:00')
+  })
+
+  it('sin timestamps reconstruye el eje con la duración y el paso del modelo', () => {
+    const linea = construirLineaTiempo([], { duration: 3600, report_timestep: 1800 })
+    expect(linea.segundos).toEqual([0, 1800, 3600])
+  })
+
+  it('sin nada de lo anterior no inventa un eje', () => {
+    const linea = construirLineaTiempo(null, null)
+    expect(linea.pasos).toBe(1)
+    expect(linea.estacionaria).toBe(true)
+  })
+})
+
+describe('la hora la declara el .inp, no Boorie', () => {
+  it('sin hora declarada muestra tiempo transcurrido, con su signo', () => {
+    const linea = construirLineaTiempo(CADA_15_MIN, OPCIONES_15)
+    expect(linea.conReloj).toBe(false)
+    expect(etiquetaPaso(linea, 0, OPCIONES_15)).toBe('+00:00:00')
+  })
+
+  it('con hora declarada muestra la hora del reloj', () => {
+    // START CLOCKTIME 6:00 en el .inp.
+    const opciones = { ...OPCIONES_15, start_clocktime: 6 * 3600 }
+    const linea = construirLineaTiempo(CADA_15_MIN, opciones)
+
+    expect(linea.conReloj).toBe(true)
+    expect(etiquetaPaso(linea, 0, opciones)).toBe('06:00:00')
+    expect(etiquetaPaso(linea, 1, opciones)).toBe('06:15:00')
+  })
+
+  it('al pasar de medianoche dice qué día es, en vez de repetir la hora', () => {
+    const opciones = { ...OPCIONES_15, start_clocktime: 22 * 3600 }
+    const linea = construirLineaTiempo(CADA_15_MIN, opciones)
+    expect(etiquetaPaso(linea, 8, opciones)).toBe('00:00:00 (día 2)')
+  })
+
+  it('un cero en start_clocktime es «nadie puso hora», no medianoche', () => {
+    const linea = construirLineaTiempo(CADA_15_MIN, { ...OPCIONES_15, start_clocktime: 0 })
+    expect(linea.conReloj).toBe(false)
+    expect(etiquetaPaso(linea, 4, OPCIONES_15)).toBe('+01:00:00')
+  })
+})
+
+describe('estado estacionario', () => {
+  it('una simulación de un solo paso se marca como estacionaria', () => {
+    // Es lo que devuelve WNTR para el modo `single`: timestamps = [0].
+    const linea = construirLineaTiempo([0], { report_timestep: 3600 })
+    expect(linea.estacionaria).toBe(true)
+    expect(linea.pasos).toBe(1)
+    expect(marcasEje(linea, 12)).toHaveLength(1)
+  })
+})
+
+describe('marcas del eje', () => {
+  it('nunca miente sobre los extremos', () => {
+    const linea = construirLineaTiempo(CADA_15_MIN, OPCIONES_15)
+    const marcas = marcasEje(linea, 12, OPCIONES_15)
+
+    expect(marcas[0].paso).toBe(0)
+    expect(marcas[marcas.length - 1].paso).toBe(96)
+    expect(marcas[marcas.length - 1].texto).toBe('+24:00')
+    expect(marcas.length).toBeLessThanOrEqual(12)
+  })
+
+  it('no pide más marcas que pasos hay', () => {
+    const linea = construirLineaTiempo([0, 3600, 7200], { report_timestep: 3600 })
+    expect(marcasEje(linea, 12, {}).length).toBeLessThanOrEqual(3)
+  })
+
+  it('la etiqueta corta se queda en horas y minutos', () => {
+    const linea = construirLineaTiempo(CADA_15_MIN, OPCIONES_15)
+    expect(etiquetaCorta(linea, 1, OPCIONES_15)).toBe('+00:15')
+  })
+
+  it('la duración total sale del último paso, no de la opción declarada', () => {
+    // Una simulación que se corta antes de tiempo debe decir lo que duró.
+    const linea = construirLineaTiempo([0, 3600, 7200], { duration: 86400 })
+    expect(duracionTotal(linea)).toBe('02:00:00')
+  })
+})

--- a/src/services/network/lineaTiempo.ts
+++ b/src/services/network/lineaTiempo.ts
@@ -120,7 +120,10 @@ export function etiquetaCorta(
   opciones?: OpcionesTiempo | null
 ): string {
   const completa = etiquetaPaso(linea, paso, opciones)
-  return completa.replace(/^(\+?\d{2}:\d{2}):\d{2}/, '$1')
+  // `\d{2,}`, no `\d{2}`: una simulación de una semana llega a las 168 horas y
+  // con dos dígitos la etiqueta se quedaba con los segundos puestos, así que el
+  // eje mezclaba «+21:00» con «+105:00:00».
+  return completa.replace(/^(\+?\d{2,}:\d{2}):\d{2}/, '$1')
 }
 
 /**

--- a/src/services/network/lineaTiempo.ts
+++ b/src/services/network/lineaTiempo.ts
@@ -1,0 +1,152 @@
+/**
+ * Eje temporal de una simulación (#45).
+ *
+ * El reloj de la interfaz salía de dos constantes: una fecha base inventada
+ * (`2025-10-09T00:00:00`) y una hora fija por paso. Para un modelo que reporta
+ * cada 15 minutos, el reloj avanzaba cuatro veces más rápido que la simulación,
+ * y la fecha no correspondía a nada.
+ *
+ * WNTR ya devuelve el eje bueno: `timestamps` es el índice de sus resultados, en
+ * segundos desde el arranque de la simulación. Y el `.inp` declara su propia hora
+ * de inicio en `start_clocktime`. Boorie sólo tiene que leerlos —criterio
+ * explícito del Ing. Luis Mora: «eso se define en EPANET; Boorie sólo debe leer
+ * ese paso temporal»—.
+ */
+
+export interface OpcionesTiempo {
+  /** Duración total en segundos. */
+  duration?: number
+  /** Cada cuánto reporta el modelo, en segundos. */
+  report_timestep?: number
+  /** Hora de arranque declarada en el .inp, en segundos desde medianoche. */
+  start_clocktime?: number
+}
+
+export interface LineaTiempo {
+  /** Segundos de simulación de cada paso. */
+  segundos: number[]
+  pasos: number
+  /** Un solo paso: es un estado estacionario y no hay nada que reproducir. */
+  estacionaria: boolean
+  /** Paso de reporte real en segundos; 0 si no se ha podido determinar. */
+  intervalo: number
+  /**
+   * La hora sale del reloj que declara el `.inp`. Cuando no lo declara se
+   * muestra tiempo relativo, que es lo honesto: un `start_clocktime` a cero no
+   * significa «medianoche», significa que nadie puso una hora.
+   */
+  conReloj: boolean
+}
+
+const VACIA: LineaTiempo = {
+  segundos: [0],
+  pasos: 1,
+  estacionaria: true,
+  intervalo: 0,
+  conReloj: false,
+}
+
+export function construirLineaTiempo(
+  timestamps: number[] | undefined | null,
+  opciones?: OpcionesTiempo | null
+): LineaTiempo {
+  const reloj = opciones?.start_clocktime
+  const conReloj = typeof reloj === 'number' && Number.isFinite(reloj) && reloj > 0
+
+  const reales = (timestamps ?? []).filter(t => typeof t === 'number' && Number.isFinite(t))
+
+  // Los timestamps de WNTR son la verdad. Sólo cuando no llegan se reconstruye el
+  // eje a partir de la duración y el paso de reporte del modelo.
+  let segundos = reales
+  if (segundos.length === 0) {
+    const duracion = opciones?.duration ?? 0
+    const paso = opciones?.report_timestep ?? 0
+    if (duracion > 0 && paso > 0) {
+      segundos = []
+      for (let t = 0; t <= duracion; t += paso) segundos.push(t)
+    }
+  }
+
+  if (segundos.length === 0) return { ...VACIA, conReloj }
+
+  const intervalo =
+    segundos.length > 1
+      ? segundos[1] - segundos[0]
+      : (opciones?.report_timestep ?? 0)
+
+  return {
+    segundos,
+    pasos: segundos.length,
+    estacionaria: segundos.length <= 1,
+    intervalo,
+    conReloj,
+  }
+}
+
+function dosDigitos(n: number): string {
+  return String(Math.floor(n)).padStart(2, '0')
+}
+
+function hhmmss(segundos: number): string {
+  const s = Math.max(0, Math.round(segundos))
+  return `${dosDigitos(s / 3600)}:${dosDigitos((s % 3600) / 60)}:${dosDigitos(s % 60)}`
+}
+
+/**
+ * Etiqueta completa de un paso. Sin reloj declarado, tiempo transcurrido con
+ * signo —`+04:15:00`— para que se lea como lo que es y no como una hora del día.
+ */
+export function etiquetaPaso(
+  linea: LineaTiempo,
+  paso: number,
+  opciones?: OpcionesTiempo | null
+): string {
+  const t = linea.segundos[paso] ?? linea.segundos[linea.segundos.length - 1] ?? 0
+
+  if (!linea.conReloj) return `+${hhmmss(t)}`
+
+  const inicio = opciones?.start_clocktime ?? 0
+  const absoluto = inicio + t
+  const dia = Math.floor(absoluto / 86400)
+  const hora = hhmmss(absoluto % 86400)
+
+  return dia > 0 ? `${hora} (día ${dia + 1})` : hora
+}
+
+/** Etiqueta corta para el eje: horas y minutos, sin segundos. */
+export function etiquetaCorta(
+  linea: LineaTiempo,
+  paso: number,
+  opciones?: OpcionesTiempo | null
+): string {
+  const completa = etiquetaPaso(linea, paso, opciones)
+  return completa.replace(/^(\+?\d{2}:\d{2}):\d{2}/, '$1')
+}
+
+/**
+ * Marcas repartidas por el eje. Se piden `cuantas` y se devuelven como mucho
+ * esas, siempre con el primer y el último paso, para que los extremos del eje no
+ * mientan sobre la duración.
+ */
+export function marcasEje(
+  linea: LineaTiempo,
+  cuantas: number,
+  opciones?: OpcionesTiempo | null
+): Array<{ paso: number; texto: string }> {
+  if (linea.pasos <= 1) return [{ paso: 0, texto: etiquetaCorta(linea, 0, opciones) }]
+
+  const total = Math.max(2, Math.min(cuantas, linea.pasos))
+  const pasos = new Set<number>()
+  for (let i = 0; i < total; i++) {
+    pasos.add(Math.round((i * (linea.pasos - 1)) / (total - 1)))
+  }
+
+  return [...pasos]
+    .sort((a, b) => a - b)
+    .map(paso => ({ paso, texto: etiquetaCorta(linea, paso, opciones) }))
+}
+
+/** Duración total de la simulación, para poder enseñarla junto al eje. */
+export function duracionTotal(linea: LineaTiempo): string {
+  return hhmmss(linea.segundos[linea.segundos.length - 1] ?? 0)
+}

--- a/src/services/network/simbologia.test.ts
+++ b/src/services/network/simbologia.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { construirEscala } from './simbologia'
+
+const RED = {
+  nodes: [{ id: 'J1' }, { id: 'J2' }, { id: 'J3' }],
+  links: [
+    { id: 'P1', from: 'J1', to: 'J2' },
+    { id: 'P2', from: 'J2', to: 'J3' },
+  ],
+}
+
+describe('la escala sale de los datos, no de un máximo escrito a mano', () => {
+  it('una red de caudales pequeños reparte todos sus colores', () => {
+    // Con el máximo fijo de 200 L/s que usaba el visor retirado, una red que va
+    // de 1 a 5 L/s caía entera en el primer color y no se distinguía nada.
+    const escala = construirEscala('caudal', RED, {
+      link_results: { P1: { flowrate: 1 }, P2: { flowrate: 5 } },
+    })!
+
+    expect(escala.min).toBe(1)
+    expect(escala.max).toBe(5)
+    expect(escala.color(1)).not.toBe(escala.color(5))
+  })
+
+  it('una red de caudales enormes tampoco satura', () => {
+    const escala = construirEscala('caudal', RED, {
+      link_results: { P1: { flowrate: 500 }, P2: { flowrate: 4000 } },
+    })!
+
+    expect(escala.max).toBe(4000)
+    expect(escala.color(500)).not.toBe(escala.color(4000))
+  })
+
+  it('el caudal negativo se colorea por su magnitud, no por su signo', () => {
+    const escala = construirEscala('caudal', RED, {
+      link_results: { P1: { flowrate: -40 }, P2: { flowrate: 40 } },
+    })!
+
+    expect(escala.min).toBe(40)
+    expect(escala.color(-40)).toBe(escala.color(40))
+  })
+
+  it('la leyenda declara los tramos reales de la red', () => {
+    const escala = construirEscala('velocidad', RED, {
+      link_results: { P1: { velocity: 0 }, P2: { velocity: 2 } },
+    })!
+
+    expect(escala.leyenda).toHaveLength(5)
+    expect(escala.leyenda[0].etiqueta).toContain('m/s')
+    expect(escala.absoluta).toBe(false)
+  })
+})
+
+describe('la presión es la excepción, y a propósito', () => {
+  it('usa cortes absolutos de servicio, no el rango de la red', () => {
+    // Escalar la presión al máximo de cada modelo escondería justamente lo que
+    // hay que ver: qué nudos quedan por debajo del mínimo de servicio.
+    const escala = construirEscala('presion', RED, {
+      node_results: { J1: { pressure: 5 }, J2: { pressure: 45 }, J3: { pressure: 90 } },
+    })!
+
+    expect(escala.absoluta).toBe(true)
+    expect(escala.color(5)).toBe('#DC2626')
+    expect(escala.color(45)).toBe('#3B82F6')
+    expect(escala.color(90)).toBe('#F97316')
+  })
+
+  it('una red entera con presión buena no pinta ningún nudo en rojo', () => {
+    const escala = construirEscala('presion', RED, {
+      node_results: { J1: { pressure: 30 }, J2: { pressure: 40 }, J3: { pressure: 50 } },
+    })!
+    expect([30, 40, 50].map(escala.color)).toEqual(['#3B82F6', '#3B82F6', '#3B82F6'])
+  })
+})
+
+describe('casos límite', () => {
+  it('sin resultados no hay escala que construir', () => {
+    expect(construirEscala('caudal', RED, null)).toBeNull()
+    expect(construirEscala('ninguna', RED, { link_results: {} })).toBeNull()
+  })
+
+  it('un parámetro que la simulación no trae no inventa una escala', () => {
+    expect(construirEscala('velocidad', RED, { node_results: { J1: { pressure: 10 } } })).toBeNull()
+  })
+
+  it('todos los valores iguales dan un color y una leyenda con ese valor', () => {
+    const escala = construirEscala('demanda', RED, {
+      node_results: { J1: { demand: 2 }, J2: { demand: 2 }, J3: { demand: 2 } },
+    })!
+
+    expect(escala.min).toBe(escala.max)
+    expect(escala.leyenda).toHaveLength(1)
+    expect(escala.leyenda[0].etiqueta).toContain('2.00 L/s')
+    expect(escala.color(2)).toBeTruthy()
+  })
+
+  it('un elemento sin dato en ese paso se queda sin color, no con uno inventado', () => {
+    const escala = construirEscala('caudal', RED, {
+      link_results: { P1: { flowrate: 10 }, P2: { flowrate: 20 } },
+    })!
+    expect(escala.color(undefined)).toBeNull()
+  })
+
+  it('lee el paso pedido cuando los resultados vienen como serie', () => {
+    const escala = construirEscala(
+      'velocidad',
+      RED,
+      { link_results: { P1: { velocity: [0.1, 3] }, P2: { velocity: [0.2, 4] } } },
+      1
+    )!
+    expect(escala.min).toBe(3)
+    expect(escala.max).toBe(4)
+  })
+})

--- a/src/services/network/simbologia.ts
+++ b/src/services/network/simbologia.ts
@@ -1,0 +1,183 @@
+/**
+ * Simbología: qué magnitud colorea la red y con qué escala (#45, rescate de #37).
+ *
+ * Los dos visores que se retiraron ofrecían más parámetros que el canónico
+ * —presión, demanda, caudal y velocidad—, y esa capacidad sí merecía volver. Lo
+ * que no vuelve es cómo la calculaban: sus escalas eran máximos fijos escritos a
+ * mano (caudal 0-200 L/s, velocidad 0-2 m/s, demanda 0-50 L/s). Es el mismo
+ * defecto que los husos codificados del #48: funciona con las redes con las que
+ * se probó y satura en el color más alto para cualquier red mayor.
+ *
+ * Aquí la escala sale de los datos del paso que se está mostrando.
+ */
+
+import { valorEnPaso, type DatosRed, type ResultadosSimulacion } from './topologia'
+
+export type Simbologia = 'ninguna' | 'presion' | 'demanda' | 'caudal' | 'velocidad'
+
+export interface TramoLeyenda {
+  color: string
+  /** Texto ya formateado para la leyenda. */
+  etiqueta: string
+}
+
+export interface Escala {
+  parametro: Exclude<Simbologia, 'ninguna'>
+  /** Sobre qué se aplica el color. */
+  aplicaA: 'nudos' | 'tramos'
+  unidad: string
+  min: number
+  max: number
+  /** `true` cuando los cortes son absolutos y no dependen de la red. */
+  absoluta: boolean
+  color: (valor: number | undefined) => string | null
+  leyenda: TramoLeyenda[]
+}
+
+const PARAMETROS: Record<Exclude<Simbologia, 'ninguna'>, {
+  aplicaA: 'nudos' | 'tramos'
+  clave: string
+  unidad: string
+  rampa: string[]
+}> = {
+  presion: { aplicaA: 'nudos', clave: 'pressure', unidad: 'm', rampa: [] },
+  demanda: {
+    aplicaA: 'nudos',
+    clave: 'demand',
+    unidad: 'L/s',
+    rampa: ['#f0f0f0', '#9ecae1', '#6baed6', '#3182bd', '#08519c'],
+  },
+  caudal: {
+    aplicaA: 'tramos',
+    clave: 'flowrate',
+    unidad: 'L/s',
+    rampa: ['#fee5d9', '#fcae91', '#fb6a4a', '#de2d26', '#a50f15'],
+  },
+  velocidad: {
+    aplicaA: 'tramos',
+    clave: 'velocity',
+    unidad: 'm/s',
+    rampa: ['#f7fbff', '#deebf7', '#c6dbef', '#6baed6', '#2171b5'],
+  },
+}
+
+/**
+ * Cortes de presión, los únicos absolutos. La presión tiene un criterio de
+ * servicio que no depende de la red —por debajo de 20 m el suministro es
+ * insuficiente—, así que escalarla al máximo de cada modelo escondería
+ * justamente lo que hay que ver. El resto de magnitudes no tienen un umbral
+ * universal y se escalan a los datos.
+ */
+const PRESION_BAJA = 20
+const PRESION_ALTA = 80
+const COLOR_PRESION = { baja: '#DC2626', normal: '#3B82F6', alta: '#F97316' }
+
+function formatear(valor: number, unidad: string): string {
+  const decimales = Math.abs(valor) >= 100 ? 0 : Math.abs(valor) >= 10 ? 1 : 2
+  return `${valor.toFixed(decimales)} ${unidad}`
+}
+
+/** Valores del parámetro en el paso pedido, para todos los elementos. */
+function valores(
+  datos: DatosRed,
+  resultados: ResultadosSimulacion,
+  parametro: Exclude<Simbologia, 'ninguna'>,
+  paso: number
+): number[] {
+  const { aplicaA, clave } = PARAMETROS[parametro]
+  const elementos = aplicaA === 'nudos' ? datos.nodes : datos.links
+  const tabla = aplicaA === 'nudos' ? resultados.node_results : resultados.link_results
+  if (!tabla) return []
+
+  const salida: number[] = []
+  for (const e of elementos) {
+    const v = valorEnPaso(tabla[e.id]?.[clave], paso)
+    // El caudal circula en los dos sentidos; para colorear importa la magnitud.
+    if (typeof v === 'number' && Number.isFinite(v)) salida.push(Math.abs(v))
+  }
+  return salida
+}
+
+export function construirEscala(
+  simbologia: Simbologia,
+  datos: DatosRed | null | undefined,
+  resultados: ResultadosSimulacion | null | undefined,
+  paso = 0
+): Escala | null {
+  if (simbologia === 'ninguna' || !datos || !resultados) return null
+
+  const def = PARAMETROS[simbologia]
+
+  if (simbologia === 'presion') {
+    const v = valores(datos, resultados, 'presion', paso)
+    if (v.length === 0) return null
+    return {
+      parametro: 'presion',
+      aplicaA: 'nudos',
+      unidad: def.unidad,
+      min: Math.min(...v),
+      max: Math.max(...v),
+      absoluta: true,
+      color: valor => {
+        if (typeof valor !== 'number' || !Number.isFinite(valor)) return null
+        if (valor < PRESION_BAJA) return COLOR_PRESION.baja
+        if (valor > PRESION_ALTA) return COLOR_PRESION.alta
+        return COLOR_PRESION.normal
+      },
+      leyenda: [
+        { color: COLOR_PRESION.baja, etiqueta: `Menos de ${PRESION_BAJA} m` },
+        { color: COLOR_PRESION.normal, etiqueta: `Entre ${PRESION_BAJA} y ${PRESION_ALTA} m` },
+        { color: COLOR_PRESION.alta, etiqueta: `Más de ${PRESION_ALTA} m` },
+      ],
+    }
+  }
+
+  const v = valores(datos, resultados, simbologia, paso)
+  if (v.length === 0) return null
+
+  const min = Math.min(...v)
+  const max = Math.max(...v)
+  const rampa = def.rampa
+  // Una red con todos los valores iguales —o un solo elemento— no tiene rango
+  // que repartir: se pinta de un color y la leyenda dice el valor, en lugar de
+  // dividir por cero y devolver colores al azar.
+  const rango = max - min
+
+  const color = (valor: number | undefined): string | null => {
+    if (typeof valor !== 'number' || !Number.isFinite(valor)) return null
+    if (rango === 0) return rampa[rampa.length - 1]
+    const normalizado = (Math.abs(valor) - min) / rango
+    const indice = Math.min(rampa.length - 1, Math.floor(normalizado * rampa.length))
+    return rampa[Math.max(0, indice)]
+  }
+
+  const leyenda: TramoLeyenda[] =
+    rango === 0
+      ? [{ color: rampa[rampa.length - 1], etiqueta: formatear(min, def.unidad) }]
+      : rampa.map((c, i) => ({
+          color: c,
+          etiqueta: `${formatear(min + (rango * i) / rampa.length, def.unidad)} – ${formatear(
+            min + (rango * (i + 1)) / rampa.length,
+            def.unidad
+          )}`,
+        }))
+
+  return {
+    parametro: simbologia,
+    aplicaA: def.aplicaA,
+    unidad: def.unidad,
+    min,
+    max,
+    absoluta: false,
+    color,
+    leyenda,
+  }
+}
+
+export const ETIQUETAS_SIMBOLOGIA: Array<{ valor: Simbologia; texto: string }> = [
+  { valor: 'ninguna', texto: 'Por tipo de elemento' },
+  { valor: 'presion', texto: 'Presión en los nudos' },
+  { valor: 'demanda', texto: 'Demanda en los nudos' },
+  { valor: 'caudal', texto: 'Caudal en los tramos' },
+  { valor: 'velocidad', texto: 'Velocidad en los tramos' },
+]

--- a/src/services/network/topologia.ts
+++ b/src/services/network/topologia.ts
@@ -1,3 +1,5 @@
+import { nudoVisible, tramoVisible, type CapasVisibles } from './capas'
+
 /**
  * Grafo topológico de la red para el visor de vis-network (#37).
  *
@@ -169,16 +171,28 @@ export function construirGrafo(
    * pinten la misma magnitud: si el esquema coloreara siempre por presión
    * mientras el panel dice «velocidad», estaría mintiendo (#37).
    */
-  escala?: { aplicaA: 'nudos' | 'tramos'; parametro: string; color: (v: number | undefined) => string | null } | null
+  escala?: { aplicaA: 'nudos' | 'tramos'; parametro: string; color: (v: number | undefined) => string | null } | null,
+  /**
+   * Tipos de elemento visibles. En el esquema, ocultar un tipo de nudo se lleva
+   * tambien los tramos que lo tocan: un tramo necesita sus dos extremos para
+   * poder dibujarse. En el mapa no pasa, porque alli cada tramo tiene su propia
+   * geometria.
+   */
+  capas?: CapasVisibles | null
 ): GrafoRed {
   if (!datos || datos.nodes.length === 0) {
     return { nodes: [], edges: [], usaFisica: false, motivo: 'La red no tiene nudos.' }
   }
 
-  const conCoordenadas = tieneCoordenadasUtiles(datos.nodes)
-  const proyectar = conCoordenadas ? escalar(datos.nodes) : null
+  const nodosVisibles = capas ? datos.nodes.filter(n => nudoVisible(n, capas)) : datos.nodes
+  if (nodosVisibles.length === 0) {
+    return { nodes: [], edges: [], usaFisica: false, motivo: 'No hay ningún tipo de elemento visible.' }
+  }
 
-  const nodes: NodoGrafo[] = datos.nodes.map(n => {
+  const conCoordenadas = tieneCoordenadasUtiles(nodosVisibles)
+  const proyectar = conCoordenadas ? escalar(nodosVisibles) : null
+
+  const nodes: NodoGrafo[] = nodosVisibles.map(n => {
     const tipo = String(n.type ?? 'junction')
     const estilo = COLOR_POR_TIPO[tipo] ?? COLOR_POR_TIPO.junction
 
@@ -210,10 +224,10 @@ export function construirGrafo(
 
   // Un tramo que apunta a un nudo que no existe rompe vis-network en lugar de
   // dibujarse a medias, asi que se descarta: pasa con .inp recortados a mano.
-  const ids = new Set(datos.nodes.map(n => n.id))
+  const ids = new Set(nodosVisibles.map(n => n.id))
 
   const edges: TramoGrafo[] = datos.links
-    .filter(l => ids.has(l.from) && ids.has(l.to))
+    .filter(l => (!capas || tramoVisible(l, capas)) && ids.has(l.from) && ids.has(l.to))
     .map(l => {
       const tipo = String(l.type ?? 'pipe')
       const estilo = COLOR_POR_TIPO_TRAMO[tipo] ?? COLOR_POR_TIPO_TRAMO.pipe

--- a/src/services/network/topologia.ts
+++ b/src/services/network/topologia.ts
@@ -163,7 +163,13 @@ function colorPorPresion(presion: number | undefined, base: string): string {
 export function construirGrafo(
   datos: DatosRed | null | undefined,
   resultados?: ResultadosSimulacion | null,
-  paso = 0
+  paso = 0,
+  /**
+   * Escala de color vigente. Se pasa desde fuera para que el esquema y el mapa
+   * pinten la misma magnitud: si el esquema coloreara siempre por presión
+   * mientras el panel dice «velocidad», estaría mintiendo (#37).
+   */
+  escala?: { aplicaA: 'nudos' | 'tramos'; parametro: string; color: (v: number | undefined) => string | null } | null
 ): GrafoRed {
   if (!datos || datos.nodes.length === 0) {
     return { nodes: [], edges: [], usaFisica: false, motivo: 'La red no tiene nudos.' }
@@ -178,6 +184,10 @@ export function construirGrafo(
 
     const res = resultados?.node_results?.[n.id]
     const presion = valorEnPaso(res?.pressure, paso)
+    const porEscala =
+      escala?.aplicaA === 'nudos'
+        ? escala.color(valorEnPaso(res?.[escala.parametro === 'presion' ? 'pressure' : 'demand'], paso))
+        : null
 
     const detalles = [`${tipo}: ${n.label ?? n.id}`]
     if (typeof n.elevation === 'number') detalles.push(`Cota: ${n.elevation}`)
@@ -191,7 +201,7 @@ export function construirGrafo(
       id: n.id,
       label: String(n.label ?? n.id),
       title: detalles.join('\n'),
-      color: colorPorPresion(presion, estilo.color),
+      color: porEscala ?? colorPorPresion(presion, estilo.color),
       shape: estilo.shape,
       size: estilo.size,
       ...(xy ? { x: xy[0], y: xy[1], fixed: true } : {}),
@@ -211,6 +221,11 @@ export function construirGrafo(
       const res = resultados?.link_results?.[l.id]
       const caudal = valorEnPaso(res?.flowrate, paso)
       const velocidad = valorEnPaso(res?.velocity, paso)
+
+      const porEscalaTramo =
+        escala?.aplicaA === 'tramos'
+          ? escala.color(valorEnPaso(res?.[escala.parametro === 'caudal' ? 'flowrate' : 'velocity'], paso))
+          : null
 
       const detalles = [`${tipo}: ${l.label ?? l.id}`]
       if (typeof l.length === 'number') detalles.push(`Longitud: ${l.length}`)
@@ -232,7 +247,7 @@ export function construirGrafo(
         from: invertido ? l.to : l.from,
         to: invertido ? l.from : l.to,
         title: detalles.join('\n'),
-        color: estilo.color,
+        color: porEscalaTramo ?? estilo.color,
         width: grosor,
         dashes: tipo === 'valve' && String(l.status ?? '').toUpperCase() === 'CLOSED',
         ...(typeof caudal === 'number' || tipo === 'pump' ? { arrows: 'to' } : {}),


### PR DESCRIPTION
## #45 — El reloj no era el de la simulación

El eje temporal salía de dos constantes escritas a mano:

```js
const baseTime = new Date('2025-10-09T00:00:00')   // una fecha inventada
const hoursToAdd = visualizationSettings.timeStep   // una hora fija por paso
```

Para un modelo que reporta cada 15 minutos, el reloj **avanzaba cuatro veces más rápido que la simulación**, y la fecha no correspondía a nada (se mostraba con zona horaria australiana). Las marcas del eje eran `00:00`–`22:00` fijas, al margen de la duración y del paso del modelo.

El dato bueno estaba delante todo el tiempo: `timestamps` es el índice de los resultados de WNTR **en segundos**, y el `.inp` declara su hora de inicio en `start_clocktime`. Criterio del Ing. Luis Mora: «eso se define en EPANET; Boorie sólo debe leer ese paso temporal».

### Decisiones

- **Sin hora declarada, tiempo transcurrido con signo (`+04:15:00`).** Un `start_clocktime` a cero no significa «medianoche», significa que nadie puso hora; enseñar `00:15` sería indistinguible de una hora real.
- **No se añade fecha de proyecto configurable.** El criterio la menciona pero el de Luis Mora la contradice y manda: el valor lo define el `.inp`. Añadir el campo sería inventar un dato que el modelo ya trae o deliberadamente no trae.
- **Reproducción por reloj real**, no `setInterval`. El bucle anterior sumaba un paso cada `1000/velocidad` ms, así que cada repintado lento acumulaba retraso y la velocidad efectiva dependía de lo cargada que estuviera la red.
- **Un modelo de un solo paso no enseña reproductor** (`timestamps = [0]` en modo `single`).
- **La duración se lee del último paso**, no de la opción declarada: una simulación cortada debe decir lo que duró.

### El repintado, que era la otra mitad del bug

`addNetworkToMap` no tenía `currentTimeStep` entre sus dependencias: la simbología se calculaba con el paso capturado al crear el callback, así que **mover la barra cambiaba el reloj y no repintaba el mapa**. Estaba anotado como aviso de `exhaustive-deps` desde antes. Las escalas de color se conservan, como pedía Luis Mora.

### El hook único

El issue pedía extraerlo y consumirlo desde los cinco componentes que duplicaban la lógica. Tres de esos cinco ya desaparecieron con #37 (eran visores muertos); quedan la barra y el panel, y los dos leen de `useSimulationTimeline`.

## #46 — Pantallas que no explicaban qué faltaba

La auditoría encontró **un hueco concreto** y el resto de las vistas cumpliendo.

**El hueco:** el aviso se resolvía por *vista*, y «Simulaciones» y «Red WNTR» llevan a la misma vista aunque sólo la primera exija red —la de red no la exige a propósito: es donde se importa el `.inp`—. Quien pulsaba «Simulaciones» sin red aterrizaba en la pantalla de importar **sin que nada dijera qué había pasado**. Ahora el aviso se resuelve por el ítem pulsado: «"Simulaciones" necesita una red cargada», con su botón.

**Lo que ya estaba bien**, recorriendo la aplicación: sin proyecto abre en Proyectos con el menú diciéndolo; la Calculadora funciona sin proyecto (criterio explícito de Luis Mora); el chat general y el Wisdom Center funcionan; Red WNTR con proyecto y sin red muestra el área de importar.

Se mantiene la decisión de #33 de que los ítems bloqueados sigan siendo pulsables: bloquearlos dejaría al usuario sin forma de llegar a la pantalla que le explica qué falta. Lo que se arregla es que esa pantalla lo explique.

## Verificación

**256 tests** (eran 240); typecheck y lint limpios. Los 16 nuevos cubren el caso exacto del criterio de aceptación —24 h con paso de 15 min, comprobando los **97 pasos uno a uno**—, un paso no redondo (7 min), la reconstrucción del eje sin `timestamps`, la hora de reloj declarada, el cruce de medianoche y el estado estacionario.

**Comprobado en la aplicación** con `Net3 2.inp` a 24 h y paso de 15 min: la barra dice `+00:00:00 · paso 1 de 97 · cada 15 min · duración 24:00:00 · tiempo transcurrido`, y avanzar cuatro pasos da `+01:00:00 · paso 5 de 97` — antes habrían sido cuatro horas. Y el aviso del #46 reproducido y verificado con un proyecto sin redes.

## Fuera de alcance

El acumulado de retraso en el repintado que el #45 dejaba como «revisión adicional pendiente»: la reproducción por reloj real lo elimina como causa, pero no se ha medido el coste de repintar una red grande paso a paso. Si aparece, es rendimiento del mapa, no del eje temporal.

Diseño y decisiones en `docs/TIEMPO_Y_ESTADOS_VACIOS.md`.

Closes #45
Closes #46