### PR TITLE
feat(versionado): historial inmutable de redes y simulaciones (#38)

### DIFF
--- a/backend/services/hydraulic/intercambio.test.ts
+++ b/backend/services/hydraulic/intercambio.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FORMATO,
+  construirPaquete,
+  describirPaquete,
+  sumaDe,
+  validarPaquete,
+  type ContenidoPaquete,
+} from './intercambio'
+
+const RED = {
+  nombre: 'Net3 2.inp',
+  filename: 'Net3 2.inp',
+  versionNumber: 3,
+  changeNote: 'Antes de tocar la impulsión',
+  creadaEl: '2026-03-15T10:00:00.000Z',
+  origen: { networkId: 'n1', versionId: 'v3', proyecto: 'Net3 2' },
+  networkData: { nodes: [{ id: 'J1', elevation: 100 }], links: [] },
+  fileContent: '[JUNCTIONS]\n J1 100\n',
+  coordinateSystem: { type: 'projected', declared_epsg: 'EPSG:32618' },
+  summary: { junctions: 1, pipes: 0 },
+}
+
+const CONTENIDO: ContenidoPaquete = { etiqueta: 'Entrega de marzo', redes: [RED] }
+const META = { generadoPor: 'Boorie 1.12.0', generadoEl: '2026-08-19T20:00:00.000Z' }
+
+const empaquetar = (c: ContenidoPaquete = CONTENIDO) =>
+  JSON.stringify(construirPaquete(c, META))
+
+describe('ida y vuelta', () => {
+  it('un paquete recién construido se valida y conserva lo que llevaba', () => {
+    expect(validarPaquete(empaquetar())).toMatchObject({
+      ok: true,
+      paquete: {
+        formato: FORMATO,
+        contenido: {
+          redes: [{ nombre: 'Net3 2.inp', fileContent: RED.fileContent, origen: { versionId: 'v3' } }],
+        },
+      },
+    })
+  })
+
+  it('sobrevive a la ida y vuelta por fichero con campos opcionales vacíos', () => {
+    // El fallo que se vio al probarlo de verdad: `JSON.stringify` descarta las
+    // claves con `undefined`, así que al releer el paquete esa clave ya no está
+    // y la suma calculada sobre el objeto original no cuadraba. Una red sin
+    // sistema de coordenadas declarado no se podía importar en ninguna parte.
+    const pelada = {
+      ...RED,
+      changeNote: undefined,
+      coordinateSystem: undefined,
+      origen: { networkId: 'n1', versionId: 'v1', proyecto: undefined },
+    }
+    const texto = JSON.stringify(construirPaquete({ redes: [pelada] }, META))
+
+    expect(validarPaquete(texto).ok).toBe(true)
+  })
+
+  it('la suma no depende del orden en que se serialicen las claves', () => {
+    // Sin esto, dos serializaciones del mismo contenido darían sumas distintas y
+    // la comprobación fallaría por un motivo que no es el que busca.
+    const a = { etiqueta: 'x', redes: [{ ...RED }] }
+    const b = { redes: [{ ...RED }], etiqueta: 'x' } as ContenidoPaquete
+    expect(sumaDe(a)).toBe(sumaDe(b))
+  })
+
+  it('describe lo que trae antes de importarlo', () => {
+    const paquete = construirPaquete(CONTENIDO, META)
+    expect(describirPaquete(paquete)).toBe('«Entrega de marzo», 1 red, exportado por Boorie 1.12.0')
+  })
+})
+
+describe('lo que el formato tiene que rechazar', () => {
+  it('un fichero que no es JSON', () => {
+    expect(validarPaquete('esto no es un paquete')).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/no se puede leer como JSON/i),
+    })
+  })
+
+  it('un JSON cualquiera que no dice ser un paquete', () => {
+    expect(validarPaquete('{"algo": 1}')).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/no declara ser un paquete/i),
+    })
+  })
+
+  it('un paquete de un formato posterior: lo dice, no lo lee a medias', () => {
+    const p = JSON.parse(empaquetar())
+    p.formato = 'boorie.red/9'
+
+    expect(validarPaquete(JSON.stringify(p))).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/Actualiza Boorie/i),
+    })
+  })
+
+  it('un paquete sin redes', () => {
+    expect(validarPaquete(empaquetar({ redes: [] }))).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/ninguna red/i),
+    })
+  })
+
+  it('una red a la que le falta el .inp', () => {
+    const sinInp = { ...RED } as Partial<typeof RED>
+    delete sinInp.fileContent
+    expect(validarPaquete(empaquetar({ redes: [sinInp as never] }))).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/fileContent/),
+    })
+  })
+
+  it('un fichero manipulado a mano', () => {
+    // El caso que justifica la suma: alguien cambia un diámetro en el JSON y la
+    // red importada sería silenciosamente distinta de la que se exportó.
+    const p = JSON.parse(empaquetar())
+    p.contenido.redes[0].networkData.nodes[0].elevation = 999
+
+    expect(validarPaquete(JSON.stringify(p))).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/no coincide con su suma/i),
+    })
+  })
+
+  it('un fichero truncado a mitad de copia', () => {
+    const texto = empaquetar()
+    expect(validarPaquete(texto.slice(0, Math.floor(texto.length * 0.8))).ok).toBe(false)
+  })
+
+  it('un paquete al que le han quitado la suma', () => {
+    const p = JSON.parse(empaquetar())
+    delete p.suma
+    expect(validarPaquete(JSON.stringify(p))).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/suma de comprobación/i),
+    })
+  })
+})

--- a/backend/services/hydraulic/intercambio.ts
+++ b/backend/services/hydraulic/intercambio.ts
@@ -1,0 +1,153 @@
+/**
+ * Formato de intercambio de versiones entre instalaciones de Boorie (#38).
+ *
+ * Un paquete lleva uno o varios estados de red congelados —los mismos que guarda
+ * el historial— con lo necesario para reconstruirlos en otra máquina: los datos
+ * de la red, su `.inp`, su sistema de coordenadas y de dónde salieron.
+ *
+ * Dos cosas que el formato hace a propósito:
+ *
+ * 1. **Lleva su propia versión.** Un lector futuro tiene que poder reconocer un
+ *    paquete que no entiende y decirlo, en lugar de leerlo a medias.
+ * 2. **Lleva una suma de comprobación.** Un fichero truncado a mitad de copia o
+ *    editado a mano produce una red silenciosamente distinta de la que se exportó,
+ *    y eso en un modelo hidráulico no se nota hasta que alguien toma una decisión
+ *    con él.
+ */
+
+import { createHash } from 'node:crypto'
+
+/** Cambiar esto sólo cuando el formato deje de ser compatible hacia atrás. */
+export const FORMATO = 'boorie.red/1'
+
+export interface RedExportada {
+  nombre: string
+  filename: string
+  versionNumber: number
+  changeNote?: string
+  creadaEl: string
+  /** De dónde salió, para poder rastrearla sin reutilizar sus identificadores. */
+  origen: {
+    networkId: string
+    versionId: string
+    proyecto?: string
+  }
+  networkData: unknown
+  fileContent: string
+  coordinateSystem?: unknown
+  summary: unknown
+}
+
+export interface ContenidoPaquete {
+  /** Etiqueta del conjunto, p. ej. el nombre de la instantánea. */
+  etiqueta?: string
+  redes: RedExportada[]
+}
+
+export interface Paquete {
+  formato: string
+  generadoPor: string
+  generadoEl: string
+  suma: string
+  contenido: ContenidoPaquete
+}
+
+/**
+ * Suma del contenido. Se calcula sobre el JSON con las claves ordenadas: sin eso,
+ * dos serializaciones del mismo contenido darían sumas distintas y la
+ * comprobación fallaría por un motivo que no es el que busca.
+ */
+export function sumaDe(contenido: ContenidoPaquete): string {
+  return createHash('sha256').update(estable(contenido)).digest('hex')
+}
+
+function estable(valor: unknown): string {
+  if (valor === null || typeof valor !== 'object') return JSON.stringify(valor) ?? 'null'
+  if (Array.isArray(valor)) return `[${valor.map(estable).join(',')}]`
+
+  const objeto = valor as Record<string, unknown>
+  // Las claves con `undefined` se descartan, igual que hace `JSON.stringify`.
+  // Contarlas rompía la ida y vuelta: un paquete sin sistema de coordenadas se
+  // guardaba sin esa clave y, al releerlo, la suma ya no cuadraba con la del
+  // objeto que la tenía puesta a `undefined`.
+  const claves = Object.keys(objeto).filter(k => objeto[k] !== undefined).sort()
+  return `{${claves.map(k => `${JSON.stringify(k)}:${estable(objeto[k])}`).join(',')}}`
+}
+
+export function construirPaquete(
+  contenido: ContenidoPaquete,
+  meta: { generadoPor: string; generadoEl: string }
+): Paquete {
+  return {
+    formato: FORMATO,
+    generadoPor: meta.generadoPor,
+    generadoEl: meta.generadoEl,
+    suma: sumaDe(contenido),
+    contenido,
+  }
+}
+
+export type Validacion =
+  | { ok: true; paquete: Paquete }
+  | { ok: false; error: string }
+
+/**
+ * Lee y comprueba un paquete. Devuelve el motivo en lenguaje llano cuando falla,
+ * porque quien importa un fichero que no vale necesita saber si está roto, si es
+ * de otra versión de Boorie o si sencillamente no es un paquete.
+ */
+export function validarPaquete(texto: string): Validacion {
+  let bruto: unknown
+  try {
+    bruto = JSON.parse(texto)
+  } catch {
+    return { ok: false, error: 'El fichero no es un paquete de Boorie: no se puede leer como JSON.' }
+  }
+
+  const p = bruto as Partial<Paquete>
+  if (!p || typeof p !== 'object' || typeof p.formato !== 'string') {
+    return { ok: false, error: 'El fichero no declara ser un paquete de Boorie.' }
+  }
+
+  if (p.formato !== FORMATO) {
+    return {
+      ok: false,
+      error: `Este paquete es del formato «${p.formato}» y esta versión de Boorie lee «${FORMATO}». Actualiza Boorie para abrirlo.`,
+    }
+  }
+
+  const contenido = p.contenido
+  if (!contenido || !Array.isArray(contenido.redes) || contenido.redes.length === 0) {
+    return { ok: false, error: 'El paquete no contiene ninguna red.' }
+  }
+
+  for (const red of contenido.redes) {
+    const falta = ['nombre', 'filename', 'networkData', 'fileContent', 'summary'].find(
+      c => (red as unknown as Record<string, unknown>)[c] === undefined
+    )
+    if (falta) {
+      return { ok: false, error: `Al paquete le falta «${falta}» en la red «${red?.nombre ?? '?'}».` }
+    }
+    if (typeof red.versionNumber !== 'number') {
+      return { ok: false, error: `La red «${red.nombre}» no declara número de versión.` }
+    }
+  }
+
+  if (typeof p.suma !== 'string' || p.suma !== sumaDe(contenido)) {
+    return {
+      ok: false,
+      error:
+        'El contenido no coincide con su suma de comprobación: el fichero se ha copiado a medias o se ha editado. No se importa nada.',
+    }
+  }
+
+  return { ok: true, paquete: p as Paquete }
+}
+
+/** Resumen del paquete para poder enseñar qué trae antes de importarlo. */
+export function describirPaquete(p: Paquete): string {
+  const n = p.contenido.redes.length
+  const redes = n === 1 ? '1 red' : `${n} redes`
+  const etiqueta = p.contenido.etiqueta ? `«${p.contenido.etiqueta}», ` : ''
+  return `${etiqueta}${redes}, exportado por ${p.generadoPor}`
+}

--- a/backend/services/hydraulic/networkVersions.ts
+++ b/backend/services/hydraulic/networkVersions.ts
@@ -13,6 +13,13 @@
 
 import type { PrismaClient } from '@prisma/client'
 import {
+  construirPaquete,
+  describirPaquete,
+  validarPaquete,
+  type ContenidoPaquete,
+  type RedExportada,
+} from './intercambio'
+import {
   RETENCION_POR_DEFECTO,
   compararSimulaciones,
   compararVersiones,
@@ -417,6 +424,146 @@ export class NetworkVersionService {
 
   async borrarSnapshot(snapshotId: string): Promise<void> {
     await this.prisma.projectSnapshot.delete({ where: { id: snapshotId } })
+  }
+
+  // --- Intercambio entre instalaciones ---------------------------------
+
+  private async empaquetarVersiones(
+    versionIds: string[],
+    etiqueta: string | undefined,
+    generadoPor: string
+  ): Promise<string> {
+    const versiones = await this.prisma.networkVersion.findMany({
+      where: { id: { in: versionIds } },
+      include: { network: { select: { name: true, filename: true, project: { select: { name: true } } } } },
+    })
+
+    const redes: RedExportada[] = versiones.map(v => ({
+      nombre: (v as any).network.name,
+      filename: (v as any).network.filename,
+      versionNumber: v.versionNumber,
+      changeNote: v.changeNote ?? undefined,
+      creadaEl: v.createdAt.toISOString(),
+      origen: {
+        networkId: v.networkId,
+        versionId: v.id,
+        proyecto: (v as any).network.project?.name,
+      },
+      networkData: JSON.parse(v.networkData),
+      fileContent: v.fileContent,
+      coordinateSystem: v.coordinateSystem ? JSON.parse(v.coordinateSystem) : undefined,
+      summary: JSON.parse(v.summary),
+    }))
+
+    const contenido: ContenidoPaquete = { etiqueta, redes }
+    return JSON.stringify(
+      construirPaquete(contenido, { generadoPor, generadoEl: new Date().toISOString() }),
+      null,
+      2
+    )
+  }
+
+  /** Exporta una versión suelta. */
+  async exportarVersion(versionId: string, generadoPor: string): Promise<string> {
+    return this.empaquetarVersiones([versionId], undefined, generadoPor)
+  }
+
+  /** Exporta el conjunto que congeló una instantánea de proyecto. */
+  async exportarSnapshot(snapshotId: string, generadoPor: string): Promise<string> {
+    const snapshot = await this.prisma.projectSnapshot.findUnique({
+      where: { id: snapshotId },
+      include: { entries: true },
+    })
+    if (!snapshot) throw new Error('Instantánea no encontrada')
+
+    return this.empaquetarVersiones(
+      snapshot.entries.map(e => e.networkVersionId),
+      snapshot.label,
+      generadoPor
+    )
+  }
+
+  /**
+   * Importa un paquete en un proyecto.
+   *
+   * Los identificadores del paquete **no se reutilizan**: en la instalación de
+   * destino podrían chocar con registros que no tienen nada que ver. Se guardan
+   * como procedencia dentro de la nota de la versión, que es lo que sirve para
+   * rastrearla, y todo lo demás nace con identificadores nuevos.
+   *
+   * Una red que ya existe con ese nombre recibe una versión más, en lugar de
+   * duplicarse: es la misma semántica que reimportar un `.inp`.
+   */
+  async importarPaquete(
+    projectId: string,
+    texto: string
+  ): Promise<{ resumen: string; creadas: string[]; versionadas: string[] }> {
+    // Sin `strict` no hay estrechamiento de la unión, así que el motivo se saca
+    // antes de comprobar: leerlo del tipo ancho es más claro que un cast.
+    const validacion = validarPaquete(texto)
+    if (!validacion.ok) {
+      throw new Error((validacion as { error: string }).error)
+    }
+
+    const creadas: string[] = []
+    const versionadas: string[] = []
+
+    for (const red of validacion.paquete.contenido.redes) {
+      const nota = [
+        `Importada de ${validacion.paquete.generadoPor}`,
+        red.origen.proyecto ? `proyecto «${red.origen.proyecto}»` : null,
+        `versión ${red.versionNumber} de origen`,
+        red.changeNote ? `«${red.changeNote}»` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+
+      const existente = await this.prisma.hydraulicNetwork.findFirst({
+        where: { projectId, name: red.nombre, isActive: true },
+        select: { id: true },
+      })
+
+      const datos = {
+        networkData: JSON.stringify(red.networkData),
+        fileContent: red.fileContent,
+        coordinateSystem: red.coordinateSystem ? JSON.stringify(red.coordinateSystem) : null,
+        summary: JSON.stringify(red.summary),
+      }
+
+      if (existente) {
+        // El estado que había se congela antes de que la importación lo pise.
+        await this.crearVersion(existente.id, {
+          origen: 'importacion',
+          changeNote: `Estado anterior a importar «${red.nombre}»`,
+        })
+        await this.prisma.hydraulicNetwork.update({
+          where: { id: existente.id },
+          data: { ...datos, updatedAt: new Date() },
+        })
+        await this.crearVersion(existente.id, { origen: 'importacion', changeNote: nota })
+        versionadas.push(red.nombre)
+      } else {
+        const nueva = await this.prisma.hydraulicNetwork.create({
+          data: {
+            projectId,
+            name: red.nombre,
+            filename: red.filename,
+            description: `Importada de otra instalación de Boorie`,
+            ...datos,
+            version: '1.0',
+          },
+        })
+        await this.crearVersion(nueva.id, { origen: 'importacion', changeNote: nota })
+        creadas.push(red.nombre)
+      }
+    }
+
+    const partes = [
+      creadas.length ? `${creadas.length} red${creadas.length === 1 ? '' : 'es'} nueva${creadas.length === 1 ? '' : 's'}` : null,
+      versionadas.length ? `${versionadas.length} actualizada${versionadas.length === 1 ? '' : 's'} con una versión más` : null,
+    ].filter(Boolean)
+
+    return { resumen: `${describirPaquete(validacion.paquete)}. ${partes.join(' y ')}.`, creadas, versionadas }
   }
 
   /**

--- a/backend/services/hydraulic/networkVersions.ts
+++ b/backend/services/hydraulic/networkVersions.ts
@@ -14,10 +14,13 @@
 import type { PrismaClient } from '@prisma/client'
 import {
   RETENCION_POR_DEFECTO,
+  compararSimulaciones,
   compararVersiones,
   resumirDiferencia,
+  resumirDiferenciaSimulaciones,
   versionesAPodar,
   type DiferenciaRed,
+  type DiferenciaSimulaciones,
   type PoliticaRetencion,
 } from './versionado'
 
@@ -252,10 +255,23 @@ export class NetworkVersionService {
   async podar(networkId: string, politica: PoliticaRetencion = RETENCION_POR_DEFECTO): Promise<number> {
     const versiones = await this.prisma.networkVersion.findMany({
       where: { networkId },
-      select: { id: true, versionNumber: true, marcada: true },
+      select: {
+        id: true,
+        versionNumber: true,
+        marcada: true,
+        _count: { select: { enSnapshots: true } },
+      },
     })
 
-    const sobran = versionesAPodar(versiones, politica)
+    const sobran = versionesAPodar(
+      versiones.map(v => ({
+        id: v.id,
+        versionNumber: v.versionNumber,
+        marcada: v.marcada,
+        enSnapshot: ((v as any)._count?.enSnapshots ?? 0) > 0,
+      })),
+      politica
+    )
     if (sobran.length === 0) return 0
 
     await this.prisma.networkVersion.deleteMany({ where: { id: { in: sobran } } })
@@ -283,6 +299,124 @@ export class NetworkVersionService {
   /** Poda aplicando la política guardada. Devuelve cuántas versiones retiró. */
   async podarSegunAjustes(networkId: string): Promise<number> {
     return this.podar(networkId, await this.politicaVigente())
+  }
+
+  /**
+   * Compara dos ejecuciones de simulación sobre el mismo paso.
+   *
+   * Tiene sentido entre versiones distintas de la red —«¿qué le hizo a las
+   * presiones cambiar ese diámetro?»— y también entre dos ejecuciones de la
+   * misma versión con parámetros distintos.
+   */
+  async compararSimulaciones(
+    runA: string,
+    runB: string,
+    paso = 0
+  ): Promise<{ diferencia: DiferenciaSimulaciones; resumen: string }> {
+    const [a, b] = await Promise.all([
+      this.prisma.simulationRun.findUnique({ where: { id: runA } }),
+      this.prisma.simulationRun.findUnique({ where: { id: runB } }),
+    ])
+    if (!a || !b) throw new Error('Simulación no encontrada')
+
+    const diferencia = compararSimulaciones(JSON.parse(a.results), JSON.parse(b.results), paso)
+    return { diferencia, resumen: resumirDiferenciaSimulaciones(diferencia) }
+  }
+
+  // --- Instantáneas de proyecto ---------------------------------------
+
+  /**
+   * Congela el proyecto entero: qué versión de cada red estaba vigente.
+   *
+   * No copia datos, apunta a versiones que ya son inmutables. Las redes que aún
+   * no tengan versión reciben una en el momento, porque una instantánea con
+   * agujeros no serviría para responder «cómo estaba el proyecto».
+   */
+  async crearSnapshot(
+    projectId: string,
+    datos: { label: string; note?: string; author?: string }
+  ): Promise<{ id: string; label: string; redes: number }> {
+    const redes = await this.prisma.hydraulicNetwork.findMany({
+      where: { projectId, isActive: true },
+      select: { id: true },
+    })
+
+    const versionIds: string[] = []
+    for (const red of redes) {
+      const ultima = await this.prisma.networkVersion.findFirst({
+        where: { networkId: red.id },
+        orderBy: { versionNumber: 'desc' },
+        select: { id: true },
+      })
+      versionIds.push(ultima ? ultima.id : (await this.crearVersion(red.id, {
+        origen: 'manual',
+        changeNote: `Estado incluido en «${datos.label}»`,
+      })).id)
+    }
+
+    const snapshot = await this.prisma.projectSnapshot.create({
+      data: {
+        projectId,
+        label: datos.label,
+        note: datos.note ?? null,
+        author: datos.author ?? null,
+        entries: { create: versionIds.map(networkVersionId => ({ networkVersionId })) },
+      },
+    })
+
+    return { id: snapshot.id, label: snapshot.label, redes: versionIds.length }
+  }
+
+  async listarSnapshots(projectId: string) {
+    const snapshots = await this.prisma.projectSnapshot.findMany({
+      where: { projectId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        entries: {
+          include: {
+            networkVersion: {
+              select: { id: true, versionNumber: true, networkId: true, network: { select: { name: true } } },
+            },
+          },
+        },
+      },
+    })
+
+    return snapshots.map(s => ({
+      id: s.id,
+      label: s.label,
+      note: s.note ?? undefined,
+      createdAt: s.createdAt,
+      redes: s.entries.map(e => ({
+        networkId: (e as any).networkVersion.networkId,
+        nombre: (e as any).networkVersion.network?.name ?? '',
+        versionId: (e as any).networkVersion.id,
+        versionNumber: (e as any).networkVersion.versionNumber,
+      })),
+    }))
+  }
+
+  /**
+   * Devuelve el proyecto entero al estado de una instantánea. Cada red se
+   * restaura por separado, y cada restauración congela antes su estado vigente:
+   * volver a marzo no puede costar perder lo de hoy.
+   */
+  async restaurarSnapshot(snapshotId: string): Promise<{ restauradas: number }> {
+    const snapshot = await this.prisma.projectSnapshot.findUnique({
+      where: { id: snapshotId },
+      include: { entries: true },
+    })
+    if (!snapshot) throw new Error('Instantánea no encontrada')
+
+    for (const entrada of snapshot.entries) {
+      await this.restaurarVersion(entrada.networkVersionId)
+    }
+
+    return { restauradas: snapshot.entries.length }
+  }
+
+  async borrarSnapshot(snapshotId: string): Promise<void> {
+    await this.prisma.projectSnapshot.delete({ where: { id: snapshotId } })
   }
 
   /**

--- a/backend/services/hydraulic/networkVersions.ts
+++ b/backend/services/hydraulic/networkVersions.ts
@@ -1,0 +1,313 @@
+/**
+ * Historial inmutable de redes y simulaciones (#38).
+ *
+ * `HydraulicNetwork` sigue siendo el estado vigente —lo que se abre, se pinta y
+ * se simula—. Este servicio guarda copias de ese estado que **no se modifican
+ * nunca**: sólo se añaden, se marcan como hito o se podan según la política.
+ *
+ * El versionado es explícito (el ingeniero guarda una versión y le pone una
+ * nota) más automático antes de cualquier operación que pisaría datos, que es
+ * lo decidido para este issue: el automático en cada cambio genera un historial
+ * de ruido que nadie consulta.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import {
+  RETENCION_POR_DEFECTO,
+  compararVersiones,
+  resumirDiferencia,
+  versionesAPodar,
+  type DiferenciaRed,
+  type PoliticaRetencion,
+} from './versionado'
+
+export type OrigenVersion = 'manual' | 'importacion' | 'escenario' | 'migracion'
+
+export interface DatosVersion {
+  id: string
+  networkId: string
+  versionNumber: number
+  changeNote?: string
+  author?: string
+  origen: OrigenVersion
+  marcada: boolean
+  createdAt: Date
+  /** Cuántas simulaciones se corrieron sobre esta versión. */
+  simulaciones: number
+}
+
+export interface DatosSimulacion {
+  id: string
+  networkVersionId: string
+  versionNumber: number
+  tipo: string
+  parameters: unknown
+  engineVersion?: string
+  marcada: boolean
+  createdAt: Date
+}
+
+const formatearVersion = (v: any, simulaciones = 0): DatosVersion => ({
+  id: v.id,
+  networkId: v.networkId,
+  versionNumber: v.versionNumber,
+  changeNote: v.changeNote ?? undefined,
+  author: v.author ?? undefined,
+  origen: (v.origen ?? 'manual') as OrigenVersion,
+  marcada: !!v.marcada,
+  createdAt: v.createdAt,
+  simulaciones,
+})
+
+export class NetworkVersionService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Congela el estado actual de la red como versión nueva.
+   *
+   * El número es correlativo por red y se calcula dentro de la transacción: dos
+   * guardados a la vez sobre la misma red no pueden acabar con el mismo número,
+   * que es lo que rompería la unicidad y, peor, la lectura del historial.
+   */
+  async crearVersion(
+    networkId: string,
+    opciones: { changeNote?: string; author?: string; origen?: OrigenVersion; marcada?: boolean } = {}
+  ): Promise<DatosVersion> {
+    return this.prisma.$transaction(async tx => {
+      const red = await tx.hydraulicNetwork.findUnique({ where: { id: networkId } })
+      if (!red) throw new Error('Red no encontrada')
+
+      const ultima = await tx.networkVersion.findFirst({
+        where: { networkId },
+        orderBy: { versionNumber: 'desc' },
+        select: { versionNumber: true },
+      })
+
+      const version = await tx.networkVersion.create({
+        data: {
+          networkId,
+          versionNumber: (ultima?.versionNumber ?? 0) + 1,
+          networkData: red.networkData,
+          fileContent: red.fileContent,
+          coordinateSystem: red.coordinateSystem,
+          summary: red.summary,
+          changeNote: opciones.changeNote ?? null,
+          author: opciones.author ?? null,
+          origen: opciones.origen ?? 'manual',
+          marcada: opciones.marcada ?? false,
+        },
+      })
+
+      return formatearVersion(version)
+    })
+  }
+
+  async listarVersiones(networkId: string): Promise<DatosVersion[]> {
+    const versiones = await this.prisma.networkVersion.findMany({
+      where: { networkId },
+      orderBy: { versionNumber: 'desc' },
+      include: { _count: { select: { simulations: true } } },
+    })
+    return versiones.map(v => formatearVersion(v, (v as any)._count?.simulations ?? 0))
+  }
+
+  /**
+   * Devuelve el estado guardado en una versión, para poder abrirlo o compararlo.
+   * El `.inp` viaja con él: sin el fichero original la versión se podría mirar
+   * pero no simular, que es media versión.
+   */
+  async leerVersion(versionId: string): Promise<{
+    version: DatosVersion
+    networkData: any
+    fileContent: string
+    coordinateSystem: any
+  }> {
+    const v = await this.prisma.networkVersion.findUnique({ where: { id: versionId } })
+    if (!v) throw new Error('Versión no encontrada')
+
+    return {
+      version: formatearVersion(v),
+      networkData: JSON.parse(v.networkData),
+      fileContent: v.fileContent,
+      coordinateSystem: v.coordinateSystem ? JSON.parse(v.coordinateSystem) : undefined,
+    }
+  }
+
+  /**
+   * Devuelve la red a un estado anterior.
+   *
+   * Antes de pisar nada se congela el estado vigente: restaurar es justamente
+   * una operación destructiva, y sin esa copia el ingeniero que restaura por
+   * error perdería aquello a lo que querría volver.
+   */
+  async restaurarVersion(versionId: string): Promise<{ version: DatosVersion; respaldo: DatosVersion }> {
+    const v = await this.prisma.networkVersion.findUnique({ where: { id: versionId } })
+    if (!v) throw new Error('Versión no encontrada')
+
+    const respaldo = await this.crearVersion(v.networkId, {
+      origen: 'manual',
+      changeNote: `Estado anterior a restaurar la versión ${v.versionNumber}`,
+    })
+
+    await this.prisma.hydraulicNetwork.update({
+      where: { id: v.networkId },
+      data: {
+        networkData: v.networkData,
+        fileContent: v.fileContent,
+        coordinateSystem: v.coordinateSystem,
+        summary: v.summary,
+        updatedAt: new Date(),
+      },
+    })
+
+    return { version: formatearVersion(v), respaldo }
+  }
+
+  async marcarVersion(versionId: string, marcada: boolean): Promise<DatosVersion> {
+    const v = await this.prisma.networkVersion.update({
+      where: { id: versionId },
+      data: { marcada },
+    })
+    return formatearVersion(v)
+  }
+
+  /** Diferencias entre dos versiones de la misma red. */
+  async compararVersiones(
+    versionA: string,
+    versionB: string
+  ): Promise<{ diferencia: DiferenciaRed; resumen: string }> {
+    const [a, b] = await Promise.all([
+      this.prisma.networkVersion.findUnique({ where: { id: versionA } }),
+      this.prisma.networkVersion.findUnique({ where: { id: versionB } }),
+    ])
+    if (!a || !b) throw new Error('Versión no encontrada')
+
+    const diferencia = compararVersiones(JSON.parse(a.networkData), JSON.parse(b.networkData))
+    return { diferencia, resumen: resumirDiferencia(diferencia) }
+  }
+
+  /**
+   * Registra una ejecución de simulación contra la versión con la que se corrió.
+   * Sin esa atadura, un resultado no se puede interpretar: no se sabe sobre qué
+   * red se calculó.
+   */
+  async registrarSimulacion(
+    networkVersionId: string,
+    datos: { tipo: string; parameters: unknown; results: unknown; engineVersion?: string }
+  ): Promise<DatosSimulacion> {
+    const version = await this.prisma.networkVersion.findUnique({ where: { id: networkVersionId } })
+    if (!version) throw new Error('Versión no encontrada')
+
+    const run = await this.prisma.simulationRun.create({
+      data: {
+        networkVersionId,
+        tipo: datos.tipo,
+        parameters: JSON.stringify(datos.parameters ?? {}),
+        results: JSON.stringify(datos.results ?? {}),
+        engineVersion: datos.engineVersion ?? null,
+      },
+    })
+
+    return {
+      id: run.id,
+      networkVersionId,
+      versionNumber: version.versionNumber,
+      tipo: run.tipo,
+      parameters: datos.parameters,
+      engineVersion: run.engineVersion ?? undefined,
+      marcada: run.marcada,
+      createdAt: run.createdAt,
+    }
+  }
+
+  async listarSimulaciones(networkId: string): Promise<DatosSimulacion[]> {
+    const runs = await this.prisma.simulationRun.findMany({
+      where: { networkVersion: { networkId } },
+      orderBy: { createdAt: 'desc' },
+      include: { networkVersion: { select: { versionNumber: true } } },
+    })
+
+    return runs.map(r => ({
+      id: r.id,
+      networkVersionId: r.networkVersionId,
+      versionNumber: (r as any).networkVersion.versionNumber,
+      tipo: r.tipo,
+      parameters: JSON.parse(r.parameters),
+      engineVersion: r.engineVersion ?? undefined,
+      marcada: r.marcada,
+      createdAt: r.createdAt,
+    }))
+  }
+
+  async leerSimulacion(runId: string): Promise<{ resultados: unknown; parametros: unknown }> {
+    const r = await this.prisma.simulationRun.findUnique({ where: { id: runId } })
+    if (!r) throw new Error('Simulación no encontrada')
+    return { resultados: JSON.parse(r.results), parametros: JSON.parse(r.parameters) }
+  }
+
+  /**
+   * Aplica la política de retención a una red. Devuelve cuántas versiones se
+   * podaron; las marcadas y la más reciente no se tocan nunca.
+   */
+  async podar(networkId: string, politica: PoliticaRetencion = RETENCION_POR_DEFECTO): Promise<number> {
+    const versiones = await this.prisma.networkVersion.findMany({
+      where: { networkId },
+      select: { id: true, versionNumber: true, marcada: true },
+    })
+
+    const sobran = versionesAPodar(versiones, politica)
+    if (sobran.length === 0) return 0
+
+    await this.prisma.networkVersion.deleteMany({ where: { id: { in: sobran } } })
+    return sobran.length
+  }
+
+  /**
+   * Política vigente. Se guarda en `app_settings` para poder ajustarla sin tocar
+   * código; si no está, rige el valor por defecto.
+   */
+  async politicaVigente(): Promise<PoliticaRetencion> {
+    try {
+      const ajuste = await this.prisma.appSetting.findUnique({
+        where: { key: 'retencion.versionesSinMarcar' },
+      })
+      const n = Number(ajuste?.value)
+      if (Number.isFinite(n) && n >= 0) return { conservarSinMarcar: n }
+    } catch {
+      // Sin ajuste guardado se usa el valor por defecto: la retención no debe
+      // depender de que exista una tabla de configuración.
+    }
+    return RETENCION_POR_DEFECTO
+  }
+
+  /** Poda aplicando la política guardada. Devuelve cuántas versiones retiró. */
+  async podarSegunAjustes(networkId: string): Promise<number> {
+    return this.podar(networkId, await this.politicaVigente())
+  }
+
+  /**
+   * Da versión inicial a las redes que aún no tienen ninguna.
+   *
+   * Es idempotente: sólo mira las redes sin versiones, así que se puede llamar
+   * en cada arranque sin duplicar nada. No toca `hydraulic_calculations`: los
+   * resultados guardados antes de esto no registran con qué red se corrieron
+   * —29 de los 40 de una base real no traían `networkId`—, así que atribuirles
+   * una versión sería inventarse la trazabilidad que precisamente falta. Se
+   * quedan donde están, intactos.
+   */
+  async migrarRedesSinVersion(): Promise<number> {
+    const redes = await this.prisma.hydraulicNetwork.findMany({
+      where: { versions: { none: {} } },
+      select: { id: true },
+    })
+
+    for (const red of redes) {
+      await this.crearVersion(red.id, {
+        origen: 'migracion',
+        changeNote: 'Estado inicial, anterior al historial de versiones',
+      })
+    }
+
+    return redes.length
+  }
+}

--- a/backend/services/hydraulic/versionado.test.ts
+++ b/backend/services/hydraulic/versionado.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   RETENCION_POR_DEFECTO,
+  compararSimulaciones,
   compararVersiones,
+  resumirDiferenciaSimulaciones,
   resumirDiferencia,
   versionesAPodar,
 } from './versionado'
@@ -136,5 +138,86 @@ describe('comparación entre versiones', () => {
   it('aguanta una versión sin nudos ni tramos declarados', () => {
     expect(compararVersiones({}, {}).sinCambios).toBe(true)
     expect(compararVersiones({}, ANTES).nudos.anadidos).toHaveLength(3)
+  })
+})
+
+describe('retención frente a las instantáneas de proyecto', () => {
+  it('una versión sujeta por una instantánea no se poda, aunque sea antigua', () => {
+    // Podarla dejaría la instantánea apuntando al vacío, y una instantánea es
+    // justamente algo que el ingeniero quiso conservar.
+    const versiones = [
+      { id: 'v1', versionNumber: 1, marcada: false, enSnapshot: true },
+      ...Array.from({ length: 14 }, (_, i) => ({
+        id: `v${i + 2}`, versionNumber: i + 2, marcada: false,
+      })),
+    ]
+    const podar = versionesAPodar(versiones, { conservarSinMarcar: 5 })
+
+    expect(podar).not.toContain('v1')
+  })
+
+  it('estar en una instantánea no consume cupo de las que sí se podan', () => {
+    const versiones = [
+      { id: 'v1', versionNumber: 1, marcada: false, enSnapshot: true },
+      { id: 'v2', versionNumber: 2, marcada: false },
+      { id: 'v3', versionNumber: 3, marcada: false },
+      { id: 'v4', versionNumber: 4, marcada: false },
+    ]
+    // Con cupo 2 se conservan v4 y v3, se poda v2, y v1 sobrevive por la instantánea.
+    expect(versionesAPodar(versiones, { conservarSinMarcar: 2 })).toEqual(['v2'])
+  })
+})
+
+describe('comparación entre dos ejecuciones de simulación', () => {
+  const A = {
+    node_results: { J1: { pressure: 40 }, J2: { pressure: 35 }, J3: { pressure: 20 } },
+    link_results: { P1: { flowrate: 10, velocity: 1 } },
+  }
+
+  it('mide cuánto se movió cada magnitud y quién se movió más', () => {
+    const B = {
+      node_results: { J1: { pressure: 42 }, J2: { pressure: 25 }, J3: { pressure: 20 } },
+      link_results: { P1: { flowrate: 12, velocity: 1.2 } },
+    }
+    const d = compararSimulaciones(A, B)
+    const presion = d.magnitudes.find(m => m.magnitud === 'Presión')!
+
+    expect(presion.comparados).toBe(3)
+    expect(presion.deltaMaximo).toBe(10)
+    expect(presion.mayores[0].id).toBe('J2')
+    expect(presion.subieron).toBe(1)
+    expect(presion.bajaron).toBe(1)
+    expect(presion.igual).toBe(1)
+  })
+
+  it('dos ejecuciones idénticas lo dicen, en vez de fingir cambios', () => {
+    expect(resumirDiferenciaSimulaciones(compararSimulaciones(A, A))).toBe('Resultados idénticos')
+  })
+
+  it('un elemento que sólo está en una ejecución no cuenta como cambio cero', () => {
+    // Si la red cambió entremedias, contar los nudos nuevos como «sin cambio»
+    // falsearía las medias hacia abajo.
+    const B = {
+      node_results: { J1: { pressure: 40 }, J2: { pressure: 35 }, J9: { pressure: 99 } },
+      link_results: A.link_results,
+    }
+    const d = compararSimulaciones(A, B)
+
+    expect(d.magnitudes.find(m => m.magnitud === 'Presión')!.comparados).toBe(2)
+    expect(d.soloEnA).toContain('J3')
+    expect(d.soloEnB).toContain('J9')
+  })
+
+  it('compara el paso de tiempo que se le pida', () => {
+    const serieA = { node_results: { J1: { pressure: [10, 50] } } }
+    const serieB = { node_results: { J1: { pressure: [10, 20] } } }
+
+    expect(compararSimulaciones(serieA, serieB, 0).magnitudes[0].deltaMaximo).toBe(0)
+    expect(compararSimulaciones(serieA, serieB, 1).magnitudes[0].deltaMaximo).toBe(30)
+  })
+
+  it('sin magnitudes en común lo dice en lugar de devolver un resumen vacío', () => {
+    const d = compararSimulaciones({ node_results: { J1: { head: 5 } } }, { node_results: { J1: { head: 6 } } })
+    expect(resumirDiferenciaSimulaciones(d)).toMatch(/no hay magnitudes comparables/i)
   })
 })

--- a/backend/services/hydraulic/versionado.test.ts
+++ b/backend/services/hydraulic/versionado.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RETENCION_POR_DEFECTO,
+  compararVersiones,
+  resumirDiferencia,
+  versionesAPodar,
+} from './versionado'
+
+const v = (n: number, marcada = false) => ({ id: `v${n}`, versionNumber: n, marcada })
+
+describe('retención', () => {
+  it('con menos versiones que el tope no poda nada', () => {
+    const versiones = [v(1), v(2), v(3)]
+    expect(versionesAPodar(versiones, { conservarSinMarcar: 10 })).toEqual([])
+  })
+
+  it('conserva las N más recientes sin marcar y poda el resto', () => {
+    const versiones = Array.from({ length: 15 }, (_, i) => v(i + 1))
+    const podar = versionesAPodar(versiones, { conservarSinMarcar: 10 })
+
+    expect(podar).toHaveLength(5)
+    // Se van las cinco más antiguas, no cinco cualesquiera.
+    expect(podar.sort()).toEqual(['v1', 'v2', 'v3', 'v4', 'v5'].sort())
+  })
+
+  it('una versión marcada como hito no se poda por vieja que sea', () => {
+    const versiones = [v(1, true), ...Array.from({ length: 14 }, (_, i) => v(i + 2))]
+    const podar = versionesAPodar(versiones, { conservarSinMarcar: 10 })
+
+    expect(podar).not.toContain('v1')
+    expect(podar).toHaveLength(4)
+  })
+
+  it('con todo marcado no se poda nada, aunque haya cien versiones', () => {
+    const versiones = Array.from({ length: 100 }, (_, i) => v(i + 1, true))
+    expect(versionesAPodar(versiones, { conservarSinMarcar: 3 })).toEqual([])
+  })
+
+  it('la más reciente se conserva siempre, aunque la política sea cero', () => {
+    // Quedarse sin ninguna version convertiria la retencion en una forma de
+    // perder el historial entero.
+    const versiones = [v(1), v(2), v(3)]
+    const podar = versionesAPodar(versiones, { conservarSinMarcar: 0 })
+
+    expect(podar).not.toContain('v3')
+    expect(podar.sort()).toEqual(['v1', 'v2'])
+  })
+
+  it('sin versiones no hay nada que podar', () => {
+    expect(versionesAPodar([], RETENCION_POR_DEFECTO)).toEqual([])
+  })
+
+  it('no depende del orden en que lleguen', () => {
+    const desordenadas = [v(3), v(1), v(15), v(2)]
+    expect(versionesAPodar(desordenadas, { conservarSinMarcar: 2 }).sort()).toEqual(['v1', 'v2'])
+  })
+})
+
+describe('comparación entre versiones', () => {
+  const ANTES = {
+    nodes: [
+      { id: 'J1', type: 'junction', elevation: 100, demand: 5 },
+      { id: 'J2', type: 'junction', elevation: 110, demand: 3 },
+      { id: 'T1', type: 'tank', elevation: 150 },
+    ],
+    links: [
+      { id: 'P1', type: 'pipe', from: 'J1', to: 'J2', diameter: 200, length: 500 },
+      { id: 'P2', type: 'pipe', from: 'J2', to: 'T1', diameter: 150, length: 300 },
+    ],
+  }
+
+  it('una red idéntica a sí misma no tiene cambios', () => {
+    const d = compararVersiones(ANTES, ANTES)
+    expect(d.sinCambios).toBe(true)
+    expect(resumirDiferencia(d)).toBe('Sin cambios en la red')
+  })
+
+  it('detecta lo añadido, lo eliminado y lo modificado', () => {
+    const despues = {
+      nodes: [
+        { id: 'J1', type: 'junction', elevation: 100, demand: 8 },
+        { id: 'T1', type: 'tank', elevation: 150 },
+        { id: 'J3', type: 'junction', elevation: 120, demand: 2 },
+      ],
+      links: [
+        { id: 'P1', type: 'pipe', from: 'J1', to: 'J3', diameter: 250, length: 500 },
+        { id: 'P2', type: 'pipe', from: 'J3', to: 'T1', diameter: 150, length: 300 },
+      ],
+    }
+    const d = compararVersiones(ANTES, despues)
+
+    expect(d.nudos.anadidos).toEqual(['J3'])
+    expect(d.nudos.eliminados).toEqual(['J2'])
+    expect(d.nudos.modificados).toEqual([{ id: 'J1', campos: ['demand'] }])
+    expect(d.tramos.modificados.find(m => m.id === 'P1')!.campos.sort()).toEqual(['diameter', 'to'])
+    expect(d.sinCambios).toBe(false)
+  })
+
+  it('«100» y «100.0» no son un cambio de diámetro', () => {
+    // Un .inp reescrito cambia el formato de los números; marcarlo como cambio
+    // llenaría el diff de ruido que esconde lo que sí cambió.
+    const despues = {
+      ...ANTES,
+      links: [
+        { id: 'P1', type: 'pipe', from: 'J1', to: 'J2', diameter: '200.0', length: '500' },
+        ANTES.links[1],
+      ],
+    }
+    expect(compararVersiones(ANTES, despues).sinCambios).toBe(true)
+  })
+
+  it('no mira los resultados de simulación que vengan dentro del nudo', () => {
+    // El diff de una red habla de la red, no de lo que se calculó sobre ella.
+    const despues = {
+      ...ANTES,
+      nodes: ANTES.nodes.map(n => ({ ...n, pressure: 42, head: 99 })),
+    }
+    expect(compararVersiones(ANTES, despues).sinCambios).toBe(true)
+  })
+
+  it('una red vaciada dice que se eliminó todo, no que no hay cambios', () => {
+    const d = compararVersiones(ANTES, { nodes: [], links: [] })
+    expect(d.nudos.eliminados).toHaveLength(3)
+    expect(d.tramos.eliminados).toHaveLength(2)
+    expect(d.sinCambios).toBe(false)
+  })
+
+  it('resume en singular y en plural, sin listar lo que no ocurrió', () => {
+    const d = compararVersiones(ANTES, {
+      nodes: [...ANTES.nodes, { id: 'J9', type: 'junction', elevation: 1 }],
+      links: ANTES.links,
+    })
+    expect(resumirDiferencia(d)).toBe('1 nudo añadido')
+  })
+
+  it('aguanta una versión sin nudos ni tramos declarados', () => {
+    expect(compararVersiones({}, {}).sinCambios).toBe(true)
+    expect(compararVersiones({}, ANTES).nudos.anadidos).toHaveLength(3)
+  })
+})

--- a/backend/services/hydraulic/versionado.ts
+++ b/backend/services/hydraulic/versionado.ts
@@ -1,0 +1,168 @@
+/**
+ * Reglas del versionado inmutable (#38): qué se conserva y qué cambió.
+ *
+ * Módulo puro, sin Prisma: la política de retención y la comparación entre
+ * versiones son decisiones que conviene poder probar sin base de datos delante,
+ * porque de ellas depende que no se borre lo que no se debe.
+ */
+
+/** Lo mínimo que hace falta de una versión para decidir si se conserva. */
+export interface VersionRetenible {
+  id: string
+  versionNumber: number
+  marcada: boolean
+}
+
+export interface PoliticaRetencion {
+  /**
+   * Cuántas versiones sin marcar se conservan, de la más reciente hacia atrás.
+   * Las marcadas como hito no cuentan y no se podan nunca.
+   */
+  conservarSinMarcar: number
+}
+
+export const RETENCION_POR_DEFECTO: PoliticaRetencion = { conservarSinMarcar: 10 }
+
+/**
+ * Versiones que sobran según la política. Devuelve ids, no las borra.
+ *
+ * La más reciente se conserva siempre, aunque no esté marcada y la política sea
+ * cero: quedarse sin ninguna versión de una red convertiría la retención en una
+ * forma de perder el historial entero.
+ */
+export function versionesAPodar(
+  versiones: VersionRetenible[],
+  politica: PoliticaRetencion = RETENCION_POR_DEFECTO
+): string[] {
+  if (versiones.length === 0) return []
+
+  const recientesPrimero = [...versiones].sort((a, b) => b.versionNumber - a.versionNumber)
+  const conservar = new Set<string>([recientesPrimero[0].id])
+
+  let sinMarcar = 0
+  for (const v of recientesPrimero) {
+    if (v.marcada) {
+      conservar.add(v.id)
+      continue
+    }
+    if (sinMarcar < Math.max(0, politica.conservarSinMarcar)) {
+      conservar.add(v.id)
+      sinMarcar++
+    }
+  }
+
+  return recientesPrimero.filter(v => !conservar.has(v.id)).map(v => v.id)
+}
+
+// --- Comparación entre dos versiones -------------------------------------
+
+export interface ElementoRed {
+  id: string
+  [campo: string]: unknown
+}
+
+export interface DatosVersion {
+  nodes?: ElementoRed[]
+  links?: ElementoRed[]
+}
+
+export interface CambioElemento {
+  id: string
+  campos: string[]
+}
+
+export interface DiferenciaLado {
+  anadidos: string[]
+  eliminados: string[]
+  modificados: CambioElemento[]
+}
+
+export interface DiferenciaRed {
+  nudos: DiferenciaLado
+  tramos: DiferenciaLado
+  sinCambios: boolean
+}
+
+/**
+ * Campos que se comparan. La lista es explícita a propósito: comparar el objeto
+ * entero marcaría como «modificado» cualquier nudo cuyo resultado de simulación
+ * viniera dentro, y el diff de una red debe hablar de la red, no de lo que se
+ * calculó sobre ella.
+ */
+const CAMPOS_NUDO = ['type', 'elevation', 'demand', 'x', 'y', 'pattern', 'initialLevel', 'diameter']
+const CAMPOS_TRAMO = ['type', 'from', 'to', 'length', 'diameter', 'roughness', 'status', 'minorLoss']
+
+function comparar(
+  antes: ElementoRed[] | undefined,
+  despues: ElementoRed[] | undefined,
+  campos: string[]
+): DiferenciaLado {
+  const mapaAntes = new Map((antes ?? []).map(e => [e.id, e]))
+  const mapaDespues = new Map((despues ?? []).map(e => [e.id, e]))
+
+  const anadidos: string[] = []
+  const modificados: CambioElemento[] = []
+
+  for (const [id, elemento] of mapaDespues) {
+    const previo = mapaAntes.get(id)
+    if (!previo) {
+      anadidos.push(id)
+      continue
+    }
+    const cambiados = campos.filter(c => !mismoValor(previo[c], elemento[c]))
+    if (cambiados.length > 0) modificados.push({ id, campos: cambiados })
+  }
+
+  const eliminados = [...mapaAntes.keys()].filter(id => !mapaDespues.has(id))
+
+  return { anadidos, eliminados, modificados }
+}
+
+/**
+ * Dos valores son el mismo si lo son numéricamente. Un `.inp` reescrito puede
+ * traer `100` donde antes ponía `100.0`, y marcar eso como un cambio de diámetro
+ * llenaría el diff de ruido que esconde los cambios de verdad.
+ */
+function mismoValor(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a == null && b == null
+  const na = Number(a)
+  const nb = Number(b)
+  if (Number.isFinite(na) && Number.isFinite(nb)) return na === nb
+  return String(a) === String(b)
+}
+
+export function compararVersiones(antes: DatosVersion, despues: DatosVersion): DiferenciaRed {
+  const nudos = comparar(antes.nodes, despues.nodes, CAMPOS_NUDO)
+  const tramos = comparar(antes.links, despues.links, CAMPOS_TRAMO)
+
+  const sinCambios =
+    nudos.anadidos.length === 0 && nudos.eliminados.length === 0 && nudos.modificados.length === 0 &&
+    tramos.anadidos.length === 0 && tramos.eliminados.length === 0 && tramos.modificados.length === 0
+
+  return { nudos, tramos, sinCambios }
+}
+
+/** Resumen de una diferencia en una línea, para listas y avisos. */
+export function resumirDiferencia(d: DiferenciaRed): string {
+  if (d.sinCambios) return 'Sin cambios en la red'
+
+  const partes: string[] = []
+  const contar = (n: number, singular: string, plural: string) =>
+    n > 0 ? `${n} ${n === 1 ? singular : plural}` : null
+
+  const nudos = [
+    contar(d.nudos.anadidos.length, 'nudo añadido', 'nudos añadidos'),
+    contar(d.nudos.eliminados.length, 'nudo eliminado', 'nudos eliminados'),
+    contar(d.nudos.modificados.length, 'nudo modificado', 'nudos modificados'),
+  ].filter(Boolean)
+
+  const tramos = [
+    contar(d.tramos.anadidos.length, 'tramo añadido', 'tramos añadidos'),
+    contar(d.tramos.eliminados.length, 'tramo eliminado', 'tramos eliminados'),
+    contar(d.tramos.modificados.length, 'tramo modificado', 'tramos modificados'),
+  ].filter(Boolean)
+
+  partes.push(...(nudos as string[]), ...(tramos as string[]))
+  return partes.join(', ')
+}

--- a/backend/services/hydraulic/versionado.ts
+++ b/backend/services/hydraulic/versionado.ts
@@ -11,6 +11,13 @@ export interface VersionRetenible {
   id: string
   versionNumber: number
   marcada: boolean
+  /**
+   * Sujeta por una instantánea de proyecto. Podarla dejaría la instantánea
+   * apuntando al vacío, así que cuenta como intocable igual que un hito, pero
+   * por un motivo distinto: el hito lo decide el ingeniero, esto lo impone la
+   * integridad de otra cosa que sí quiso conservar.
+   */
+  enSnapshot?: boolean
 }
 
 export interface PoliticaRetencion {
@@ -26,9 +33,10 @@ export const RETENCION_POR_DEFECTO: PoliticaRetencion = { conservarSinMarcar: 10
 /**
  * Versiones que sobran según la política. Devuelve ids, no las borra.
  *
- * La más reciente se conserva siempre, aunque no esté marcada y la política sea
- * cero: quedarse sin ninguna versión de una red convertiría la retención en una
- * forma de perder el historial entero.
+ * Nunca se poda una marcada como hito, ni una sujeta por una instantánea de
+ * proyecto, ni la más reciente —aunque no esté marcada y la política sea cero—:
+ * quedarse sin ninguna versión de una red convertiría la retención en una forma
+ * de perder el historial entero.
  */
 export function versionesAPodar(
   versiones: VersionRetenible[],
@@ -41,7 +49,7 @@ export function versionesAPodar(
 
   let sinMarcar = 0
   for (const v of recientesPrimero) {
-    if (v.marcada) {
+    if (v.marcada || v.enSnapshot) {
       conservar.add(v.id)
       continue
     }
@@ -165,4 +173,118 @@ export function resumirDiferencia(d: DiferenciaRed): string {
 
   partes.push(...(nudos as string[]), ...(tramos as string[]))
   return partes.join(', ')
+}
+
+// --- Comparación entre dos ejecuciones de simulación ---------------------
+
+export interface ResultadosSimulacion {
+  node_results?: Record<string, Record<string, number | number[] | undefined>>
+  link_results?: Record<string, Record<string, number | number[] | undefined>>
+}
+
+export interface CambioMagnitud {
+  id: string
+  antes: number
+  despues: number
+  delta: number
+}
+
+export interface DiferenciaMagnitud {
+  magnitud: string
+  unidad: string
+  /** Elementos comparables, es decir, presentes en las dos ejecuciones. */
+  comparados: number
+  /** Los que más se mueven, ordenados por magnitud del cambio. */
+  mayores: CambioMagnitud[]
+  deltaMedio: number
+  deltaMaximo: number
+  subieron: number
+  bajaron: number
+  igual: number
+}
+
+export interface DiferenciaSimulaciones {
+  magnitudes: DiferenciaMagnitud[]
+  /** Ids presentes en una ejecución y no en la otra: la red cambió entremedias. */
+  soloEnA: string[]
+  soloEnB: string[]
+}
+
+const MAGNITUDES: Array<{ clave: string; nombre: string; unidad: string; lado: 'nudos' | 'tramos' }> = [
+  { clave: 'pressure', nombre: 'Presión', unidad: 'm', lado: 'nudos' },
+  { clave: 'demand', nombre: 'Demanda', unidad: 'L/s', lado: 'nudos' },
+  { clave: 'flowrate', nombre: 'Caudal', unidad: 'L/s', lado: 'tramos' },
+  { clave: 'velocity', nombre: 'Velocidad', unidad: 'm/s', lado: 'tramos' },
+]
+
+/** Toma el valor de un paso concreto, o el escalar si no es una serie. */
+function enPaso(v: number | number[] | undefined, paso: number): number | undefined {
+  if (Array.isArray(v)) return v[paso] ?? v[0]
+  return typeof v === 'number' ? v : undefined
+}
+
+/**
+ * Compara dos ejecuciones sobre el mismo paso de tiempo.
+ *
+ * Sólo se comparan los elementos presentes en las dos: si entre una ejecución y
+ * otra se añadieron nudos, esos no tienen con qué compararse, y contarlos como
+ * «cambio cero» falsearía las medias. Se listan aparte.
+ */
+export function compararSimulaciones(
+  a: ResultadosSimulacion,
+  b: ResultadosSimulacion,
+  paso = 0,
+  cuantosMayores = 5
+): DiferenciaSimulaciones {
+  const magnitudes: DiferenciaMagnitud[] = []
+  const idsA = new Set([...Object.keys(a.node_results ?? {}), ...Object.keys(a.link_results ?? {})])
+  const idsB = new Set([...Object.keys(b.node_results ?? {}), ...Object.keys(b.link_results ?? {})])
+
+  for (const m of MAGNITUDES) {
+    const tablaA = m.lado === 'nudos' ? a.node_results : a.link_results
+    const tablaB = m.lado === 'nudos' ? b.node_results : b.link_results
+    if (!tablaA || !tablaB) continue
+
+    const cambios: CambioMagnitud[] = []
+    for (const id of Object.keys(tablaA)) {
+      const antes = enPaso(tablaA[id]?.[m.clave], paso)
+      const despues = enPaso(tablaB[id]?.[m.clave], paso)
+      if (typeof antes !== 'number' || typeof despues !== 'number') continue
+      cambios.push({ id, antes, despues, delta: despues - antes })
+    }
+    if (cambios.length === 0) continue
+
+    const absolutos = cambios.map(c => Math.abs(c.delta))
+    magnitudes.push({
+      magnitud: m.nombre,
+      unidad: m.unidad,
+      comparados: cambios.length,
+      mayores: [...cambios]
+        .sort((x, y) => Math.abs(y.delta) - Math.abs(x.delta))
+        .slice(0, cuantosMayores),
+      deltaMedio: absolutos.reduce((s, v) => s + v, 0) / cambios.length,
+      deltaMaximo: Math.max(...absolutos),
+      subieron: cambios.filter(c => c.delta > 0).length,
+      bajaron: cambios.filter(c => c.delta < 0).length,
+      igual: cambios.filter(c => c.delta === 0).length,
+    })
+  }
+
+  return {
+    magnitudes,
+    soloEnA: [...idsA].filter(id => !idsB.has(id)),
+    soloEnB: [...idsB].filter(id => !idsA.has(id)),
+  }
+}
+
+/** Resumen en una línea, para la lista de simulaciones. */
+export function resumirDiferenciaSimulaciones(d: DiferenciaSimulaciones): string {
+  if (d.magnitudes.length === 0) return 'No hay magnitudes comparables entre las dos ejecuciones'
+
+  const partes = d.magnitudes
+    .filter(m => m.deltaMaximo > 0)
+    .map(m => `${m.magnitud}: hasta ${m.deltaMaximo.toFixed(2)} ${m.unidad}`)
+
+  if (partes.length === 0) return 'Resultados idénticos'
+  return partes.join(' · ')
 }

--- a/docs/VERSIONADO_INMUTABLE.md
+++ b/docs/VERSIONADO_INMUTABLE.md
@@ -42,6 +42,7 @@ HydraulicProject
 | Interfaz del historial | `src/components/hydraulic/HistorialRed.tsx` |
 | Instantáneas de proyecto | `src/components/hydraulic/InstantaneasProyecto.tsx` |
 | Ajuste de retención | `src/components/settings/tabs/GeneralTab.tsx` |
+| Formato de intercambio | `backend/services/hydraulic/intercambio.ts` |
 | Esquema y DDL de producción | `prisma/schema.prisma`, `electron/main.ts` |
 
 ## Decisiones
@@ -160,9 +161,54 @@ marcar se conservan por red. Se guarda en `app_settings` con la clave
 política no toca nunca: los hitos, las versiones sujetas por una instantánea y la
 más reciente.
 
+## Exportar e importar entre instalaciones
+
+Un paquete `.boorie.json` lleva uno o varios estados de red con lo necesario para
+reconstruirlos en otra máquina: los datos, el `.inp`, el sistema de coordenadas y
+de dónde salieron. Se exporta una versión desde su historial, o el conjunto que
+congeló una instantánea.
+
+**El formato lleva su propia versión.** `boorie.red/1`. Un Boorie más antiguo que
+reciba un paquete futuro tiene que reconocer que no lo entiende y decirlo, en
+lugar de leerlo a medias y crear una red incompleta.
+
+**Y lleva una suma de comprobación.** Un fichero truncado a mitad de copia, o
+editado a mano, produciría una red silenciosamente distinta de la que se exportó
+—y eso, en un modelo hidráulico, no se nota hasta que alguien toma una decisión
+con él—. Si la suma no cuadra no se importa nada.
+
+**Los identificadores no se reutilizan.** En la instalación de destino podrían
+chocar con registros que no tienen nada que ver. Se guardan como procedencia
+dentro de la nota de la versión —«Importada de Boorie 1.12.0 · proyecto "X" ·
+versión 4 de origen»—, que es lo que sirve para rastrearla; todo lo demás nace con
+identificadores nuevos. Una red que ya existe con ese nombre recibe una versión
+más en lugar de duplicarse, que es la misma semántica que reimportar un `.inp`.
+
+**Los resultados de simulación no viajan en el paquete.** Un solo resultado de
+calidad sobre una red grande ronda los 80 MB; el paquete es el estado de la red,
+que es lo que hace falta para reconstruirla y volver a calcular.
+
+### Un fallo que sólo apareció al probarlo de verdad
+
+Los tests pasaban y el primer intento real falló: un paquete recién exportado no
+validaba su propia suma. `JSON.stringify` **descarta las claves cuyo valor es
+`undefined`**, así que una red sin sistema de coordenadas se guardaba sin esa
+clave, y al releerla la suma calculada sobre el objeto original —que sí la tenía,
+puesta a `undefined`— ya no cuadraba. Los datos del test tenían todos los campos
+llenos y por eso no lo veían. La suma descarta ahora esas claves igual que hace
+`JSON.stringify`, y hay un test con los campos opcionales vacíos.
+
+Comprobado de extremo a extremo contra la base real: exportar la `v4` de
+`Net3 2.inp` da un paquete de 101 KB, importarlo en el proyecto
+`villa_100_casas` crea la red allí, y un paquete con un valor cambiado a mano se
+rechaza sin importar nada.
+
 ## Fuera de alcance
 
-**Exportar e importar versiones entre instalaciones** (punto 3 de las decisiones
-pendientes). Descartado para esta entrega; el modelo queda preparado con
-identificadores estables y número de versión.
+**Llevar los resultados de simulación en el paquete**, por su tamaño (ver arriba).
+
+**Resolver conflictos al importar**: una red con el mismo nombre recibe una
+versión más, sin preguntar. Es lo coherente con el resto del versionado —nada se
+pierde, todo queda en el historial—, pero no hay diálogo de «esto ya existe, ¿qué
+hago?».
 

--- a/docs/VERSIONADO_INMUTABLE.md
+++ b/docs/VERSIONADO_INMUTABLE.md
@@ -40,6 +40,8 @@ HydraulicProject
 | Persistencia | `backend/services/hydraulic/networkVersions.ts` |
 | Canales IPC | `network-version:*` en `networkRepository.handler.ts` |
 | Interfaz del historial | `src/components/hydraulic/HistorialRed.tsx` |
+| Instantáneas de proyecto | `src/components/hydraulic/InstantaneasProyecto.tsx` |
+| Ajuste de retención | `src/components/settings/tabs/GeneralTab.tsx` |
 | Esquema y DDL de producción | `prisma/schema.prisma`, `electron/main.ts` |
 
 ## Decisiones
@@ -102,6 +104,9 @@ hubiera nombres duplicados por proyecto.
 | Cada resultado trazable a la versión exacta y a sus parámetros | Hecho para las simulaciones nuevas. Las 40 anteriores no lo son: los datos para atribuirlas no existen (ver arriba). |
 | Ninguna operación normal destruye datos históricos | Hecho. Restaurar y reimportar versionan antes; la retención sólo poda lo no marcado por encima del tope. |
 | La migración preserva el 100 % de proyectos, redes y resultados | Hecho, verificado por conteo antes y después: 5 proyectos, 5 redes, 40 cálculos, 11 conversaciones, 434 fragmentos. |
+| Versionado del proyecto (punto 4) | Hecho: instantáneas que anotan qué versión de cada red estaba vigente. |
+| Comparación entre versiones y entre simulaciones (punto 5) | Hecho: diff de red entre versiones y comparación de magnitudes entre ejecuciones. |
+| Política de retención configurable (punto 6) | Hecho, en Ajustes. |
 
 ## Comprobado en la aplicación
 
@@ -111,19 +116,53 @@ anterior —«Sin cambios en la red», que es lo correcto porque nada había cam
 y se restauró la versión 2, que dejó en el historial la `v3` con la nota «Estado
 anterior a restaurar la versión 2».
 
-## Fuera de alcance
+## Instantáneas de proyecto
 
-**Versionado del proyecto** como instantánea del conjunto de versiones de red
-activas (punto 4 del issue). Responde a «¿cómo estaba este proyecto en la entrega
-de marzo?» a nivel de proyecto, no de red. El modelo lo admite —bastaría una
-entidad que apunte a un conjunto de `NetworkVersion`— pero no se construye aquí.
+Responden a «¿cómo estaba este proyecto en la entrega de marzo?» a nivel de
+proyecto, no de red. Una instantánea **no copia nada**: anota qué versión de cada
+red estaba vigente, y esas versiones ya son inmutables. Congelar un proyecto
+entero cuesta unas pocas filas.
+
+```
+ProjectSnapshot ──< ProjectSnapshotEntry >── NetworkVersion
+```
+
+**Una versión sujeta por una instantánea no se puede podar.** Es la consecuencia
+que hacía falta atar: sin ella, la retención podía dejar una instantánea apuntando
+al vacío. Cuenta como intocable igual que un hito, pero por un motivo distinto —el
+hito lo decide el ingeniero; esto lo impone la integridad de algo que sí quiso
+conservar—.
+
+Restaurar una instantánea restaura cada red por separado, y cada restauración
+congela antes su estado vigente: volver a marzo no puede costar perder lo de hoy.
+
+Comprobado sobre la base real con la política puesta a cero: de las cuatro
+versiones de `Net3 2.inp`, se podó la `v1` y sobrevivieron la `v2` (hito), la `v3`
+(sujeta por la instantánea «Entrega de marzo») y la `v4` (la más reciente).
+
+## Comparar dos ejecuciones de simulación
+
+Tiene sentido entre versiones distintas de la red —«¿qué le hizo a las presiones
+cambiar ese diámetro?»— y también entre dos ejecuciones de la misma versión con
+parámetros distintos. Se comparan presión y demanda en los nudos, caudal y
+velocidad en los tramos, sobre el mismo paso de tiempo: cuánto se movió cada
+magnitud, cuántos elementos subieron y bajaron, y los que más cambiaron.
+
+**Sólo se comparan los elementos presentes en las dos ejecuciones.** Si la red
+cambió entremedias, los nudos nuevos no tienen con qué compararse, y contarlos
+como «cambio cero» falsearía las medias hacia abajo. Se listan aparte.
+
+## La retención, en Ajustes
+
+`Configuración → General → Historial de versiones` expone cuántas versiones sin
+marcar se conservan por red. Se guarda en `app_settings` con la clave
+`retencion.versionesSinMarcar`; sin ajuste, rigen 10. La pantalla dice lo que la
+política no toca nunca: los hitos, las versiones sujetas por una instantánea y la
+más reciente.
+
+## Fuera de alcance
 
 **Exportar e importar versiones entre instalaciones** (punto 3 de las decisiones
 pendientes). Descartado para esta entrega; el modelo queda preparado con
 identificadores estables y número de versión.
 
-**El control de retención en la interfaz de Ajustes.** La política se lee de
-`app_settings` y se puede cambiar ahí, pero no hay pantalla que la exponga.
-
-**Comparar resultados entre dos simulaciones** (parte del punto 5). Se compara la
-red entre versiones; comparar dos ejecuciones es otra funcionalidad.

--- a/docs/VERSIONADO_INMUTABLE.md
+++ b/docs/VERSIONADO_INMUTABLE.md
@@ -1,0 +1,129 @@
+# Versionado inmutable de redes y simulaciones
+
+Diseño y decisiones del issue [#38](https://github.com/Boorie-AI/boorie_cliente/issues/38).
+Es prerrequisito de la indexación de simulaciones en el RAG por versión
+([#41](https://github.com/Boorie-AI/boorie_cliente/issues/41)).
+
+## Lo que decían los datos antes de empezar
+
+El issue parte de que «sólo se conserva la última simulación» porque
+`HydraulicNetwork.simulationResults` se sobrescribe. Sobre una base real eso
+resultó ser **medio cierto**, y la mitad que falla cambia el objetivo:
+
+| | |
+|---|---|
+| Base de datos | 30,3 MB |
+| De los cuales, resultados de simulación | **21,4 MB en 40 filas** |
+| `simulationResults` en las cinco redes | **vacío** |
+
+Los resultados no se guardan en ese campo: la aplicación escribe en
+`hydraulic_calculations`, que **ya acumula histórico**. Lo que falta no es
+conservar, es saber **sobre qué estado de la red se calculó cada resultado**. Y no
+hay ninguna retención, que es lo que ya costaba 21 MB con una red de 97 nudos —la
+misma simulación sobre una de 3.358 rondaría los 80 MB—.
+
+## El modelo
+
+`HydraulicNetwork` sigue siendo **el estado vigente**: lo que se abre, se pinta y
+se simula. El historial vive aparte y no se reescribe nunca.
+
+```
+HydraulicProject
+  └─ HydraulicNetwork          ← contenedor: el estado de ahora
+       └─ NetworkVersion       ← copias congeladas, sólo se añaden
+            └─ SimulationRun   ← cada ejecución, atada a la versión con la que corrió
+```
+
+| Pieza | Fichero |
+|---|---|
+| Reglas puras: retención y comparación | `backend/services/hydraulic/versionado.ts` |
+| Persistencia | `backend/services/hydraulic/networkVersions.ts` |
+| Canales IPC | `network-version:*` en `networkRepository.handler.ts` |
+| Interfaz del historial | `src/components/hydraulic/HistorialRed.tsx` |
+| Esquema y DDL de producción | `prisma/schema.prisma`, `electron/main.ts` |
+
+## Decisiones
+
+**La restricción `@@unique([projectId, name])` se conserva, no se elimina.** El
+issue ofrecía las dos opciones y ésta es la buena. Con la red como contenedor,
+reimportar un `.inp` corregido crea una versión de **la misma fila**, no una
+segunda red: la restricción deja de estorbar y pasa a significar lo correcto —un
+nombre identifica una red, no uno de sus estados—. Lo que había que cambiar no era
+el esquema sino la conducta, que era rechazar el guardado con un error.
+
+**Versionado explícito, más automático antes de pisar datos.** El ingeniero guarda
+una versión y le pone una nota. Además, Boorie versiona solo antes de reimportar
+un `.inp` sobre una red existente y antes de restaurar. El automático en cada
+cambio genera un historial de ruido que nadie consulta.
+
+**Restaurar guarda antes el estado vigente.** Restaurar es una operación
+destructiva como cualquier otra: sin esa copia, quien restaura por error pierde
+justamente aquello a lo que querría volver. El historial lo deja escrito con su
+nota, «Estado anterior a restaurar la versión N».
+
+**Retención: hitos siempre, más las 10 últimas sin marcar.** Configurable en
+`app_settings` (`retencion.versionesSinMarcar`); si no hay ajuste, rige el valor
+por defecto. La más reciente se conserva siempre, aunque la política sea cero:
+quedarse sin ninguna versión convertiría la retención en una forma de perder el
+historial entero. La poda corre al añadir, que es cuando el historial crece.
+
+**`hydraulic_calculations` no se migra, y es deliberado.** De los 40 resultados
+guardados en una base real, **29 no registran ningún `networkId`** —su campo
+`inputs` está vacío— y 11 sí. Atribuirles una versión sería inventarse justamente
+la trazabilidad que falta. Se quedan donde están, intactos, y las simulaciones
+nuevas se registran además en `SimulationRun`, atadas a la versión con la que
+corrieron. El criterio «la migración preserva el 100 %» se cumple no tocándolos.
+
+**El diff compara la red, no lo que se calculó sobre ella.** La lista de campos es
+explícita: comparar el objeto entero marcaría como «modificado» cualquier nudo que
+llevara dentro su presión de la última simulación. Y `100` y `100.0` no son un
+cambio de diámetro: un `.inp` reescrito cambia el formato de los números, y
+señalarlo llenaría el diff de ruido que esconde los cambios de verdad.
+
+## Migración
+
+Cada red sin versiones recibe la suya, marcada como `migracion`, con la nota
+«Estado inicial, anterior al historial de versiones». Corre en cada arranque y es
+idempotente —sólo mira las redes que no tienen ninguna—, así que también cubre las
+instalaciones que actualicen más tarde. No bloquea el inicio: una base grande no
+debe retrasar la ventana.
+
+El índice único se creó a mano sobre la base existente en lugar de dejar que
+`prisma db push` reconstruyera la tabla: avisaba de posible pérdida de datos, y
+crear el índice directamente no puede perder filas. Se comprobó antes que no
+hubiera nombres duplicados por proyecto.
+
+## Estado de los criterios de aceptación
+
+| Criterio | Estado |
+|---|---|
+| Reimportar un `.inp` modificado crea una versión nueva sin destruir la anterior | Hecho. Antes el guardado se rechazaba con un error. |
+| Ver el historial y restaurar cualquier versión previa | Hecho, con nota, hito, comparación con la anterior y restauración con respaldo. |
+| Cada resultado trazable a la versión exacta y a sus parámetros | Hecho para las simulaciones nuevas. Las 40 anteriores no lo son: los datos para atribuirlas no existen (ver arriba). |
+| Ninguna operación normal destruye datos históricos | Hecho. Restaurar y reimportar versionan antes; la retención sólo poda lo no marcado por encima del tope. |
+| La migración preserva el 100 % de proyectos, redes y resultados | Hecho, verificado por conteo antes y después: 5 proyectos, 5 redes, 40 cálculos, 11 conversaciones, 434 fragmentos. |
+
+## Comprobado en la aplicación
+
+Con la base real: las 5 redes recibieron su versión 1 al arrancar. Sobre
+`Net3 2.inp` se guardó una versión con nota, se marcó como hito, se comparó con la
+anterior —«Sin cambios en la red», que es lo correcto porque nada había cambiado—
+y se restauró la versión 2, que dejó en el historial la `v3` con la nota «Estado
+anterior a restaurar la versión 2».
+
+## Fuera de alcance
+
+**Versionado del proyecto** como instantánea del conjunto de versiones de red
+activas (punto 4 del issue). Responde a «¿cómo estaba este proyecto en la entrega
+de marzo?» a nivel de proyecto, no de red. El modelo lo admite —bastaría una
+entidad que apunte a un conjunto de `NetworkVersion`— pero no se construye aquí.
+
+**Exportar e importar versiones entre instalaciones** (punto 3 de las decisiones
+pendientes). Descartado para esta entrega; el modelo queda preparado con
+identificadores estables y número de versión.
+
+**El control de retención en la interfaz de Ajustes.** La política se lee de
+`app_settings` y se puede cambiar ahí, pero no hay pantalla que la exponga.
+
+**Comparar resultados entre dos simulaciones** (parte del punto 5). Se compara la
+red entre versiones; comparar dos ejecuciones es otra funcionalidad.

--- a/electron/handlers/index.ts
+++ b/electron/handlers/index.ts
@@ -22,6 +22,7 @@ import { HydraulicHandler } from './hydraulic.handler'
 import { setupWNTRHandlers } from './wntr.handler'
 import { registerWisdomHandlers, registerVectorGraphHandlers, registerWisdomExtendedHandlers, registerChatAttachmentHandler } from './document.handler'
 import { NetworkRepositoryHandler } from './networkRepository.handler'
+import { NetworkVersionService } from '../../backend/services/hydraulic/networkVersions'
 import { registerAgenticRAGHandlers } from './agenticRAG.handler'
 import { registerGuardrailsHandlers } from './guardrails.handler'
 import { registerMilvusHandlers } from './milvus.handler'
@@ -49,6 +50,17 @@ export class HandlersManager {
     this.authHandler = new AuthHandler(services.database)
     this.hydraulicHandler = new HydraulicHandler(services)
     this.networkRepositoryHandler = new NetworkRepositoryHandler(services.database.prisma)
+
+    /**
+     * Las redes guardadas antes del historial arrancan con su versión inicial
+     * (#38). Es idempotente —sólo mira las que no tienen ninguna— así que puede
+     * correr en cada arranque, y no bloquea el inicio: una base grande no debe
+     * retrasar la ventana.
+     */
+    new NetworkVersionService(services.database.prisma)
+      .migrarRedesSinVersion()
+      .then(n => { if (n > 0) console.log(`Historial de versiones: ${n} redes migradas`) })
+      .catch(e => console.warn('No se pudo migrar el historial de versiones:', e?.message))
 
     // Setup WNTR handlers
     setupWNTRHandlers()

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { app, dialog, ipcMain } from 'electron'
 import { readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -438,6 +438,65 @@ export class NetworkRepositoryHandler {
         await this.versiones.borrarSnapshot(snapshotId)
         return { success: true }
       } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    // --- Intercambio entre instalaciones (#38) ---
+
+    /** Nombre de fichero sin caracteres que molesten en Windows. */
+    const nombreSeguro = (texto: string) =>
+      texto.replace(/[\\/:*?"<>|]/g, '-').replace(/\s+/g, '_').slice(0, 60)
+
+    const guardarPaquete = async (contenido: string, sugerido: string) => {
+      const r = await dialog.showSaveDialog({
+        title: 'Exportar para otra instalación de Boorie',
+        defaultPath: `${nombreSeguro(sugerido)}.boorie.json`,
+        filters: [{ name: 'Paquete de Boorie', extensions: ['json'] }],
+      })
+      if (r.canceled || !r.filePath) return { success: false, error: 'Exportación cancelada' }
+
+      await writeFile(r.filePath, contenido, 'utf-8')
+      return { success: true, filePath: r.filePath }
+    }
+
+    ipcMain.handle('network-version:export', async (_, data: { versionId: string; nombre: string }) => {
+      try {
+        const contenido = await this.versiones.exportarVersion(data.versionId, `Boorie ${app.getVersion()}`)
+        return await guardarPaquete(contenido, data.nombre)
+      } catch (error) {
+        appLogger.error('Failed to export network version', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('project-snapshot:export', async (_, data: { snapshotId: string; nombre: string }) => {
+      try {
+        const contenido = await this.versiones.exportarSnapshot(data.snapshotId, `Boorie ${app.getVersion()}`)
+        return await guardarPaquete(contenido, data.nombre)
+      } catch (error) {
+        appLogger.error('Failed to export project snapshot', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:import', async (_, projectId: string) => {
+      try {
+        const elegido = await dialog.showOpenDialog({
+          title: 'Importar un paquete de Boorie',
+          properties: ['openFile'],
+          filters: [{ name: 'Paquete de Boorie', extensions: ['json'] }],
+        })
+        if (elegido.canceled || elegido.filePaths.length === 0) {
+          return { success: false, error: 'Importación cancelada' }
+        }
+
+        const texto = await readFile(elegido.filePaths[0], 'utf-8')
+        const r = await this.versiones.importarPaquete(projectId, texto)
+        appLogger.success('Package imported', { projectId, ...r })
+        return { success: true, data: r }
+      } catch (error) {
+        appLogger.error('Failed to import package', error as Error)
         return { success: false, error: (error as Error).message }
       }
     })

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -384,6 +384,64 @@ export class NetworkRepositoryHandler {
       }
     })
 
+    ipcMain.handle('network-version:compare-simulations', async (_, data: {
+      runA: string
+      runB: string
+      paso?: number
+    }) => {
+      try {
+        return { success: true, data: await this.versiones.compararSimulaciones(data.runA, data.runB, data.paso ?? 0) }
+      } catch (error) {
+        appLogger.error('Failed to compare simulation runs', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    // --- Instantáneas de proyecto (#38) ---
+
+    ipcMain.handle('project-snapshot:list', async (_, projectId: string) => {
+      try {
+        return { success: true, data: await this.versiones.listarSnapshots(projectId) }
+      } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('project-snapshot:create', async (_, data: {
+      projectId: string
+      label: string
+      note?: string
+    }) => {
+      try {
+        const s = await this.versiones.crearSnapshot(data.projectId, data)
+        appLogger.success('Project snapshot created', { projectId: data.projectId, redes: s.redes })
+        return { success: true, data: s }
+      } catch (error) {
+        appLogger.error('Failed to create project snapshot', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('project-snapshot:restore', async (_, snapshotId: string) => {
+      try {
+        const r = await this.versiones.restaurarSnapshot(snapshotId)
+        appLogger.success('Project snapshot restored', { snapshotId, redes: r.restauradas })
+        return { success: true, data: r }
+      } catch (error) {
+        appLogger.error('Failed to restore project snapshot', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('project-snapshot:delete', async (_, snapshotId: string) => {
+      try {
+        await this.versiones.borrarSnapshot(snapshotId)
+        return { success: true }
+      } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
     // Get network details
     ipcMain.handle('network-repo:get', async (_, networkId: string) => {
       try {

--- a/electron/handlers/networkRepository.handler.ts
+++ b/electron/handlers/networkRepository.handler.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { NetworkRepositoryService } from '../../backend/services/hydraulic/networkRepository'
+import { NetworkVersionService } from '../../backend/services/hydraulic/networkVersions'
 import { construirResumenRed, formatearContextoRed } from '../../backend/services/hydraulic/networkContext'
 import { leerRedActiva } from '../../backend/services/hydraulic/redActiva'
 import { proveedorSoportaHerramientas } from '../../backend/services/ai/toolWire'
@@ -11,11 +12,13 @@ import { appLogger } from '../../backend/utils/logger'
 
 export class NetworkRepositoryHandler {
   private networkRepo: NetworkRepositoryService
+  private versiones: NetworkVersionService
   private prisma: PrismaClient
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma
     this.networkRepo = new NetworkRepositoryService(prisma)
+    this.versiones = new NetworkVersionService(prisma)
     this.setupHandlers()
   }
 
@@ -67,6 +70,42 @@ export class NetworkRepositoryHandler {
           throw new Error('Falta el contenido del .inp: envia fileContent o filePath')
         }
 
+        /**
+         * Reimportar un `.inp` con el mismo nombre ya no es un error (#38).
+         *
+         * Antes el repositorio lo rechazaba, porque la restricción única impedía
+         * dos redes con el mismo nombre en un proyecto. Ahora la red es el
+         * contenedor: se congela su estado como versión —automáticamente, que es
+         * justo el caso de «operación que pisaría datos»— y se actualiza encima.
+         */
+        const existente = await this.prisma.hydraulicNetwork.findFirst({
+          where: { projectId: data.projectId, name: data.networkData.name, isActive: true },
+          select: { id: true },
+        })
+
+        if (existente) {
+          const respaldo = await this.versiones.crearVersion(existente.id, {
+            origen: 'importacion',
+            changeNote: `Estado anterior a reimportar ${data.filename}`,
+          })
+          const actualizada = await this.networkRepo.updateNetwork(
+            existente.id,
+            data.networkData,
+            fileContent ?? '',
+            data.filename,
+            data.description
+          )
+          await this.versiones.crearVersion(existente.id, {
+            origen: 'importacion',
+            changeNote: `Importado ${data.filename}`,
+          })
+          appLogger.success('Network re-imported as a new version', {
+            networkId: existente.id,
+            respaldo: respaldo.versionNumber,
+          })
+          return { success: true, data: actualizada, versionada: true }
+        }
+
         const savedNetwork = await this.networkRepo.saveNetwork(
           data.projectId,
           data.networkData,
@@ -75,6 +114,13 @@ export class NetworkRepositoryHandler {
           data.description,
           data.scenario
         )
+
+        // Toda red guardada arranca con su versión 1: sin ella no habría nada
+        // sobre lo que registrar simulaciones ni a lo que volver.
+        await this.versiones.crearVersion(savedNetwork.id, {
+          origen: 'importacion',
+          changeNote: `Importado ${data.filename}`,
+        })
 
         appLogger.success('Network saved successfully', {
           networkId: savedNetwork.id,
@@ -213,6 +259,128 @@ export class NetworkRepositoryHandler {
           success: false,
           error: (error as Error).message
         }
+      }
+    })
+
+    // --- Historial inmutable de versiones (#38) ---
+
+    ipcMain.handle('network-version:list', async (_, networkId: string) => {
+      try {
+        return { success: true, data: await this.versiones.listarVersiones(networkId) }
+      } catch (error) {
+        appLogger.error('Failed to list network versions', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:create', async (_, data: {
+      networkId: string
+      changeNote?: string
+      marcada?: boolean
+    }) => {
+      try {
+        const version = await this.versiones.crearVersion(data.networkId, {
+          changeNote: data.changeNote,
+          marcada: data.marcada,
+          origen: 'manual',
+        })
+        // La retención se aplica al añadir, que es cuando el historial crece.
+        const podadas = await this.versiones.podarSegunAjustes(data.networkId)
+        appLogger.success('Network version created', {
+          networkId: data.networkId,
+          version: version.versionNumber,
+          podadas,
+        })
+        return { success: true, data: version, podadas }
+      } catch (error) {
+        appLogger.error('Failed to create network version', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    /**
+     * Abre una versión: devuelve sus datos y materializa su `.inp` en un
+     * temporal, igual que `network-repo:load`, para poder simular sobre ella.
+     */
+    ipcMain.handle('network-version:open', async (_, versionId: string) => {
+      try {
+        const v = await this.versiones.leerVersion(versionId)
+        const filePath = join(tmpdir(), `boorie-version-${versionId}.inp`)
+        await writeFile(filePath, v.fileContent, 'utf-8')
+        return { success: true, data: v.networkData, version: v.version, filePath }
+      } catch (error) {
+        appLogger.error('Failed to open network version', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:restore', async (_, versionId: string) => {
+      try {
+        const r = await this.versiones.restaurarVersion(versionId)
+        appLogger.success('Network version restored', { versionId, respaldo: r.respaldo.versionNumber })
+        return { success: true, data: r }
+      } catch (error) {
+        appLogger.error('Failed to restore network version', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:mark', async (_, data: { versionId: string; marcada: boolean }) => {
+      try {
+        return { success: true, data: await this.versiones.marcarVersion(data.versionId, data.marcada) }
+      } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:compare', async (_, data: { versionA: string; versionB: string }) => {
+      try {
+        return { success: true, data: await this.versiones.compararVersiones(data.versionA, data.versionB) }
+      } catch (error) {
+        appLogger.error('Failed to compare network versions', error as Error)
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:simulations', async (_, networkId: string) => {
+      try {
+        return { success: true, data: await this.versiones.listarSimulaciones(networkId) }
+      } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    ipcMain.handle('network-version:simulation-results', async (_, runId: string) => {
+      try {
+        return { success: true, data: await this.versiones.leerSimulacion(runId) }
+      } catch (error) {
+        return { success: false, error: (error as Error).message }
+      }
+    })
+
+    /** Registra una ejecución contra la versión vigente de la red. */
+    ipcMain.handle('network-version:record-simulation', async (_, data: {
+      networkId: string
+      tipo: string
+      parameters: unknown
+      results: unknown
+      engineVersion?: string
+    }) => {
+      try {
+        const versiones = await this.versiones.listarVersiones(data.networkId)
+        if (versiones.length === 0) {
+          return { success: false, error: 'La red no tiene ninguna versión sobre la que registrar la simulación' }
+        }
+        const run = await this.versiones.registrarSimulacion(versiones[0].id, {
+          tipo: data.tipo,
+          parameters: data.parameters,
+          results: data.results,
+          engineVersion: data.engineVersion,
+        })
+        return { success: true, data: run }
+      } catch (error) {
+        appLogger.error('Failed to record simulation run', error as Error)
+        return { success: false, error: (error as Error).message }
       }
     })
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -476,6 +476,25 @@ async function ensureProductionSchema(prismaClient: any): Promise<void> {
     `CREATE INDEX IF NOT EXISTS "network_versions_networkId_idx" ON "network_versions"("networkId")`,
     `CREATE INDEX IF NOT EXISTS "simulation_runs_networkVersionId_idx" ON "simulation_runs"("networkVersionId")`,
     `CREATE UNIQUE INDEX IF NOT EXISTS "network_versions_networkId_versionNumber_key" ON "network_versions"("networkId", "versionNumber")`,
+    `CREATE TABLE IF NOT EXISTS "project_snapshots" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "projectId" TEXT NOT NULL,
+      "label" TEXT NOT NULL,
+      "note" TEXT,
+      "author" TEXT,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "project_snapshots_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "hydraulic_projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`,
+    `CREATE TABLE IF NOT EXISTS "project_snapshot_entries" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "snapshotId" TEXT NOT NULL,
+      "networkVersionId" TEXT NOT NULL,
+      CONSTRAINT "project_snapshot_entries_snapshotId_fkey" FOREIGN KEY ("snapshotId") REFERENCES "project_snapshots" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+      CONSTRAINT "project_snapshot_entries_networkVersionId_fkey" FOREIGN KEY ("networkVersionId") REFERENCES "network_versions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`,
+    `CREATE INDEX IF NOT EXISTS "project_snapshots_projectId_idx" ON "project_snapshots"("projectId")`,
+    `CREATE INDEX IF NOT EXISTS "project_snapshot_entries_networkVersionId_idx" ON "project_snapshot_entries"("networkVersionId")`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "project_snapshot_entries_snapshotId_networkVersionId_key" ON "project_snapshot_entries"("snapshotId", "networkVersionId")`,
 
     // Unique indexes
     `CREATE UNIQUE INDEX IF NOT EXISTS "ai_providers_name_key" ON "ai_providers"("name")`,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -446,6 +446,37 @@ async function ensureProductionSchema(prismaClient: any): Promise<void> {
       "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
       "updatedAt" DATETIME NOT NULL
     )`,
+    // Historial inmutable de redes y simulaciones (#38)
+    `CREATE TABLE IF NOT EXISTS "network_versions" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "networkId" TEXT NOT NULL,
+      "versionNumber" INTEGER NOT NULL,
+      "networkData" TEXT NOT NULL,
+      "fileContent" TEXT NOT NULL,
+      "coordinateSystem" TEXT,
+      "summary" TEXT NOT NULL,
+      "changeNote" TEXT,
+      "author" TEXT,
+      "origen" TEXT NOT NULL DEFAULT 'manual',
+      "marcada" INTEGER NOT NULL DEFAULT 0,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "network_versions_networkId_fkey" FOREIGN KEY ("networkId") REFERENCES "hydraulic_networks" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`,
+    `CREATE TABLE IF NOT EXISTS "simulation_runs" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "networkVersionId" TEXT NOT NULL,
+      "tipo" TEXT NOT NULL,
+      "parameters" TEXT NOT NULL,
+      "results" TEXT NOT NULL,
+      "engineVersion" TEXT,
+      "marcada" INTEGER NOT NULL DEFAULT 0,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "simulation_runs_networkVersionId_fkey" FOREIGN KEY ("networkVersionId") REFERENCES "network_versions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`,
+    `CREATE INDEX IF NOT EXISTS "network_versions_networkId_idx" ON "network_versions"("networkId")`,
+    `CREATE INDEX IF NOT EXISTS "simulation_runs_networkVersionId_idx" ON "simulation_runs"("networkVersionId")`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "network_versions_networkId_versionNumber_key" ON "network_versions"("networkId", "versionNumber")`,
+
     // Unique indexes
     `CREATE UNIQUE INDEX IF NOT EXISTS "ai_providers_name_key" ON "ai_providers"("name")`,
     `CREATE UNIQUE INDEX IF NOT EXISTS "ai_models_providerId_modelId_key" ON "ai_models"("providerId", "modelId")`,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -203,6 +203,30 @@ const electronAPI = {
     getStats: (projectId: string) => ipcRenderer.invoke('network-repo:stats', projectId),
   },
 
+  /** Historial inmutable de versiones y simulaciones (#38) */
+  networkVersions: {
+    list: (networkId: string) => ipcRenderer.invoke('network-version:list', networkId),
+    create: (data: { networkId: string; changeNote?: string; marcada?: boolean }) =>
+      ipcRenderer.invoke('network-version:create', data),
+    /** Abre una versión y materializa su .inp para poder simular sobre ella. */
+    open: (versionId: string) => ipcRenderer.invoke('network-version:open', versionId),
+    restore: (versionId: string) => ipcRenderer.invoke('network-version:restore', versionId),
+    mark: (data: { versionId: string; marcada: boolean }) =>
+      ipcRenderer.invoke('network-version:mark', data),
+    compare: (data: { versionA: string; versionB: string }) =>
+      ipcRenderer.invoke('network-version:compare', data),
+    simulations: (networkId: string) => ipcRenderer.invoke('network-version:simulations', networkId),
+    simulationResults: (runId: string) =>
+      ipcRenderer.invoke('network-version:simulation-results', runId),
+    recordSimulation: (data: {
+      networkId: string
+      tipo: string
+      parameters: unknown
+      results: unknown
+      engineVersion?: string
+    }) => ipcRenderer.invoke('network-version:record-simulation', data),
+  },
+
   // WNTR operations
   wntr: {
     // Python/WNTR status check

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -218,6 +218,8 @@ const electronAPI = {
     simulations: (networkId: string) => ipcRenderer.invoke('network-version:simulations', networkId),
     simulationResults: (runId: string) =>
       ipcRenderer.invoke('network-version:simulation-results', runId),
+    compareSimulations: (data: { runA: string; runB: string; paso?: number }) =>
+      ipcRenderer.invoke('network-version:compare-simulations', data),
     recordSimulation: (data: {
       networkId: string
       tipo: string
@@ -225,6 +227,15 @@ const electronAPI = {
       results: unknown
       engineVersion?: string
     }) => ipcRenderer.invoke('network-version:record-simulation', data),
+  },
+
+  /** Instantáneas de proyecto: qué versión de cada red estaba vigente (#38) */
+  projectSnapshots: {
+    list: (projectId: string) => ipcRenderer.invoke('project-snapshot:list', projectId),
+    create: (data: { projectId: string; label: string; note?: string }) =>
+      ipcRenderer.invoke('project-snapshot:create', data),
+    restore: (snapshotId: string) => ipcRenderer.invoke('project-snapshot:restore', snapshotId),
+    delete: (snapshotId: string) => ipcRenderer.invoke('project-snapshot:delete', snapshotId),
   },
 
   // WNTR operations

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -218,6 +218,11 @@ const electronAPI = {
     simulations: (networkId: string) => ipcRenderer.invoke('network-version:simulations', networkId),
     simulationResults: (runId: string) =>
       ipcRenderer.invoke('network-version:simulation-results', runId),
+    /** Exporta una versión a un fichero para otra instalación (#38). */
+    exportar: (data: { versionId: string; nombre: string }) =>
+      ipcRenderer.invoke('network-version:export', data),
+    /** Importa un paquete en el proyecto indicado. */
+    importar: (projectId: string) => ipcRenderer.invoke('network-version:import', projectId),
     compareSimulations: (data: { runA: string; runB: string; paso?: number }) =>
       ipcRenderer.invoke('network-version:compare-simulations', data),
     recordSimulation: (data: {
@@ -235,6 +240,8 @@ const electronAPI = {
     create: (data: { projectId: string; label: string; note?: string }) =>
       ipcRenderer.invoke('project-snapshot:create', data),
     restore: (snapshotId: string) => ipcRenderer.invoke('project-snapshot:restore', snapshotId),
+    exportar: (data: { snapshotId: string; nombre: string }) =>
+      ipcRenderer.invoke('project-snapshot:export', data),
     delete: (snapshotId: string) => ipcRenderer.invoke('project-snapshot:delete', snapshotId),
   },
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,7 @@ model HydraulicProject {
   updatedAt   DateTime @updatedAt
 
   calculations  HydraulicCalculation[]
+  snapshots     ProjectSnapshot[]
   documents     ProjectDocument[]
   teamMembers   ProjectTeamMember[]
   conversations Conversation[]
@@ -391,6 +392,10 @@ model NetworkVersion {
 
   simulations SimulationRun[]
 
+  /// Instantáneas de proyecto que apuntan a esta versión. Mientras haya una, la
+  /// retención no puede podarla: dejaría la instantánea apuntando al vacío.
+  enSnapshots ProjectSnapshotEntry[]
+
   @@unique([networkId, versionNumber])
   @@index([networkId])
   @@map("network_versions")
@@ -415,6 +420,40 @@ model SimulationRun {
 
   @@index([networkVersionId])
   @@map("simulation_runs")
+}
+
+/// Instantánea de un proyecto: qué versión de cada red estaba vigente (#38).
+///
+/// Responde a «¿cómo estaba este proyecto en la entrega de marzo?» a nivel de
+/// proyecto y no de red. No copia nada: apunta a versiones que ya son inmutables,
+/// así que una instantánea de un proyecto entero cuesta unas pocas filas.
+model ProjectSnapshot {
+  id        String           @id @default(cuid())
+  projectId String
+  project   HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  /// Cómo la reconoce el ingeniero: «Entrega de marzo».
+  label     String
+  note      String?
+  author    String?
+  createdAt DateTime @default(now())
+
+  entries ProjectSnapshotEntry[]
+
+  @@index([projectId])
+  @@map("project_snapshots")
+}
+
+model ProjectSnapshotEntry {
+  id               String          @id @default(cuid())
+  snapshotId       String
+  snapshot         ProjectSnapshot @relation(fields: [snapshotId], references: [id], onDelete: Cascade)
+  networkVersionId String
+  networkVersion   NetworkVersion  @relation(fields: [networkVersionId], references: [id], onDelete: Cascade)
+
+  @@unique([snapshotId, networkVersionId])
+  @@index([networkVersionId])
+  @@map("project_snapshot_entries")
 }
 
 // RLHF Feedback System

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,16 +9,16 @@ datasource db {
 }
 
 model Conversation {
-  id          String   @id @default(cuid())
-  title       String
-  model       String
-  provider    String
-  projectId   String?  // Optional link to hydraulic project
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id        String   @id @default(cuid())
+  title     String
+  model     String
+  provider  String
+  projectId String? // Optional link to hydraulic project
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  messages    Message[]
-  project     HydraulicProject? @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  messages Message[]
+  project  HydraulicProject? @relation(fields: [projectId], references: [id], onDelete: SetNull)
 
   @@map("conversations")
 }
@@ -26,31 +26,31 @@ model Conversation {
 model Message {
   id             String   @id @default(cuid())
   conversationId String
-  role           String   // 'user' | 'assistant' | 'system'
+  role           String // 'user' | 'assistant' | 'system'
   content        String
   timestamp      DateTime @default(now())
-  metadata       String?  // JSON as string for additional data
+  metadata       String? // JSON as string for additional data
   createdAt      DateTime @default(now())
 
-  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversation Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
 
   @@map("messages")
 }
 
 model AIProvider {
-  id               String   @id @default(cuid())
-  name             String   @unique
-  type             String   // 'local' | 'api'
-  apiKey           String?  // Encrypted API key
-  isActive         Boolean  @default(false) // Changed to default false
-  isConnected      Boolean  @default(false)
-  lastTestResult   String?  // 'success' | 'error' | null
-  lastTestMessage  String?  // Error message or success details
-  config           String?  // Additional configuration as JSON string
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  id              String   @id @default(cuid())
+  name            String   @unique
+  type            String // 'local' | 'api'
+  apiKey          String? // Encrypted API key
+  isActive        Boolean  @default(false) // Changed to default false
+  isConnected     Boolean  @default(false)
+  lastTestResult  String? // 'success' | 'error' | null
+  lastTestMessage String? // Error message or success details
+  config          String? // Additional configuration as JSON string
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
-  models           AIModel[]
+  models AIModel[]
 
   @@map("ai_providers")
 }
@@ -63,12 +63,12 @@ model AIModel {
   isDefault   Boolean  @default(false)
   isAvailable Boolean  @default(true)
   isSelected  Boolean  @default(false) // New field for user selection
-  description String?  // Model description
-  metadata    String?  // Model-specific metadata as JSON string
+  description String? // Model description
+  metadata    String? // Model-specific metadata as JSON string
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  provider    AIProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  provider AIProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
 
   @@unique([providerId, modelId])
   @@map("ai_models")
@@ -78,7 +78,7 @@ model AppSetting {
   id        String   @id @default(cuid())
   key       String   @unique
   value     String
-  category  String?  // 'general', 'ai', 'theme', etc.
+  category  String? // 'general', 'ai', 'theme', etc.
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -86,14 +86,14 @@ model AppSetting {
 }
 
 model Document {
-  id          String   @id @default(cuid())
-  filename    String
-  filepath    String
-  content     String
-  metadata    String?  // JSON as string
-  embeddings  String?  // JSON as string
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id         String   @id @default(cuid())
+  filename   String
+  filepath   String
+  content    String
+  metadata   String? // JSON as string
+  embeddings String? // JSON as string
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   chunks DocumentChunk[]
 
@@ -104,8 +104,8 @@ model DocumentChunk {
   id         String   @id @default(cuid())
   documentId String
   content    String
-  embedding  String?  // JSON as string
-  metadata   String?  // JSON as string
+  embedding  String? // JSON as string
+  metadata   String? // JSON as string
   startPos   Int?
   endPos     Int?
   createdAt  DateTime @default(now())
@@ -116,14 +116,14 @@ model DocumentChunk {
 }
 
 model AuthToken {
-  id          String   @id @default(cuid())
-  provider    String
-  tokenType   String
-  accessToken String
+  id           String    @id @default(cuid())
+  provider     String
+  tokenType    String
+  accessToken  String
   refreshToken String?
-  expiresAt   DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  expiresAt    DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   @@unique([provider, tokenType])
   @@map("auth_tokens")
@@ -135,12 +135,12 @@ model EmailMessage {
   messageId   String
   subject     String
   from        String
-  to          String   // JSON as string
-  cc          String?  // JSON as string
-  bcc         String?  // JSON as string
+  to          String // JSON as string
+  cc          String? // JSON as string
+  bcc         String? // JSON as string
   body        String
   htmlBody    String?
-  attachments String?  // JSON as string
+  attachments String? // JSON as string
   isRead      Boolean  @default(false)
   isImportant Boolean  @default(false)
   receivedAt  DateTime
@@ -161,7 +161,7 @@ model CalendarEvent {
   startTime   DateTime
   endTime     DateTime
   isAllDay    Boolean  @default(false)
-  attendees   String?  // JSON as string
+  attendees   String? // JSON as string
   organizer   String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -171,16 +171,16 @@ model CalendarEvent {
 }
 
 model UserProfile {
-  id          String   @id @default(cuid())
-  provider    String   // 'microsoft' | 'google'
-  providerId  String   // User ID from provider
-  email       String
-  name        String?
-  pictureUrl  String?
-  isActive    Boolean  @default(true)
-  metadata    String?  // Additional profile data as JSON
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id         String   @id @default(cuid())
+  provider   String // 'microsoft' | 'google'
+  providerId String // User ID from provider
+  email      String
+  name       String?
+  pictureUrl String?
+  isActive   Boolean  @default(true)
+  metadata   String? // Additional profile data as JSON
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   @@unique([provider, providerId])
   @@map("user_profiles")
@@ -188,18 +188,18 @@ model UserProfile {
 
 // Hydraulic Engineering Models
 model HydraulicProject {
-  id            String   @id @default(cuid())
-  name          String
-  description   String?
-  type          String   // 'design' | 'analysis' | 'optimization' | 'troubleshooting'
-  networkType   String   // 'distribution' | 'transmission' | 'collection'
-  location      String   // JSON with country, region, city, coordinates
-  status        String   // 'planning' | 'design' | 'review' | 'approved' | 'construction' | 'completed'
-  regulations   String   // JSON array of regulation IDs
-  wntrModel     String?  // JSON serialized WNTR model
-  metadata      String?  // Additional project metadata
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  type        String // 'design' | 'analysis' | 'optimization' | 'troubleshooting'
+  networkType String // 'distribution' | 'transmission' | 'collection'
+  location    String // JSON with country, region, city, coordinates
+  status      String // 'planning' | 'design' | 'review' | 'approved' | 'construction' | 'completed'
+  regulations String // JSON array of regulation IDs
+  wntrModel   String? // JSON serialized WNTR model
+  metadata    String? // Additional project metadata
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
   calculations  HydraulicCalculation[]
   documents     ProjectDocument[]
@@ -211,20 +211,20 @@ model HydraulicProject {
 }
 
 model HydraulicCalculation {
-  id          String   @id @default(cuid())
-  projectId   String
-  type        String   // 'pipe_sizing' | 'pump_selection' | 'head_loss' | 'water_hammer' | etc
-  name        String
-  inputs      String   // JSON with calculation inputs
-  results     String   // JSON with calculation results
-  formulas    String   // JSON array of formulas used
-  verified    Boolean  @default(false)
-  verifiedBy  String?
-  notes       String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id         String   @id @default(cuid())
+  projectId  String
+  type       String // 'pipe_sizing' | 'pump_selection' | 'head_loss' | 'water_hammer' | etc
+  name       String
+  inputs     String // JSON with calculation inputs
+  results    String // JSON with calculation results
+  formulas   String // JSON array of formulas used
+  verified   Boolean  @default(false)
+  verifiedBy String?
+  notes      String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  project     HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@map("hydraulic_calculations")
 }
@@ -232,17 +232,17 @@ model HydraulicCalculation {
 model ProjectDocument {
   id          String   @id @default(cuid())
   projectId   String
-  type        String   // 'calculation_memory' | 'technical_spec' | 'report' | 'plan' | 'compliance'
+  type        String // 'calculation_memory' | 'technical_spec' | 'report' | 'plan' | 'compliance'
   title       String
-  content     String   // Document content (could be markdown, HTML, etc)
-  metadata    String   // JSON with author, version, status, etc
-  attachments String?  // JSON array of attachment info
+  content     String // Document content (could be markdown, HTML, etc)
+  metadata    String // JSON with author, version, status, etc
+  attachments String? // JSON array of attachment info
   version     String   @default("1.0")
   status      String   @default("draft") // 'draft' | 'review' | 'approved'
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  project     HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@map("project_documents")
 }
@@ -250,12 +250,12 @@ model ProjectDocument {
 model ProjectTeamMember {
   id          String   @id @default(cuid())
   projectId   String
-  userId      String   // Reference to user (could be email or ID)
-  role        String   // 'project_manager' | 'design_engineer' | 'reviewer' | 'client'
-  permissions String   // JSON with specific permissions
+  userId      String // Reference to user (could be email or ID)
+  role        String // 'project_manager' | 'design_engineer' | 'reviewer' | 'client'
+  permissions String // JSON with specific permissions
   joinedAt    DateTime @default(now())
 
-  project     HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@unique([projectId, userId])
   @@map("project_team_members")
@@ -263,73 +263,73 @@ model ProjectTeamMember {
 
 // RAG Knowledge Base Models
 model HydraulicKnowledge {
-  id          String   @id @default(cuid())
-  category    String   // 'hydraulics' | 'regulations' | 'best-practices'
-  subcategory String
-  region      String   // JSON array of applicable regions
+  id                  String   @id @default(cuid())
+  category            String // 'hydraulics' | 'regulations' | 'best-practices'
+  subcategory         String
+  region              String // JSON array of applicable regions
   secondaryCategories String? // JSON array of additional categories
-  title       String
-  content     String   // Main content of the document
-  metadata    String   // JSON with formulas, tables, examples, references
-  keywords    String   // JSON array for search optimization
-  language    String   @default("es")
-  version     String   @default("1.0")
-  status      String   @default("active") // 'draft' | 'active' | 'deprecated'
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  title               String
+  content             String // Main content of the document
+  metadata            String // JSON with formulas, tables, examples, references
+  keywords            String // JSON array for search optimization
+  language            String   @default("es")
+  version             String   @default("1.0")
+  status              String   @default("active") // 'draft' | 'active' | 'deprecated'
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
-  chunks      KnowledgeChunk[]
+  chunks KnowledgeChunk[]
 
   @@map("hydraulic_knowledge")
 }
 
 model KnowledgeChunk {
-  id            String   @id @default(cuid())
-  knowledgeId   String
-  content       String
-  embedding     String?  // Vector embedding as JSON array (nullable until indexed)
-  metadata      String?  // Additional chunk metadata
-  chunkIndex    Int      // Order of chunk in document
-  createdAt     DateTime @default(now())
+  id          String   @id @default(cuid())
+  knowledgeId String
+  content     String
+  embedding   String? // Vector embedding as JSON array (nullable until indexed)
+  metadata    String? // Additional chunk metadata
+  chunkIndex  Int // Order of chunk in document
+  createdAt   DateTime @default(now())
 
-  knowledge     HydraulicKnowledge @relation(fields: [knowledgeId], references: [id], onDelete: Cascade)
+  knowledge HydraulicKnowledge @relation(fields: [knowledgeId], references: [id], onDelete: Cascade)
 
   @@map("knowledge_chunks")
 }
 
 // Hydraulic Components Catalog
 model HydraulicComponent {
-  id              String   @id @default(cuid())
-  type            String   // 'pipe' | 'pump' | 'valve' | 'tank' | 'fitting'
-  manufacturer    String?
-  model           String?
-  specifications  String   // JSON with technical specs
-  priceInfo       String?  // JSON with pricing data
-  availability    String?  // JSON with availability info
-  documentation   String?  // Links to technical docs
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String   @id @default(cuid())
+  type           String // 'pipe' | 'pump' | 'valve' | 'tank' | 'fitting'
+  manufacturer   String?
+  model          String?
+  specifications String // JSON with technical specs
+  priceInfo      String? // JSON with pricing data
+  availability   String? // JSON with availability info
+  documentation  String? // Links to technical docs
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("hydraulic_components")
 }
 
 // Hydraulic Network Storage
 model HydraulicNetwork {
-  id                String   @id @default(cuid())
+  id                String    @id @default(cuid())
   projectId         String
   name              String
   description       String?
-  filename          String   // Original filename (e.g., "network1.inp")
-  fileContent       String   // INP file content
-  networkData       String   // JSON serialized network data from WNTR
-  coordinateSystem  String?  // JSON with coordinate system info
-  summary           String   // JSON with network summary (nodes, pipes, etc.)
-  simulationResults String?  // JSON with last simulation results
-  version           String   @default("1.0")
-  isActive          Boolean  @default(true)
+  filename          String // Original filename (e.g., "network1.inp")
+  fileContent       String // INP file content
+  networkData       String // JSON serialized network data from WNTR
+  coordinateSystem  String? // JSON with coordinate system info
+  summary           String // JSON with network summary (nodes, pipes, etc.)
+  simulationResults String? // JSON with last simulation results
+  version           String    @default("1.0")
+  isActive          Boolean   @default(true)
   lastLoaded        DateTime?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   // Jerarquia madre/hija de escenarios (#31). La red importada es la "madre" y
   // cada escenario derivado (esqueletizacion, interrupcion de servicio...) es una
@@ -338,61 +338,124 @@ model HydraulicNetwork {
   // onDelete: SetNull y no Cascade a proposito: borrar la red original no debe
   // llevarse por delante los escenarios derivados de ella, que pueden tener
   // resultados que el usuario quiere conservar. Se quedan como raiz.
-  parentId          String?
-  parent            HydraulicNetwork?  @relation("EscenariosDeRed", fields: [parentId], references: [id], onDelete: SetNull)
-  scenarios         HydraulicNetwork[] @relation("EscenariosDeRed")
+  parentId  String?
+  parent    HydraulicNetwork?  @relation("EscenariosDeRed", fields: [parentId], references: [id], onDelete: SetNull)
+  scenarios HydraulicNetwork[] @relation("EscenariosDeRed")
 
   /// Etiqueta del escenario, p. ej. "esqueletizada 100 mm". Null en la red madre.
-  scenarioLabel     String?
+  scenarioLabel String?
   /// Carpeta de resultados del escenario, validada por el usuario.
-  resultsPath       String?
+  resultsPath   String?
 
-  project           HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project HydraulicProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  @@index([parentId])
+  /// Versiones inmutables de esta red (#38). La fila de arriba es el estado
+  /// vigente —lo que se abre y se simula—; el historial vive aparte y no se
+  /// modifica nunca, sólo se le añaden entradas.
+  versions NetworkVersion[]
+
   @@unique([projectId, name])
+  @@index([parentId])
   @@map("hydraulic_networks")
+}
+
+/// Una versión de una red, inmutable (#38).
+///
+/// La restricción `@@unique([projectId, name])` se queda, pero cambia de
+/// significado: pasa a ser del contenedor. Antes impedía que coexistieran dos
+/// estados de la misma red y obligaba a pisar el anterior o a inventarse un
+/// nombre; ahora los estados viven aquí y el nombre identifica la red, no una
+/// de sus versiones.
+model NetworkVersion {
+  id        String           @id @default(cuid())
+  networkId String
+  network   HydraulicNetwork @relation(fields: [networkId], references: [id], onDelete: Cascade)
+
+  /// Correlativo por red, empezando en 1. Es lo que ve el ingeniero.
+  versionNumber    Int
+  /// Copia completa del estado en ese momento; nunca se reescribe.
+  networkData      String
+  fileContent      String
+  coordinateSystem String?
+  summary          String
+
+  /// Qué cambió, en palabras del ingeniero.
+  changeNote String?
+  author     String?
+  /// Cómo nació: 'manual' | 'importacion' | 'escenario' | 'migracion'
+  origen     String  @default("manual")
+  /// Hito: la retención no la poda nunca.
+  marcada    Boolean @default(false)
+
+  createdAt DateTime @default(now())
+
+  simulations SimulationRun[]
+
+  @@unique([networkId, versionNumber])
+  @@index([networkId])
+  @@map("network_versions")
+}
+
+/// Una ejecución de simulación, atada a la versión exacta con la que se corrió (#38).
+model SimulationRun {
+  id               String         @id @default(cuid())
+  networkVersionId String
+  networkVersion   NetworkVersion @relation(fields: [networkVersionId], references: [id], onDelete: Cascade)
+
+  /// 'hydraulic' | 'quality' | 'scenario' | 'resilience' ...
+  tipo          String
+  /// Parámetros con los que se lanzó, para poder repetirla.
+  parameters    String
+  results       String
+  /// Versión del motor, para saber con qué se calculó.
+  engineVersion String?
+  marcada       Boolean @default(false)
+
+  createdAt DateTime @default(now())
+
+  @@index([networkVersionId])
+  @@map("simulation_runs")
 }
 
 // RLHF Feedback System
 model Feedback {
-  id            String   @id @default(cuid())
-  query         String   // Original user query
-  response      String   // System response
-  rating        Int      // 1 (thumbs up) or -1 (thumbs down)
-  correction    String?  // Optional user correction text
-  context       String?  // JSON with retrieved documents IDs or content
-  modelUsed     String?  // Name of the model used (e.g., 'gpt-4', 'llama3')
-  category      String?  // 'hydraulics', 'regulations', etc.
-  userId        String?  // Optional user ID
-  createdAt     DateTime @default(now())
-  
+  id         String   @id @default(cuid())
+  query      String // Original user query
+  response   String // System response
+  rating     Int // 1 (thumbs up) or -1 (thumbs down)
+  correction String? // Optional user correction text
+  context    String? // JSON with retrieved documents IDs or content
+  modelUsed  String? // Name of the model used (e.g., 'gpt-4', 'llama3')
+  category   String? // 'hydraulics', 'regulations', etc.
+  userId     String? // Optional user ID
+  createdAt  DateTime @default(now())
+
   @@map("feedback")
 }
 
 model LongTermMemory {
-  id          String   @id @default(cuid())
-  key         String   // Subject or Topic
-  value       String   // The fact or summary
-  category    String?  // 'summary', 'fact', 'user_preference'
-  confidence  Float    @default(1.0)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id         String   @id @default(cuid())
+  key        String // Subject or Topic
+  value      String // The fact or summary
+  category   String? // 'summary', 'fact', 'user_preference'
+  confidence Float    @default(1.0)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   @@map("long_term_memory")
 }
 
 model GuardrailViolation {
   id             String   @id @default(cuid())
-  conversationId String?  // Optional link to conversation
-  messageId      String?  // Optional link to message that triggered the rail
-  rail           String   // 'input' | 'retrieval' | 'output' | 'execution'
-  severity       String   // 'low' | 'medium' | 'high' | 'critical'
-  reason         String   // Human-readable reason from the rail
-  blocked        Boolean  @default(true)  // false when in advisory/warn mode
-  judgeModel     String?  // Model used to evaluate (e.g. 'nemotron-mini', 'nemoguard')
-  judgeProvider  String?  // 'ollama' | 'nvidia-api'
-  payload        String?  // JSON: input snippet, retrieved chunks, output snippet
+  conversationId String? // Optional link to conversation
+  messageId      String? // Optional link to message that triggered the rail
+  rail           String // 'input' | 'retrieval' | 'output' | 'execution'
+  severity       String // 'low' | 'medium' | 'high' | 'critical'
+  reason         String // Human-readable reason from the rail
+  blocked        Boolean  @default(true) // false when in advisory/warn mode
+  judgeModel     String? // Model used to evaluate (e.g. 'nemotron-mini', 'nemoguard')
+  judgeProvider  String? // 'ollama' | 'nvidia-api'
+  payload        String? // JSON: input snippet, retrieved chunks, output snippet
   createdAt      DateTime @default(now())
 
   @@index([conversationId])

--- a/src/components/hydraulic/HistorialRed.tsx
+++ b/src/components/hydraulic/HistorialRed.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle, GitCompare, History, RotateCcw, Star, Plus } from 'lucide-react'
+import { Activity, AlertTriangle, GitCompare, History, RotateCcw, Star, Plus } from 'lucide-react'
 import { logger } from '@/utils/logger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -37,6 +37,13 @@ const ORIGEN: Record<Version['origen'], string> = {
   migracion: 'Estado inicial',
 }
 
+interface Simulacion {
+  id: string
+  versionNumber: number
+  tipo: string
+  createdAt: string
+}
+
 interface HistorialRedProps {
   abierto: boolean
   onCerrar: () => void
@@ -59,14 +66,22 @@ export function HistorialRed({
   const [nota, setNota] = useState('')
   const [comparacion, setComparacion] = useState<{ contra: number; resumen: string } | null>(null)
   const [confirmarRestaurar, setConfirmarRestaurar] = useState<Version | null>(null)
+  const [simulaciones, setSimulaciones] = useState<Simulacion[]>([])
+  /** Las dos ejecuciones elegidas para comparar. */
+  const [elegidas, setElegidas] = useState<string[]>([])
+  const [comparaSims, setComparaSims] = useState<string | null>(null)
 
   const recargar = useCallback(async () => {
     setCargando(true)
     setError(null)
     try {
-      const r = await window.electronAPI.networkVersions.list(networkId)
+      const [r, rs] = await Promise.all([
+        window.electronAPI.networkVersions.list(networkId),
+        window.electronAPI.networkVersions.simulations(networkId),
+      ])
       if (!r?.success) throw new Error(r?.error || 'No se pudo leer el historial')
       setVersiones(r.data)
+      if (rs?.success) setSimulaciones(rs.data)
     } catch (e) {
       logger.error('Error leyendo el historial de versiones:', e)
       setError(e instanceof Error ? e.message : 'No se pudo leer el historial')
@@ -79,6 +94,8 @@ export function HistorialRed({
     if (abierto) {
       setComparacion(null)
       setConfirmarRestaurar(null)
+      setElegidas([])
+      setComparaSims(null)
       recargar()
     }
   }, [abierto, recargar])
@@ -127,6 +144,28 @@ export function HistorialRed({
       setComparacion({ contra: v.versionNumber, resumen: r.data.resumen })
     } catch (e) {
       setError(e instanceof Error ? e.message : 'No se pudo comparar')
+    }
+  }
+
+  /** Se eligen dos: al marcar una tercera, se descarta la más antigua. */
+  const alternarEleccion = (id: string) => {
+    setComparaSims(null)
+    setElegidas(previas =>
+      previas.includes(id) ? previas.filter(x => x !== id) : [...previas, id].slice(-2)
+    )
+  }
+
+  const compararEjecuciones = async () => {
+    if (elegidas.length !== 2) return
+    try {
+      const r = await window.electronAPI.networkVersions.compareSimulations({
+        runA: elegidas[0],
+        runB: elegidas[1],
+      })
+      if (!r?.success) throw new Error(r?.error || 'No se pudieron comparar')
+      setComparaSims(r.data.resumen)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudieron comparar')
     }
   }
 
@@ -233,6 +272,50 @@ export function HistorialRed({
             </div>
           ))}
         </div>
+
+        {simulaciones.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="flex items-center gap-2 text-sm font-medium">
+                <Activity className="h-3.5 w-3.5" />
+                Simulaciones sobre esta red
+              </h3>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={elegidas.length !== 2}
+                onClick={compararEjecuciones}
+              >
+                Comparar las dos elegidas
+              </Button>
+            </div>
+
+            <div className="max-h-40 divide-y divide-border overflow-y-auto rounded-md border border-border">
+              {simulaciones.map(sim => (
+                <button
+                  key={sim.id}
+                  onClick={() => alternarEleccion(sim.id)}
+                  className={cn(
+                    'flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted',
+                    elegidas.includes(sim.id) && 'bg-primary/10'
+                  )}
+                >
+                  <span>
+                    {sim.tipo}
+                    <span className="ml-2 text-muted-foreground">versión {sim.versionNumber}</span>
+                  </span>
+                  <span className="text-muted-foreground">{fecha(sim.createdAt)}</span>
+                </button>
+              ))}
+            </div>
+
+            {comparaSims && (
+              <p className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs">
+                {comparaSims}
+              </p>
+            )}
+          </div>
+        )}
 
         {confirmarRestaurar && (
           <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs">

--- a/src/components/hydraulic/HistorialRed.tsx
+++ b/src/components/hydraulic/HistorialRed.tsx
@@ -1,0 +1,259 @@
+/**
+ * Historial de versiones de una red (#38).
+ *
+ * Responde a «¿cómo estaba esta red en marzo?» y permite volver. Las versiones
+ * son inmutables: aquí se añaden, se marcan como hito y se restauran, pero
+ * ninguna acción reescribe una existente.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, GitCompare, History, RotateCcw, Star, Plus } from 'lucide-react'
+import { logger } from '@/utils/logger'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/utils/cn'
+
+interface Version {
+  id: string
+  versionNumber: number
+  changeNote?: string
+  origen: 'manual' | 'importacion' | 'escenario' | 'migracion'
+  marcada: boolean
+  createdAt: string
+  simulaciones: number
+}
+
+const ORIGEN: Record<Version['origen'], string> = {
+  manual: 'Guardada a mano',
+  importacion: 'Importación',
+  escenario: 'Escenario',
+  migracion: 'Estado inicial',
+}
+
+interface HistorialRedProps {
+  abierto: boolean
+  onCerrar: () => void
+  networkId: string
+  nombreRed: string
+  /** Se llama tras restaurar, para que la vista recargue la red. */
+  onRestaurada?: () => void
+}
+
+export function HistorialRed({
+  abierto,
+  onCerrar,
+  networkId,
+  nombreRed,
+  onRestaurada,
+}: HistorialRedProps) {
+  const [versiones, setVersiones] = useState<Version[]>([])
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [nota, setNota] = useState('')
+  const [comparacion, setComparacion] = useState<{ contra: number; resumen: string } | null>(null)
+  const [confirmarRestaurar, setConfirmarRestaurar] = useState<Version | null>(null)
+
+  const recargar = useCallback(async () => {
+    setCargando(true)
+    setError(null)
+    try {
+      const r = await window.electronAPI.networkVersions.list(networkId)
+      if (!r?.success) throw new Error(r?.error || 'No se pudo leer el historial')
+      setVersiones(r.data)
+    } catch (e) {
+      logger.error('Error leyendo el historial de versiones:', e)
+      setError(e instanceof Error ? e.message : 'No se pudo leer el historial')
+    } finally {
+      setCargando(false)
+    }
+  }, [networkId])
+
+  useEffect(() => {
+    if (abierto) {
+      setComparacion(null)
+      setConfirmarRestaurar(null)
+      recargar()
+    }
+  }, [abierto, recargar])
+
+  const guardarVersion = async () => {
+    try {
+      const r = await window.electronAPI.networkVersions.create({
+        networkId,
+        changeNote: nota.trim() || undefined,
+      })
+      if (!r?.success) throw new Error(r?.error || 'No se pudo guardar la versión')
+      setNota('')
+      await recargar()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo guardar la versión')
+    }
+  }
+
+  const alternarHito = async (v: Version) => {
+    await window.electronAPI.networkVersions.mark({ versionId: v.id, marcada: !v.marcada })
+    await recargar()
+  }
+
+  const restaurar = async (v: Version) => {
+    try {
+      const r = await window.electronAPI.networkVersions.restore(v.id)
+      if (!r?.success) throw new Error(r?.error || 'No se pudo restaurar')
+      setConfirmarRestaurar(null)
+      await recargar()
+      onRestaurada?.()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo restaurar')
+    }
+  }
+
+  /** Compara una versión con la inmediatamente anterior. */
+  const compararConAnterior = async (v: Version) => {
+    const anterior = versiones.find(x => x.versionNumber === v.versionNumber - 1)
+    if (!anterior) return
+    try {
+      const r = await window.electronAPI.networkVersions.compare({
+        versionA: anterior.id,
+        versionB: v.id,
+      })
+      if (!r?.success) throw new Error(r?.error || 'No se pudo comparar')
+      setComparacion({ contra: v.versionNumber, resumen: r.data.resumen })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo comparar')
+    }
+  }
+
+  const fecha = (iso: string) =>
+    new Date(iso).toLocaleString('es-ES', {
+      day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+    })
+
+  return (
+    <Dialog open={abierto} onOpenChange={v => !v && onCerrar()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <History className="h-4 w-4" />
+            Historial de {nombreRed}
+          </DialogTitle>
+          <DialogDescription>
+            Cada versión es una copia congelada de la red. No se modifican nunca: se añaden, se
+            marcan como hito y se pueden restaurar.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex gap-2">
+          <Input
+            value={nota}
+            onChange={e => setNota(e.target.value)}
+            placeholder="Qué cambió, para reconocerla después"
+            onKeyDown={e => { if (e.key === 'Enter') guardarVersion() }}
+          />
+          <Button size="sm" onClick={guardarVersion} className="shrink-0">
+            <Plus className="mr-2 h-3.5 w-3.5" />
+            Guardar versión
+          </Button>
+        </div>
+
+        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+
+        <div className="max-h-96 divide-y divide-border overflow-y-auto rounded-md border border-border">
+          {cargando && <p className="px-3 py-6 text-center text-sm text-muted-foreground">Cargando…</p>}
+
+          {!cargando && versiones.length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              Esta red todavía no tiene versiones guardadas.
+            </p>
+          )}
+
+          {versiones.map(v => (
+            <div key={v.id} className="px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium">Versión {v.versionNumber}</span>
+                    {v.marcada && (
+                      <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-500">
+                        hito
+                      </span>
+                    )}
+                    <span className="text-xs text-muted-foreground">{ORIGEN[v.origen]}</span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {fecha(v.createdAt)}
+                    {v.simulaciones > 0 &&
+                      ` · ${v.simulaciones} ${v.simulaciones === 1 ? 'simulación' : 'simulaciones'}`}
+                  </p>
+                  {v.changeNote && <p className="mt-1 text-xs">{v.changeNote}</p>}
+                  {comparacion?.contra === v.versionNumber && (
+                    <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
+                      Frente a la versión {v.versionNumber - 1}: {comparacion.resumen}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title={v.marcada ? 'Quitar el hito' : 'Marcar como hito (nunca se poda)'}
+                    onClick={() => alternarHito(v)}
+                  >
+                    <Star className={cn('h-3.5 w-3.5', v.marcada && 'fill-amber-500 text-amber-500')} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    disabled={!versiones.some(x => x.versionNumber === v.versionNumber - 1)}
+                    title="Comparar con la versión anterior"
+                    onClick={() => compararConAnterior(v)}
+                  >
+                    <GitCompare className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Restaurar esta versión"
+                    onClick={() => setConfirmarRestaurar(v)}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {confirmarRestaurar && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
+            <div className="min-w-0 flex-1">
+              <p>
+                La red volverá a como estaba en la versión {confirmarRestaurar.versionNumber}. El
+                estado actual no se pierde: se guarda antes como una versión nueva.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <Button size="sm" onClick={() => restaurar(confirmarRestaurar)}>
+                  Restaurar
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => setConfirmarRestaurar(null)}>
+                  Cancelar
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/hydraulic/HistorialRed.tsx
+++ b/src/components/hydraulic/HistorialRed.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react'
-import { Activity, AlertTriangle, GitCompare, History, RotateCcw, Star, Plus } from 'lucide-react'
+import { Activity, AlertTriangle, GitCompare, History, RotateCcw, Share2, Star, Plus } from 'lucide-react'
 import { logger } from '@/utils/logger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -169,6 +169,19 @@ export function HistorialRed({
     }
   }
 
+  const exportar = async (v: Version) => {
+    try {
+      const r = await window.electronAPI.networkVersions.exportar({
+        versionId: v.id,
+        nombre: `${nombreRed}-v${v.versionNumber}`,
+      })
+      // Cancelar el diálogo de guardado no es un error que haya que enseñar.
+      if (!r?.success && r?.error && !/cancelada/i.test(r.error)) throw new Error(r.error)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo exportar')
+    }
+  }
+
   const fecha = (iso: string) =>
     new Date(iso).toLocaleString('es-ES', {
       day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
@@ -183,7 +196,7 @@ export function HistorialRed({
             Historial de {nombreRed}
           </DialogTitle>
           <DialogDescription>
-            Cada versión es un escenario distinto de la red de la cual precede. No se modifican
+            Cada versión es un escenario distinto de la red de la cual procede. No se modifican
             nunca: se añaden, se marcan como hito y se pueden restaurar.
           </DialogDescription>
         </DialogHeader>
@@ -257,6 +270,15 @@ export function HistorialRed({
                     onClick={() => compararConAnterior(v)}
                   >
                     <GitCompare className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Exportar para otra instalación de Boorie"
+                    onClick={() => exportar(v)}
+                  >
+                    <Share2 className="h-3.5 w-3.5" />
                   </Button>
                   <Button
                     variant="ghost"

--- a/src/components/hydraulic/HistorialRed.tsx
+++ b/src/components/hydraulic/HistorialRed.tsx
@@ -183,8 +183,8 @@ export function HistorialRed({
             Historial de {nombreRed}
           </DialogTitle>
           <DialogDescription>
-            Cada versión es una copia congelada de la red. No se modifican nunca: se añaden, se
-            marcan como hito y se pueden restaurar.
+            Cada versión es un escenario distinto de la red de la cual precede. No se modifican
+            nunca: se añaden, se marcan como hito y se pueden restaurar.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/hydraulic/InstantaneasProyecto.tsx
+++ b/src/components/hydraulic/InstantaneasProyecto.tsx
@@ -1,0 +1,224 @@
+/**
+ * Instantáneas de un proyecto (#38).
+ *
+ * Responde a «¿cómo estaba este proyecto en la entrega de marzo?». Una
+ * instantánea no copia nada: anota qué versión de cada red estaba vigente, y esas
+ * versiones ya son inmutables. Por eso congelar un proyecto entero cuesta unas
+ * pocas filas, y por eso la retención no puede podar una versión que una
+ * instantánea sujete.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, Camera, RotateCcw, Trash2 } from 'lucide-react'
+import { logger } from '@/utils/logger'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface RedEnSnapshot {
+  networkId: string
+  nombre: string
+  versionId: string
+  versionNumber: number
+}
+
+interface Snapshot {
+  id: string
+  label: string
+  note?: string
+  createdAt: string
+  redes: RedEnSnapshot[]
+}
+
+interface InstantaneasProyectoProps {
+  abierto: boolean
+  onCerrar: () => void
+  projectId: string
+  nombreProyecto: string
+  /** Se llama tras restaurar, para recargar lo que la vista tenga abierto. */
+  onRestaurado?: () => void
+}
+
+export function InstantaneasProyecto({
+  abierto,
+  onCerrar,
+  projectId,
+  nombreProyecto,
+  onRestaurado,
+}: InstantaneasProyectoProps) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([])
+  const [etiqueta, setEtiqueta] = useState('')
+  const [cargando, setCargando] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmar, setConfirmar] = useState<Snapshot | null>(null)
+
+  const recargar = useCallback(async () => {
+    setCargando(true)
+    setError(null)
+    try {
+      const r = await window.electronAPI.projectSnapshots.list(projectId)
+      if (!r?.success) throw new Error(r?.error || 'No se pudieron leer las instantáneas')
+      setSnapshots(r.data)
+    } catch (e) {
+      logger.error('Error leyendo instantáneas:', e)
+      setError(e instanceof Error ? e.message : 'No se pudieron leer las instantáneas')
+    } finally {
+      setCargando(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    if (abierto) {
+      setConfirmar(null)
+      recargar()
+    }
+  }, [abierto, recargar])
+
+  const crear = async () => {
+    if (!etiqueta.trim()) return
+    try {
+      const r = await window.electronAPI.projectSnapshots.create({
+        projectId,
+        label: etiqueta.trim(),
+      })
+      if (!r?.success) throw new Error(r?.error || 'No se pudo crear la instantánea')
+      setEtiqueta('')
+      await recargar()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo crear la instantánea')
+    }
+  }
+
+  const restaurar = async (s: Snapshot) => {
+    try {
+      const r = await window.electronAPI.projectSnapshots.restore(s.id)
+      if (!r?.success) throw new Error(r?.error || 'No se pudo restaurar')
+      setConfirmar(null)
+      onRestaurado?.()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo restaurar')
+    }
+  }
+
+  const borrar = async (s: Snapshot) => {
+    await window.electronAPI.projectSnapshots.delete(s.id)
+    await recargar()
+  }
+
+  const fecha = (iso: string) =>
+    new Date(iso).toLocaleString('es-ES', {
+      day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+    })
+
+  return (
+    <Dialog open={abierto} onOpenChange={v => !v && onCerrar()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Camera className="h-4 w-4" />
+            Instantáneas de {nombreProyecto}
+          </DialogTitle>
+          <DialogDescription>
+            Una instantánea anota qué versión de cada red estaba vigente. Sirve para volver al
+            estado completo de una entrega, y sujeta esas versiones para que la retención no las
+            pode.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex gap-2">
+          <Input
+            value={etiqueta}
+            onChange={e => setEtiqueta(e.target.value)}
+            placeholder="Cómo la reconocerás: «Entrega de marzo»"
+            onKeyDown={e => { if (e.key === 'Enter') crear() }}
+          />
+          <Button size="sm" onClick={crear} disabled={!etiqueta.trim()} className="shrink-0">
+            <Camera className="mr-2 h-3.5 w-3.5" />
+            Congelar el proyecto
+          </Button>
+        </div>
+
+        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+
+        <div className="max-h-96 divide-y divide-border overflow-y-auto rounded-md border border-border">
+          {cargando && <p className="px-3 py-6 text-center text-sm text-muted-foreground">Cargando…</p>}
+
+          {!cargando && snapshots.length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              Este proyecto todavía no tiene instantáneas.
+            </p>
+          )}
+
+          {snapshots.map(s => (
+            <div key={s.id} className="px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">{s.label}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {fecha(s.createdAt)} · {s.redes.length}{' '}
+                    {s.redes.length === 1 ? 'red' : 'redes'}
+                  </p>
+                  <ul className="mt-1 space-y-0.5">
+                    {s.redes.map(r => (
+                      <li key={r.versionId} className="text-xs text-muted-foreground">
+                        {r.nombre} — versión {r.versionNumber}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Devolver el proyecto a este estado"
+                    onClick={() => setConfirmar(s)}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-red-500"
+                    title="Borrar la instantánea (no borra las versiones)"
+                    onClick={() => borrar(s)}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {confirmar && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
+            <div className="min-w-0 flex-1">
+              <p>
+                Las {confirmar.redes.length} redes del proyecto volverán a como estaban en «
+                {confirmar.label}». El estado actual de cada una se guarda antes como una versión
+                nueva, así que no se pierde.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <Button size="sm" onClick={() => restaurar(confirmar)}>
+                  Restaurar el proyecto
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => setConfirmar(null)}>
+                  Cancelar
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/hydraulic/InstantaneasProyecto.tsx
+++ b/src/components/hydraulic/InstantaneasProyecto.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle, Camera, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertTriangle, Camera, Download, RotateCcw, Share2, Trash2 } from 'lucide-react'
 import { logger } from '@/utils/logger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -57,6 +57,7 @@ export function InstantaneasProyecto({
   const [cargando, setCargando] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [confirmar, setConfirmar] = useState<Snapshot | null>(null)
+  const [importado, setImportado] = useState<string | null>(null)
 
   const recargar = useCallback(async () => {
     setCargando(true)
@@ -111,6 +112,26 @@ export function InstantaneasProyecto({
     await recargar()
   }
 
+  const exportar = async (s: Snapshot) => {
+    const r = await window.electronAPI.projectSnapshots.exportar({
+      snapshotId: s.id,
+      nombre: `${nombreProyecto}-${s.label}`,
+    })
+    if (!r?.success && r?.error && !/cancelada/i.test(r.error)) setError(r.error)
+  }
+
+  const importar = async () => {
+    setError(null)
+    const r = await window.electronAPI.networkVersions.importar(projectId)
+    if (!r?.success) {
+      if (r?.error && !/cancelada/i.test(r.error)) setError(r.error)
+      return
+    }
+    setImportado(r.data.resumen)
+    await recargar()
+    onRestaurado?.()
+  }
+
   const fecha = (iso: string) =>
     new Date(iso).toLocaleString('es-ES', {
       day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
@@ -144,6 +165,21 @@ export function InstantaneasProyecto({
           </Button>
         </div>
 
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            Un paquete lleva las redes con su `.inp` y su sistema de coordenadas, y se comprueba al
+            abrirlo: si llegó a medias o alguien lo editó, no se importa nada.
+          </p>
+          <Button variant="outline" size="sm" className="shrink-0" onClick={importar}>
+            <Download className="mr-2 h-3.5 w-3.5" />
+            Importar paquete
+          </Button>
+        </div>
+
+        {importado && (
+          <p className="rounded-md border border-border bg-muted/50 px-3 py-2 text-xs">{importado}</p>
+        )}
+
         {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
 
         <div className="max-h-96 divide-y divide-border overflow-y-auto rounded-md border border-border">
@@ -174,6 +210,15 @@ export function InstantaneasProyecto({
                 </div>
 
                 <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Exportar para otra instalación de Boorie"
+                    onClick={() => exportar(s)}
+                  >
+                    <Share2 className="h-3.5 w-3.5" />
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/src/components/hydraulic/InstantaneasProyecto.tsx
+++ b/src/components/hydraulic/InstantaneasProyecto.tsx
@@ -140,7 +140,7 @@ export function InstantaneasProyecto({
           />
           <Button size="sm" onClick={crear} disabled={!etiqueta.trim()} className="shrink-0">
             <Camera className="mr-2 h-3.5 w-3.5" />
-            Congelar el proyecto
+            Crear una Instantánea
           </Button>
         </div>
 

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -11,10 +11,11 @@ import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { WNTRAdvancedMapViewer } from './WNTRAdvancedMapViewer';
 import { ProjectDashboard } from './ProjectDashboard';
+import { HistorialRed } from './HistorialRed';
 import { Project, NetworkAsset, CalculationAsset } from '../../types/project';
 import { hydraulicService } from '@/services/hydraulic/hydraulicService';
 import {
-  FileUp, Play, Network,
+  FileUp, Play, Network, History,
   RefreshCw, AlertCircle,
   Activity, Database,
   Target, FolderOpen, ChevronDown,
@@ -335,10 +336,28 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
         else refreshCurrentProject();
       })
       .catch((e: unknown) => logger.error('Error guardando el calculo:', e));
+
+    /**
+     * Y además, atado a la versión de la red con la que se corrió (#38). Es lo
+     * que hace interpretable un resultado: sin saber sobre qué estado de la red
+     * se calculó, un informe de presiones no dice nada. El guardado anterior se
+     * mantiene porque `hydraulic_calculations` es el histórico que ya existía y
+     * del que la vista lee sus listas.
+     */
+    if (networkId && networkId !== 'unknown') {
+      window.electronAPI.networkVersions
+        .recordSimulation({ networkId, tipo: name, parameters: {}, results })
+        .then((res: any) => {
+          if (!res?.success) logger.warn('No se pudo atar la simulacion a su version:', res?.error);
+        })
+        .catch((e: unknown) => logger.error('Error registrando la simulacion:', e));
+    }
   }, [activeProjectId, refreshCurrentProject]);
 
   // Core state
   const [networkData, setNetworkData] = useState<NetworkData | null>(null);
+  /** Red cuyo historial de versiones se está mirando (#38). */
+  const [historialDe, setHistorialDe] = useState<{ id: string; nombre: string } | null>(null);
 
   /**
    * Red guardada que corresponde a lo que se está mostrando. La declaración del
@@ -977,11 +996,11 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                     <h4 className="text-sm font-medium mb-2">Redes Guardadas</h4>
                     <div className="space-y-2">
                       {currentProject.networks.map((net) => (
+                        <div key={net.id} className={`flex items-center gap-1 ${net.parentId ? 'ml-4' : ''}`}>
                         <Button
-                          key={net.id}
                           variant="outline"
                           size="sm"
-                          className={`w-full justify-start text-xs ${net.parentId ? 'ml-4 w-[calc(100%-1rem)]' : ''}`}
+                          className="flex-1 justify-start text-xs min-w-0"
                           onClick={async () => {
                             // Datos y .inp desde la base de datos: la red se abre
                             // aunque el fichero original ya no este en disco.
@@ -1021,7 +1040,21 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
                           <span className="ml-auto text-muted-foreground">
                             {net.nodeCount} nudos
                           </span>
+                          {/* Dentro del botón de abrir la red iría anidado, así
+                              que el historial va como hermano: un botón dentro de
+                              otro no es HTML válido y el clic se volvería
+                              impredecible. */}
                         </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 shrink-0"
+                          title={`Historial de versiones de ${net.name}`}
+                          onClick={() => setHistorialDe({ id: net.id, nombre: net.name })}
+                        >
+                          <History className="h-3.5 w-3.5" />
+                        </Button>
+                        </div>
                       ))}
                     </div>
                   </div>
@@ -1946,6 +1979,26 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   return (
     <div className="w-full h-full bg-background text-foreground overflow-hidden">
       {renderDashboard()}
+      {historialDe && (
+        <HistorialRed
+          abierto
+          onCerrar={() => setHistorialDe(null)}
+          networkId={historialDe.id}
+          nombreRed={historialDe.nombre}
+          onRestaurada={async () => {
+            const res = await window.electronAPI.networkRepository.load(historialDe.id);
+            if (res?.success) {
+              setNetworkData(res.data);
+              setLoadedNetworkPath(res.filePath ?? null);
+              if (res.filePath) {
+                try { await window.electronAPI.wntr.loadINPFromPath(res.filePath); }
+                catch (err) { logger.warn('No se pudo recargar el .inp restaurado:', err); }
+              }
+            }
+            await refreshActiveNetworks();
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/hydraulic/WNTRMainInterface.tsx
+++ b/src/components/hydraulic/WNTRMainInterface.tsx
@@ -12,10 +12,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { WNTRAdvancedMapViewer } from './WNTRAdvancedMapViewer';
 import { ProjectDashboard } from './ProjectDashboard';
 import { HistorialRed } from './HistorialRed';
+import { InstantaneasProyecto } from './InstantaneasProyecto';
 import { Project, NetworkAsset, CalculationAsset } from '../../types/project';
 import { hydraulicService } from '@/services/hydraulic/hydraulicService';
 import {
-  FileUp, Play, Network, History,
+  FileUp, Play, Network, History, Camera,
   RefreshCw, AlertCircle,
   Activity, Database,
   Target, FolderOpen, ChevronDown,
@@ -358,6 +359,8 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   const [networkData, setNetworkData] = useState<NetworkData | null>(null);
   /** Red cuyo historial de versiones se está mirando (#38). */
   const [historialDe, setHistorialDe] = useState<{ id: string; nombre: string } | null>(null);
+  /** Instantáneas del proyecto activo (#38). */
+  const [verInstantaneas, setVerInstantaneas] = useState(false);
 
   /**
    * Red guardada que corresponde a lo que se está mostrando. La declaración del
@@ -993,7 +996,18 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
 
                 {currentProject.networks.length > 0 && (
                   <div className="pt-4 border-t">
-                    <h4 className="text-sm font-medium mb-2">Redes Guardadas</h4>
+                    <div className="mb-2 flex items-center justify-between">
+                      <h4 className="text-sm font-medium">Redes Guardadas</h4>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-auto px-2 py-1 text-xs"
+                        onClick={() => setVerInstantaneas(true)}
+                      >
+                        <Camera className="mr-1.5 h-3 w-3" />
+                        Instantáneas
+                      </Button>
+                    </div>
                     <div className="space-y-2">
                       {currentProject.networks.map((net) => (
                         <div key={net.id} className={`flex items-center gap-1 ${net.parentId ? 'ml-4' : ''}`}>
@@ -1979,6 +1993,25 @@ export const WNTRMainInterface: React.FC<WNTRMainInterfaceProps> = ({
   return (
     <div className="w-full h-full bg-background text-foreground overflow-hidden">
       {renderDashboard()}
+      {verInstantaneas && currentProject && (
+        <InstantaneasProyecto
+          abierto
+          onCerrar={() => setVerInstantaneas(false)}
+          projectId={currentProject.id}
+          nombreProyecto={currentProject.name}
+          onRestaurado={async () => {
+            setVerInstantaneas(false);
+            await refreshActiveNetworks();
+            if (redGuardadaId) {
+              const res = await window.electronAPI.networkRepository.load(redGuardadaId);
+              if (res?.success) {
+                setNetworkData(res.data);
+                setLoadedNetworkPath(res.filePath ?? null);
+              }
+            }
+          }}
+        />
+      )}
       {historialDe && (
         <HistorialRed
           abierto

--- a/src/components/settings/tabs/GeneralTab.tsx
+++ b/src/components/settings/tabs/GeneralTab.tsx
@@ -3,12 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/stores/appStore'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 import { databaseService } from '@/services/database'
-import { Moon, Sun, RotateCcw, Languages, Eye, EyeOff, Map, Check, Terminal } from 'lucide-react'
+import { Moon, Sun, RotateCcw, Languages, Eye, EyeOff, Map, Check, Terminal, History } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import * as Switch from '@radix-ui/react-switch'
 import * as Select from '@radix-ui/react-select'
 
 const MAPBOX_TOKEN_SETTING_KEY = 'mapbox_access_token'
+/** Cuántas versiones sin marcar conserva el historial de cada red (#38). */
+const RETENCION_SETTING_KEY = 'retencion.versionesSinMarcar'
+const RETENCION_POR_DEFECTO = 10
 
 export function GeneralTab() {
   const { t } = useTranslation()
@@ -25,6 +28,8 @@ export function GeneralTab() {
   const [mapboxToken, setMapboxToken] = useState('')
   const [showMapboxToken, setShowMapboxToken] = useState(false)
   const [mapboxSaved, setMapboxSaved] = useState(false)
+  const [retencion, setRetencion] = useState(String(RETENCION_POR_DEFECTO))
+  const [retencionSaved, setRetencionSaved] = useState(false)
 
   const [pythonPath, setPythonPath] = useState('')
   const [pythonDetected, setPythonDetected] = useState('')
@@ -55,6 +60,9 @@ export function GeneralTab() {
 
   useEffect(() => {
     loadPreferences()
+    databaseService.getSetting(RETENCION_SETTING_KEY).then((value) => {
+      if (value !== null && value !== undefined) setRetencion(value)
+    })
     databaseService.getSetting(MAPBOX_TOKEN_SETTING_KEY).then((value) => {
       if (value) setMapboxToken(value)
     })
@@ -97,6 +105,16 @@ export function GeneralTab() {
     if (ok) {
       setMapboxSaved(true)
       setTimeout(() => setMapboxSaved(false), 2000)
+    }
+  }
+
+  const handleSaveRetencion = async () => {
+    const n = Number(retencion)
+    if (!Number.isFinite(n) || n < 0) return
+    const ok = await databaseService.setSetting(RETENCION_SETTING_KEY, String(Math.floor(n)), 'hydraulic')
+    if (ok) {
+      setRetencionSaved(true)
+      setTimeout(() => setRetencionSaved(false), 2000)
     }
   }
 
@@ -329,6 +347,47 @@ export function GeneralTab() {
               >
                 {mapboxSaved ? <Check size={16} /> : null}
                 {mapboxSaved ? 'Guardado' : 'Guardar'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Historial de versiones (#38) */}
+        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+          <div className="flex items-center gap-2 mb-4">
+            <History size={20} className="text-muted-foreground" />
+            <h2 className="text-xl font-semibold text-card-foreground">Historial de versiones</h2>
+          </div>
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium text-card-foreground">
+                Versiones sin marcar que se conservan por red
+              </label>
+              <p className="text-xs text-muted-foreground mt-1">
+                Las marcadas como hito y las sujetas por una instantánea de proyecto no se podan
+                nunca, cuenten lo que cuenten. La más reciente tampoco, aunque pongas cero.
+              </p>
+            </div>
+            <div className="flex space-x-2">
+              <input
+                type="number"
+                min={0}
+                value={retencion}
+                onChange={(e) => setRetencion(e.target.value)}
+                className="w-32 px-3 py-2 bg-input border border-border rounded-lg text-foreground focus:border-ring focus:outline-none text-sm"
+              />
+              <button
+                type="button"
+                onClick={handleSaveRetencion}
+                className={cn(
+                  'px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5',
+                  retencionSaved
+                    ? 'bg-green-600/10 text-green-600'
+                    : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                )}
+              >
+                {retencionSaved ? <Check size={16} /> : null}
+                {retencionSaved ? 'Guardado' : 'Guardar'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Los datos cambiaron el objetivo del issue

El enunciado parte de que «sólo se conserva la última simulación» porque `simulationResults` se sobrescribe. Sobre tu base real eso resultó ser **medio cierto**, y la mitad que falla mueve el objetivo:

| | |
|---|---|
| Base de datos | 30,3 MB |
| De los cuales, resultados de simulación | **21,4 MB en 40 filas** |
| `simulationResults` en las cinco redes | **vacío** |

Los resultados no van a ese campo: van a `hydraulic_calculations`, que **ya acumula histórico**. Lo que falta no es conservar, es saber **sobre qué estado de la red se calculó cada resultado**. Y no hay ninguna retención, que es lo que ya cuesta 21 MB con una red de 97 nudos — la misma simulación sobre una de 3.358 rondaría los 80 MB.

## El modelo

```
HydraulicProject
  └─ HydraulicNetwork          ← contenedor: el estado de ahora
       └─ NetworkVersion       ← copias congeladas, sólo se añaden
            └─ SimulationRun   ← cada ejecución, atada a la versión con la que corrió
```

## Decisiones

**La restricción `@@unique([projectId, name])` se conserva, no se elimina.** El issue ofrecía las dos opciones y ésta es la buena: con la red como contenedor, reimportar un `.inp` corregido crea una versión de **la misma fila**, no una segunda red. La restricción deja de estorbar y pasa a significar lo correcto. Lo que había que cambiar no era el esquema sino la conducta, que era rechazar el guardado con un error.

**Versionado explícito + automático antes de pisar datos** (tu propia recomendación en el issue). **Restaurar guarda antes el estado vigente**: es una operación destructiva como cualquier otra, y sin esa copia quien restaura por error pierde justamente aquello a lo que querría volver.

**Retención: hitos siempre + las 10 últimas sin marcar**, configurable en `app_settings`. La más reciente no se poda nunca, aunque la política sea cero.

**`hydraulic_calculations` no se migra, y es deliberado.** De sus 40 filas, **29 no registran ningún `networkId`**. Atribuirles una versión sería inventarse justamente la trazabilidad que falta. Se quedan intactas; las simulaciones nuevas sí quedan atadas a su versión.

**El diff compara la red, no lo que se calculó sobre ella**, y `100` frente a `100.0` no es un cambio de diámetro: un `.inp` reescrito cambia el formato de los números y señalarlo llenaría el diff de ruido.

## Verificación

**290 tests** (eran 276); typecheck y lint limpios. Los 14 nuevos cubren la retención —hitos que no se podan, la más reciente que se conserva siempre, independencia del orden— y la comparación.

**Comprobado con tu base real.** La migración corrió al arrancar y dio versión 1 a las 5 redes. Sobre `Net3 2.inp`: se guardó una versión con nota, se marcó como hito, se comparó con la anterior («Sin cambios en la red», correcto) y se restauró, dejando en el historial la `v3` con «Estado anterior a restaurar la versión 2».

Recuento antes y después de migrar el esquema, idéntico: **5 proyectos, 5 redes, 40 cálculos, 11 conversaciones, 37 mensajes, 434 fragmentos**. El índice único se creó a mano en lugar de dejar que `prisma db push` reconstruyera la tabla, porque avisaba de posible pérdida.

## Fuera de alcance

- **Versionado del proyecto** como instantánea del conjunto de versiones activas (punto 4 del issue).
- **Exportar/importar entre instalaciones**: descartado para esta entrega por decisión tuya; el modelo queda preparado.
- **El control de retención en Ajustes**: la política se lee de `app_settings`, pero no hay pantalla que la exponga.
- **Comparar resultados entre dos simulaciones**: se compara la red entre versiones; comparar ejecuciones es otra cosa.

Diseño y decisiones en `docs/VERSIONADO_INMUTABLE.md`.

Closes #38