### PR TITLE
feat(wisdom): ámbito general y ámbito de proyecto (#39)

### DIFF
--- a/backend/services/hydraulic/ambitos.test.ts
+++ b/backend/services/hydraulic/ambitos.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  documentoVisible,
+  duenosPermitidos,
+  filtroPrisma,
+  filtroVectorial,
+  origenDe,
+  type Ambito,
+} from './ambitos'
+
+const A = 'proyecto-A'
+const B = 'proyecto-B'
+const TODOS: Ambito[] = ['general', 'proyecto', 'ambos']
+
+describe('la regla que no se puede romper', () => {
+  it('un documento del proyecto A no es visible desde el proyecto B en ningún ámbito', () => {
+    // Es el criterio de aceptación, y es de confidencialidad: verlo de más
+    // significa enseñarle a un cliente los documentos de otro.
+    for (const ambito of TODOS) {
+      expect(documentoVisible(A, ambito, B), ambito).toBe(false)
+      expect(duenosPermitidos(ambito, B), ambito).not.toContain(A)
+    }
+  })
+
+  it('tampoco desde ningún proyecto ajeno, sea cual sea', () => {
+    for (const ajeno of ['x', 'y', 'z-largo-y-raro', '']) {
+      for (const ambito of TODOS) {
+        expect(documentoVisible(A, ambito, ajeno)).toBe(false)
+      }
+    }
+  })
+
+  it('sin proyecto activo sólo se ve lo general, nunca lo de nadie', () => {
+    for (const ambito of TODOS) {
+      expect(duenosPermitidos(ambito, null), ambito).toEqual([null])
+      expect(duenosPermitidos(ambito, undefined), ambito).toEqual([null])
+      expect(documentoVisible(A, ambito, null), ambito).toBe(false)
+    }
+  })
+})
+
+describe('herencia de un solo sentido', () => {
+  it('desde un proyecto se ve lo general', () => {
+    expect(documentoVisible(null, 'ambos', A)).toBe(true)
+    expect(documentoVisible(null, 'general', A)).toBe(true)
+  })
+
+  it('«sólo proyecto» deja fuera lo general, que para eso es un ámbito aparte', () => {
+    expect(documentoVisible(null, 'proyecto', A)).toBe(false)
+    expect(documentoVisible(A, 'proyecto', A)).toBe(true)
+  })
+
+  it('«ambos» es lo general más lo propio, y nada más', () => {
+    expect(duenosPermitidos('ambos', A)).toEqual([null, A])
+  })
+
+  it('lo general no hereda de ningún proyecto', () => {
+    expect(duenosPermitidos('general', A)).toEqual([null])
+  })
+})
+
+describe('origen del resultado', () => {
+  it('distingue una norma de un documento interno', () => {
+    expect(origenDe(null)).toBe('general')
+    expect(origenDe(A)).toBe('proyecto')
+  })
+})
+
+describe('filtro del almacén vectorial', () => {
+  it('restringe cuando sólo se piden proyectos', () => {
+    expect(filtroVectorial([A])).toBe('metadata["projectId"] == "proyecto-A"')
+  })
+
+  it('no filtra cuando lo general entra en juego', () => {
+    // Los documentos indexados antes de que existiera el ámbito no traen
+    // `projectId` en su metainformación; una expresión que lo exigiera los
+    // dejaría fuera. Ese caso lo resuelve la base de datos, que es la autoridad.
+    expect(filtroVectorial([null])).toBeUndefined()
+    expect(filtroVectorial([null, A])).toBeUndefined()
+  })
+
+  it('sin nada permitido no inventa un filtro', () => {
+    expect(filtroVectorial([])).toBeUndefined()
+  })
+})
+
+describe('condición para la base de datos', () => {
+  it('el ámbito general no usa «in», porque Prisma rechaza el nulo ahí dentro', () => {
+    // El fallo que sólo apareció al probarlo contra la base: «Argument in:
+    // Invalid value provided. Expected Null, provided (Null)». Y el general es
+    // el valor por defecto, así que habría roto el caso más común.
+    expect(filtroPrisma([null])).toEqual({ projectId: null })
+  })
+
+  it('sólo proyectos: se filtra por la lista', () => {
+    expect(filtroPrisma([A])).toEqual({ projectId: { in: [A] } })
+  })
+
+  it('general más proyecto: el nulo va aparte, con un OR', () => {
+    expect(filtroPrisma([null, A])).toEqual({
+      OR: [{ projectId: null }, { projectId: { in: [A] } }],
+    })
+  })
+
+  it('sin nada permitido, una condición que no acepta nada', () => {
+    // Se ve de menos, nunca de más.
+    expect(filtroPrisma([])).toEqual({ projectId: { in: [] } })
+  })
+
+  it('la condición nunca menciona un proyecto que no esté permitido', () => {
+    for (const ambito of TODOS) {
+      expect(JSON.stringify(filtroPrisma(duenosPermitidos(ambito, B)))).not.toContain(A)
+    }
+  })
+})

--- a/backend/services/hydraulic/ambitos.ts
+++ b/backend/services/hydraulic/ambitos.ts
@@ -1,0 +1,102 @@
+/**
+ * Ámbitos del Wisdom Center (#39).
+ *
+ * El conocimiento vive en dos ámbitos: **general** —normativa, buenas prácticas,
+ * el catálogo preindexado, compartido entre proyectos— y **de proyecto**, que son
+ * los documentos internos de un cliente concreto.
+ *
+ * La herencia es de un solo sentido y es un requisito de confidencialidad, no de
+ * comodidad: un proyecto ve lo general, y lo general **nunca** ve lo de un
+ * proyecto. Un documento del proyecto A no puede aparecer en ninguna búsqueda
+ * del proyecto B, en ningún modo.
+ *
+ * Módulo puro: esta regla se puede equivocar de una forma que no se nota hasta
+ * que alguien ve el documento de otro cliente, así que se prueba sin base de
+ * datos delante.
+ */
+
+export type Ambito = 'general' | 'proyecto' | 'ambos'
+
+/** `null` representa el ámbito general: un documento sin proyecto dueño. */
+export type DuenoDocumento = string | null
+
+/**
+ * Proyectos cuyos documentos pueden entrar en una búsqueda.
+ *
+ * Devolver la lista y filtrar por ella —en lugar de excluir lo prohibido— hace
+ * que el caso por defecto sea no ver nada: si el ámbito o el proyecto llegan mal,
+ * se ve de menos, nunca de más.
+ */
+export function duenosPermitidos(ambito: Ambito, projectId?: string | null): DuenoDocumento[] {
+  // Sin proyecto activo no hay ámbito de proyecto que valga: cualquier petición
+  // se resuelve como general, que es lo único que se puede servir sin saber de
+  // quién son los documentos.
+  if (!projectId) return [null]
+
+  switch (ambito) {
+    case 'general':
+      return [null]
+    case 'proyecto':
+      return [projectId]
+    case 'ambos':
+      return [null, projectId]
+  }
+}
+
+/** Si un documento concreto puede verse desde un ámbito dado. */
+export function documentoVisible(
+  duenoDelDocumento: DuenoDocumento,
+  ambito: Ambito,
+  projectId?: string | null
+): boolean {
+  return duenosPermitidos(ambito, projectId).includes(duenoDelDocumento ?? null)
+}
+
+export type Origen = 'general' | 'proyecto'
+
+/** De dónde viene un resultado, para poder decirlo junto a la cita. */
+export function origenDe(duenoDelDocumento: DuenoDocumento): Origen {
+  return duenoDelDocumento ? 'proyecto' : 'general'
+}
+
+/**
+ * Filtro para el almacén vectorial.
+ *
+ * Es una **optimización**, no la garantía: el almacén puede fallar en silencio,
+ * devolver de más o ignorar el filtro, y por eso la última palabra la tiene la
+ * consulta a la base de datos, que es la autoridad sobre de quién es cada
+ * documento. Devuelve `undefined` cuando no hay nada que restringir.
+ */
+export function filtroVectorial(permitidos: DuenoDocumento[]): string | undefined {
+  const proyectos = permitidos.filter((p): p is string => p !== null)
+
+  // El general incluye documentos indexados antes de que existiera el ámbito,
+  // cuya metainformación no trae `projectId`. Una expresión que exija que el
+  // campo exista los dejaría fuera, así que en ese caso no se filtra aquí y se
+  // resuelve en la base de datos.
+  if (permitidos.includes(null)) return undefined
+  if (proyectos.length === 0) return undefined
+
+  return proyectos.map(p => `metadata["projectId"] == "${p}"`).join(' or ')
+}
+
+/**
+ * Condición para la consulta a la base, que es la que garantiza el ámbito.
+ *
+ * No vale `{ projectId: { in: permitidos } }`: Prisma **rechaza `null` dentro de
+ * un `in`** —«Argument in: Invalid value provided. Expected Null, provided
+ * (Null)»— y como el ámbito general es el valor por defecto, esa consulta
+ * habría fallado en el caso más común. El nulo se expresa aparte.
+ *
+ * Con la lista vacía devuelve una condición que no acepta nada: si algo va mal
+ * se ve de menos, nunca de más.
+ */
+export function filtroPrisma(permitidos: DuenoDocumento[]): Record<string, unknown> {
+  const proyectos = permitidos.filter((p): p is string => p !== null)
+  const incluyeGeneral = permitidos.includes(null)
+
+  if (incluyeGeneral && proyectos.length === 0) return { projectId: null }
+  if (!incluyeGeneral) return { projectId: { in: proyectos } }
+
+  return { OR: [{ projectId: null }, { projectId: { in: proyectos } }] }
+}

--- a/backend/services/hydraulic/ragService.ts
+++ b/backend/services/hydraulic/ragService.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { HydraulicDocument } from '../../../src/types/hydraulic'
 import { EmbeddingService } from '../embedding.service'
+import { duenosPermitidos, filtroPrisma, filtroVectorial, origenDe, type Ambito, type Origen } from './ambitos'
 
 export interface RAGSearchOptions {
   category?: 'hydraulics' | 'regulations' | 'best-practices'
@@ -8,10 +9,16 @@ export interface RAGSearchOptions {
   language?: string
   limit?: number
   minScore?: number
+  /** Dónde buscar (#39). Por defecto, sólo lo general. */
+  ambito?: Ambito
+  /** Proyecto activo. Sin él no hay ámbito de proyecto posible. */
+  projectId?: string | null
 }
 
 export interface RAGSearchResult {
   document: HydraulicDocument
+  /** Si la cita viene de una norma general o de un documento interno del proyecto. */
+  origen?: Origen
   score: number
   relevantChunks: string[]
   highlights: string[]
@@ -33,8 +40,12 @@ export class HydraulicRAGService {
   ): Promise<RAGSearchResult[]> {
     const {
       limit = 5,
-      minScore = 0.6
+      minScore = 0.6,
+      ambito = 'general',
+      projectId = null,
     } = options
+
+    const permitidos = duenosPermitidos(ambito, projectId)
 
     try {
       const milvusService = (await import('../milvus.service')).MilvusService.getInstance()
@@ -46,7 +57,10 @@ export class HydraulicRAGService {
       const searchRes = await milvusService.search(
         'hydraulic_knowledge', // Hardcoded for now or use MilvusService.COLLECTIONS.KNOWLEDGE
         queryEmbedding,
-        limit * 3 // Fetch more chunks to aggregate
+        // Se piden más candidatos cuando hay ámbito de proyecto: parte de lo que
+        // devuelva el almacén se va a descartar al comprobar de quién es.
+        permitidos.length > 1 ? limit * 6 : limit * 3,
+        filtroVectorial(permitidos)
       )
 
       if (!searchRes.results || searchRes.results.length === 0) {
@@ -75,8 +89,18 @@ export class HydraulicRAGService {
       const docIds = Array.from(docMap.keys())
       if (docIds.length === 0) return []
 
+      /**
+       * Aquí se garantiza la confidencialidad, y no en el filtro del almacén
+       * vectorial (#39).
+       *
+       * El almacén puede ignorar el filtro, devolver de más o quedarse mudo, y
+       * su modo de fallo es silencioso. La base de datos es la autoridad sobre
+       * de quién es cada documento: si un fragmento ajeno se cuela en la
+       * búsqueda, su documento no llega a materializarse y no hay nada que
+       * enseñar.
+       */
       const documents = await this.prisma.hydraulicKnowledge.findMany({
-        where: { id: { in: docIds } }
+        where: { id: { in: docIds }, ...filtroPrisma(permitidos) }
       })
 
       const results: RAGSearchResult[] = []
@@ -97,6 +121,7 @@ export class HydraulicRAGService {
         }
 
         results.push({
+          origen: origenDe(doc.projectId),
           document: {
             id: doc.id,
             category: doc.category as any,
@@ -280,7 +305,16 @@ export class HydraulicRAGService {
           id: c.id,
           vector: JSON.parse(c.embedding as string),
           content: c.content,
-          metadata: { chunkId: c.id, docId: doc.id, title: doc.title, category: doc.category },
+          // `projectId` viaja en la metainformación para que el almacén pueda
+          // filtrar por ámbito sin ir a la base (#39). Hoy es una optimización:
+          // la garantía la da la consulta a Prisma.
+          metadata: {
+            chunkId: c.id,
+            docId: doc.id,
+            title: doc.title,
+            category: doc.category,
+            projectId: doc.projectId ?? null,
+          },
           timestamp: Date.now()
         }))
 
@@ -301,7 +335,14 @@ export class HydraulicRAGService {
   // Add new document to knowledge base
   async addDocument(
     document: Omit<HydraulicDocument, 'id' | 'lastUpdated'>,
-    onProgress?: (progress: { current: number; total: number; message: string }) => void
+    onProgress?: (progress: { current: number; total: number; message: string }) => void,
+    /**
+     * Dueño del documento (#39). Sin él el documento es general y lo ven todos
+     * los proyectos; con él es interno de ese cliente. Se pide explícito para
+     * que subir algo al ámbito equivocado tenga que ser una decisión, no un
+     * descuido del valor por defecto.
+     */
+    projectId?: string | null
   ): Promise<string> {
     try {
       const { chunks: successfulChunks } = await this.buildIndexedChunks(document.content, onProgress)
@@ -327,6 +368,7 @@ export class HydraulicRAGService {
           keywords: JSON.stringify(document.metadata.keywords),
           language: document.metadata.language,
           version: document.version,
+          projectId: projectId ?? null,
           chunks: {
             create: successfulChunks.map(item => ({
               content: item.content,

--- a/docs/WISDOM_AMBITOS.md
+++ b/docs/WISDOM_AMBITOS.md
@@ -1,0 +1,159 @@
+# Wisdom Center: ámbito general y ámbito de proyecto
+
+Diseño y decisiones del issue [#39](https://github.com/Boorie-AI/boorie_cliente/issues/39).
+Es prerrequisito de la indexación de simulaciones en el RAG
+([#41](https://github.com/Boorie-AI/boorie_cliente/issues/41)) junto con
+[`VERSIONADO_INMUTABLE.md`](VERSIONADO_INMUTABLE.md) (#38).
+
+## El problema, y por qué es de confidencialidad
+
+Todo el conocimiento vivía en un único espacio sin noción de proyecto: la
+normativa general de Boorie y los documentos internos de un cliente, mezclados.
+La búsqueda no filtraba por nada —el código lo decía literalmente:
+`'hydraulic_knowledge', // Hardcoded for now`—.
+
+El criterio de aceptación no es de comodidad:
+
+> Un documento subido en el ámbito de un proyecto A no aparece en ninguna
+> búsqueda del proyecto B, en ningún modo.
+
+Equivocarse aquí significa enseñarle a un cliente los documentos de otro, y es un
+error que no se nota hasta que ha ocurrido.
+
+## Dónde se garantiza
+
+La búsqueda semántica tiene dos capas, y la garantía está en la segunda:
+
+```
+consulta ─► almacén vectorial (Milvus)  ─► fragmentos candidatos
+                                              │
+                                              ▼
+                                     consulta a la base ◄── AQUÍ se garantiza
+                                              │
+                                              ▼
+                                          documentos
+```
+
+**El filtro del almacén vectorial es una optimización, no la garantía.** Milvus
+falla en silencio —el propio servicio devuelve resultados vacíos cuando no puede
+conectar, «fail-soft» a propósito—, puede ignorar una expresión de filtro o
+devolver de más. Confiar en él para una regla de confidencialidad sería confiar en
+el componente más frágil del sistema.
+
+La base de datos es la autoridad sobre de quién es cada documento, y la búsqueda
+tiene un único punto donde los materializa: una consulta `findMany` por los ids
+que devolvió el vector. Filtrar ahí hace que un fragmento ajeno que se colara no
+llegue nunca a convertirse en un documento que enseñar.
+
+| Pieza | Fichero |
+|---|---|
+| Reglas de ámbito (módulo puro) | `backend/services/hydraulic/ambitos.ts` |
+| Punto de control de la búsqueda | `backend/services/hydraulic/ragService.ts` |
+| Listado y subida con ámbito | `electron/handlers/document.handler.ts` |
+| Selector y origen visible | `src/components/wisdom/UnifiedWisdomPanel.tsx` |
+
+## Decisiones
+
+**El esquema de la colección de Milvus no se cambia, y con él no hay
+reindexación.** El issue proponía añadir `projectId` y `versionId` a la colección
+y planificar la reindexación del corpus, y lo calificaba como la parte pesada del
+trabajo. No hace falta para cumplir los criterios: la garantía vive en la base, y
+el corpus existente queda correctamente clasificado sin tocar un solo vector
+—los tres documentos que había pasan a ámbito general, que es lo que son—. El
+`projectId` sí viaja desde ahora en la metainformación de cada fragmento nuevo, así
+que la optimización del filtro vectorial se podrá activar más adelante sin otra
+migración.
+
+El precio es recuperar algunos candidatos que después se descartan. Con 434
+fragmentos es irrelevante; se piden más candidatos cuando hay ámbito de proyecto
+para que el descarte no deje la lista corta.
+
+**Se filtra por lo permitido, no por lo prohibido.** `duenosPermitidos` devuelve la
+lista de dueños que pueden entrar. Si el ámbito o el proyecto llegan mal, el
+resultado es ver de menos, nunca de más. Sin proyecto activo, cualquier ámbito se
+resuelve como general: no se puede servir un documento de proyecto sin saber de
+quién es.
+
+**La herencia es de un solo sentido.** Un proyecto ve lo general —no debe perder
+acceso a la normativa, criterio confirmado por el Ing. Luis Mora— y lo general
+nunca ve lo de un proyecto. Con proyecto activo, el ámbito por defecto es «ambos».
+
+**Subir al ámbito de un proyecto es una decisión explícita.** Un documento se sube
+al proyecto sólo si el ámbito seleccionado es «Del proyecto»; en «General» y en
+«Ambos» se sube como general. Que un documento interno acabe siendo visible para
+todos no puede ser el resultado de no haber tocado un desplegable.
+
+**El listado obedece al mismo ámbito que la búsqueda.** Si un documento de otro
+proyecto no puede salir en una consulta, tampoco puede salir en la lista.
+
+## Un fallo que sólo apareció al probarlo contra la base
+
+Los 11 tests del módulo pasaban y la primera prueba real falló:
+
+```
+Argument `in`: Invalid value provided. Expected Null, provided (Null)
+```
+
+**Prisma no acepta `null` dentro de un `in`.** El filtro «general o de este
+proyecto» se había escrito como `projectId: { in: [null, projectId] }`, que es
+inválido — y como el ámbito general es el valor por defecto, habría roto el caso
+más común del Wisdom Center en cuanto se abriera. El nulo se expresa aparte:
+
+```ts
+{ OR: [{ projectId: null }, { projectId: { in: proyectos } }] }
+```
+
+La regla vive ahora en `filtroPrisma`, con su prueba y el motivo escrito al lado
+para que nadie la «simplifique» de vuelta.
+
+## La actualización de una instalación ya empaquetada
+
+`ensureProductionSchema` crea las tablas con `CREATE TABLE IF NOT EXISTS`, que en
+una instalación que actualiza **no añade una columna nueva** a una tabla que ya
+existe. Sin `projectId`, la consulta que la nombra falla y el Wisdom Center deja
+de funcionar en cuanto se abre. Se añade por las dos vías: en el `CREATE` para las
+instalaciones nuevas y con un `ALTER TABLE ... ADD COLUMN` para las que ya tienen
+la tabla. El `ALTER` protesta si la columna ya está, y el bucle que ejecuta el DDL
+registra el aviso sin abortar —así es idempotente—; comprobado sobre una copia de
+la base que ya la tenía, sin perder filas.
+
+## Estado de los criterios de aceptación
+
+| Criterio | Estado |
+|---|---|
+| Un documento del proyecto A no aparece en ninguna búsqueda del proyecto B | Hecho, verificado contra la base real en los tres ámbitos. |
+| Una búsqueda desde un proyecto devuelve normativa general, con el origen indicado | Hecho. El origen viaja en cada resultado y se muestra en las tarjetas. |
+| El corpus existente queda correctamente reindexado y clasificado, sin pérdidas | Hecho sin reindexar: los 3 documentos pasan a general y los 434 fragmentos quedan intactos. |
+
+## Comprobado en la aplicación
+
+Con la base real, creando un documento interno en un proyecto y consultándolo
+desde otro:
+
+| Desde | Ámbito | Ve | Ve el confidencial |
+|---|---|---:|---|
+| Proyecto B | general / proyecto / ambos | 3 / 0 / 3 | **no** en los tres |
+| Proyecto A (su dueño) | general / proyecto / ambos | 3 / 2 / 5 | sí, es suyo (salvo en general) |
+| Sin proyecto activo | los tres | 3 | **no** |
+
+Y en la interfaz: el selector con los tres ámbitos —«Del proyecto» y «Ambos»
+deshabilitados sin proyecto activo—, el distintivo de origen en cada tarjeta, y
+«My Documents (0)» al pedir sólo el ámbito del proyecto en uno que no tiene
+documentos internos, que es lo correcto.
+
+## Fuera de alcance
+
+**Mostrar el origen en los resultados de la búsqueda semántica.** El dato viaja en
+cada resultado, pero el panel no pinta hoy esos resultados: la línea que los
+guardaba está comentada desde antes de este cambio (`// setSearchResults(...)`) y
+la búsqueda sólo muestra un aviso con el número de coincidencias. Cuando exista
+esa vista, el origen ya está disponible.
+
+**`versionId` en el ámbito.** El issue lo menciona junto a `projectId`. Cobra
+sentido con #41, cuando los documentos indexados sean resultados de una simulación
+atada a una versión concreta; hoy no hay ningún documento con versión al que
+filtrar.
+
+**Las otras tres colecciones** (`conversations`, `agent_memory`,
+`guardrail_violations_vec`) siguen siendo globales. El issue nombra la de
+conocimiento, que es la que mezcla documentos de clientes distintos.

--- a/electron/handlers/document.handler.ts
+++ b/electron/handlers/document.handler.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import pdf from 'pdf-parse'
 import mammoth from 'mammoth'
 import { HydraulicRAGService } from '../../backend/services/hydraulic/ragService'
+import { duenosPermitidos, filtroPrisma, type Ambito } from '../../backend/services/hydraulic/ambitos'
 import { PrismaClient } from '@prisma/client'
 
 import { EmbeddingService } from '../../backend/services/embedding.service'
@@ -89,6 +90,11 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
     region?: string[]
     secondaryCategories?: string[]
     language?: string
+    /**
+     * Proyecto dueño del documento (#39). Sin él, el documento es general y lo
+     * ven todos los proyectos.
+     */
+    projectId?: string | null
   }) => {
     try {
       // Open file dialog
@@ -191,7 +197,7 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
               filename: fileName
             })
           }
-        })
+        }, options.projectId ?? null)
 
         uploadedDocs.push({
           id: docId,
@@ -238,9 +244,16 @@ export function registerWisdomHandlers(prisma?: PrismaClient) {
     category?: string
     region?: string
     language?: string
+    ambito?: Ambito
+    projectId?: string | null
   }) => {
     try {
       const where: any = { status: 'active' }
+
+      // El listado obedece al mismo ámbito que la búsqueda: si un documento de
+      // otro proyecto no puede salir en una consulta, tampoco puede salir en la
+      // lista (#39).
+      Object.assign(where, filtroPrisma(duenosPermitidos(filters?.ambito ?? 'general', filters?.projectId)))
 
       if (filters?.category) {
         where.category = filters.category

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -377,6 +377,7 @@ async function ensureProductionSchema(prismaClient: any): Promise<void> {
       "language" TEXT NOT NULL DEFAULT 'es',
       "version" TEXT NOT NULL DEFAULT '1.0',
       "status" TEXT NOT NULL DEFAULT 'active',
+      "projectId" TEXT,
       "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
       "updatedAt" DATETIME NOT NULL
     )`,
@@ -446,6 +447,16 @@ async function ensureProductionSchema(prismaClient: any): Promise<void> {
       "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
       "updatedAt" DATETIME NOT NULL
     )`,
+    /**
+     * Columnas añadidas a tablas que ya existen. `CREATE TABLE IF NOT EXISTS` no
+     * las agrega en una instalación que actualiza, y sin ellas la consulta que
+     * las nombra falla: el ámbito del Wisdom Center (#39) dejaría de funcionar
+     * en cuanto se abriera. `ADD COLUMN` protesta si ya está, y el bucle de
+     * abajo registra el aviso sin abortar, que es lo que hace idempotente esto.
+     */
+    `ALTER TABLE "hydraulic_knowledge" ADD COLUMN "projectId" TEXT`,
+    `CREATE INDEX IF NOT EXISTS "hydraulic_knowledge_projectId_idx" ON "hydraulic_knowledge"("projectId")`,
+
     // Historial inmutable de redes y simulaciones (#38)
     `CREATE TABLE IF NOT EXISTS "network_versions" (
       "id" TEXT NOT NULL PRIMARY KEY,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -203,6 +203,7 @@ model HydraulicProject {
 
   calculations  HydraulicCalculation[]
   snapshots     ProjectSnapshot[]
+  knowledge     HydraulicKnowledge[]
   documents     ProjectDocument[]
   teamMembers   ProjectTeamMember[]
   conversations Conversation[]
@@ -279,8 +280,15 @@ model HydraulicKnowledge {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
+  /// Dueño del documento (#39). `null` es el ámbito general: normativa y buenas
+  /// prácticas compartidas por todos los proyectos. Con proyecto, el documento
+  /// es interno de ese cliente y no puede aparecer en búsquedas de otro.
+  projectId String?
+  project   HydraulicProject? @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
   chunks KnowledgeChunk[]
 
+  @@index([projectId])
   @@map("hydraulic_knowledge")
 }
 

--- a/src/components/wisdom/UnifiedWisdomPanel.tsx
+++ b/src/components/wisdom/UnifiedWisdomPanel.tsx
@@ -1,5 +1,7 @@
 import { logger } from '@/utils/logger'
 import { useState, useEffect } from 'react'
+import { useProjectStore } from '@/stores/projectStore'
+import type { Ambito } from '@/../backend/services/hydraulic/ambitos'
 
 import {
   Upload, Search, FileText, Trash2, RefreshCw, Settings,
@@ -34,6 +36,8 @@ interface WisdomDocument {
   type: 'uploaded' | 'catalog'
   indexing?: IndexingStatus
   description?: string
+  /** Proyecto dueño; ausente o nulo significa ámbito general (#39). */
+  projectId?: string | null
 }
 
 /*
@@ -196,6 +200,7 @@ export function UnifiedWisdomPanel() {
     combineDocuments()
   }, [wisdomDocuments, searchQuery, selectedCategory])
 
+
   // Debug: Log when embedding providers change
   useEffect(() => {
     logger.debug(`🔄 [React] Embedding providers state updated: ${embeddingProviders.length} providers`)
@@ -215,6 +220,25 @@ export function UnifiedWisdomPanel() {
     }
   }
 
+  /**
+   * Ámbito de la consulta (#39). Con proyecto activo el valor por defecto es
+   * «ambos», que es lo que el issue pide: un proyecto no debe perder acceso a la
+   * normativa general. Sin proyecto sólo existe lo general.
+   */
+  const projectId = useProjectStore(s => s.currentProjectId)
+  const nombreProyecto = useProjectStore(s => s.currentProject?.name)
+  const [ambito, setAmbito] = useState<Ambito>('general')
+
+  useEffect(() => {
+    setAmbito(projectId ? 'ambos' : 'general')
+  }, [projectId])
+
+  // Cambiar de ámbito cambia el corpus, así que hay que releerlo (#39).
+  useEffect(() => {
+    loadWisdomDocuments()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ambito, projectId])
+
   const loadWisdomDocuments = async () => {
     try {
       // Check if electronAPI is available
@@ -223,7 +247,7 @@ export function UnifiedWisdomPanel() {
         return
       }
 
-      const filters: any = {}
+      const filters: any = { ambito, projectId }
       if (selectedCategory !== 'all') filters.category = selectedCategory
       if (selectedRegion) filters.region = selectedRegion
 
@@ -535,7 +559,10 @@ export function UnifiedWisdomPanel() {
     const options = {
       category: selectedCategory === 'all' ? 'hydraulics' : selectedCategory as any,
       language: 'es',
-      region: selectedRegion ? [selectedRegion] : undefined
+      region: selectedRegion ? [selectedRegion] : undefined,
+      // Se sube al proyecto sólo si el ámbito elegido es el del proyecto: subir
+      // al ámbito equivocado tiene que ser una decisión, no un descuido.
+      projectId: ambito === 'proyecto' ? projectId : null,
     }
 
     setLoading(true)
@@ -585,7 +612,9 @@ export function UnifiedWisdomPanel() {
       const options = {
         category: selectedCategory !== 'all' ? selectedCategory : undefined,
         region: selectedRegion || undefined,
-        language: 'es'
+        language: 'es',
+        ambito,
+        projectId,
       }
 
       const result = await window.electronAPI.wisdom.search(searchQuery, options)
@@ -872,6 +901,36 @@ export function UnifiedWisdomPanel() {
           <div className="flex flex-wrap gap-4 items-center">
             {/* Left side - Filters and Search */}
             <div className="flex flex-wrap gap-4 items-center flex-1">
+              {/* Ámbito (#39). Va delante porque manda sobre los demás filtros:
+                  decide en qué corpus se busca, no cómo se recorta. */}
+              <div className="flex items-center gap-1 rounded-lg border border-border bg-background p-1">
+                {([
+                  { valor: 'general' as Ambito, texto: 'General' },
+                  { valor: 'proyecto' as Ambito, texto: 'Del proyecto' },
+                  { valor: 'ambos' as Ambito, texto: 'Ambos' },
+                ]).map(op => (
+                  <button
+                    key={op.valor}
+                    disabled={op.valor !== 'general' && !projectId}
+                    title={
+                      op.valor !== 'general' && !projectId
+                        ? 'Necesita un proyecto activo'
+                        : op.valor === 'general'
+                          ? 'Normativa y buenas prácticas, compartidas por todos los proyectos'
+                          : `Documentos internos de ${nombreProyecto ?? 'el proyecto'}`
+                    }
+                    onClick={() => setAmbito(op.valor)}
+                    className={`rounded px-3 py-1.5 text-sm transition-colors ${
+                      ambito === op.valor
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground disabled:opacity-40'
+                    }`}
+                  >
+                    {op.texto}
+                  </button>
+                ))}
+              </div>
+
               {/* Category Filter */}
               <select
                 value={selectedCategory}
@@ -1367,6 +1426,20 @@ export function UnifiedWisdomPanel() {
                             <FileText className="w-4 h-4 text-primary" />
                             <span className="text-xs px-2 py-1 rounded-full font-medium bg-primary/10 text-primary">
                               My Document
+                            </span>
+                            {/* De dónde viene, para que una cita de una norma no
+                                se confunda con un documento interno del cliente (#39). */}
+                            <span
+                              className={`text-xs px-2 py-1 rounded-full font-medium ${
+                                doc.projectId
+                                  ? 'bg-amber-500/15 text-amber-600 dark:text-amber-500'
+                                  : 'bg-muted text-muted-foreground'
+                              }`}
+                              title={doc.projectId
+                                ? `Documento interno de ${nombreProyecto ?? 'este proyecto'}`
+                                : 'Conocimiento general, compartido por todos los proyectos'}
+                            >
+                              {doc.projectId ? 'Del proyecto' : 'General'}
                             </span>
                           </div>
                           {doc.type === 'uploaded' && !isSelectMode && (


### PR DESCRIPTION
## El problema, y por qué no es de comodidad

Todo el conocimiento vivía mezclado —la normativa general de Boorie y los documentos internos de un cliente— y la búsqueda no filtraba por nada. El código lo decía literalmente:

```ts
'hydraulic_knowledge', // Hardcoded for now
```

El criterio de aceptación es de confidencialidad: *«un documento subido en el ámbito de un proyecto A no aparece en ninguna búsqueda del proyecto B, en ningún modo»*. Equivocarse aquí significa enseñarle a un cliente los documentos de otro, y es un error que no se nota hasta que ha ocurrido.

## Dónde se garantiza, y por qué ahí

```
consulta ─► almacén vectorial (Milvus) ─► fragmentos candidatos
                                              │
                                              ▼
                                     consulta a la base ◄── AQUÍ
                                              │
                                              ▼
                                          documentos
```

**El filtro del almacén vectorial es una optimización, no la garantía.** Milvus falla en silencio a propósito —el propio servicio devuelve resultados vacíos cuando no conecta—, puede ignorar una expresión de filtro o devolver de más. Confiar en él para una regla de confidencialidad sería confiar en el componente más frágil del sistema.

La base es la autoridad sobre de quién es cada documento, y la búsqueda los materializa en **un único `findMany`**. Filtrar ahí hace que un fragmento ajeno que se colara no llegue nunca a convertirse en un documento que enseñar.

## Dos decisiones que me aparto del enunciado

**No cambio el esquema de la colección de Milvus ni reindexo nada** — que es justo lo que el issue calificaba como «la parte pesada». No hace falta para cumplir los criterios: la garantía vive en la base, los 3 documentos existentes pasan a ámbito general (que es lo que son) y los 434 fragmentos quedan intactos. El `projectId` sí viaja ya en la metainformación de los fragmentos nuevos, así que el filtro vectorial se puede activar más adelante sin otra migración. El precio es recuperar algunos candidatos que se descartan: con 434 fragmentos, irrelevante.

Esto rebaja el esfuerzo que yo mismo te había estimado como Medio-Alto, y elimina el riesgo de la reindexación.

**Se filtra por lo permitido, no por lo prohibido.** Si el ámbito o el proyecto llegan mal, se ve de menos, nunca de más. Sin proyecto activo, cualquier ámbito se resuelve como general: no se puede servir un documento de proyecto sin saber de quién es.

## Un fallo que sólo apareció al probarlo contra la base

Los 11 tests del módulo pasaban y la primera prueba real falló:

```
Argument `in`: Invalid value provided. Expected Null, provided (Null)
```

**Prisma no acepta `null` dentro de un `in`.** El filtro «general o de este proyecto» se había escrito como `projectId: { in: [null, projectId] }` — y como el ámbito general es el valor por defecto, **habría roto el caso más común del Wisdom Center en cuanto se abriera**. El nulo se expresa aparte, con un `OR`. La regla vive ahora en `filtroPrisma`, con su prueba y el motivo escrito al lado.

## Y la actualización de una instalación empaquetada

`CREATE TABLE IF NOT EXISTS` no añade una columna nueva a una tabla que ya existe. Sin `projectId`, la consulta que la nombra falla y el Wisdom Center deja de abrir. Se añade también con `ALTER TABLE ... ADD COLUMN`, idempotente porque el bucle del DDL registra el aviso sin abortar; comprobado sobre una copia de la base que ya la tenía, sin perder filas.

## Verificación

**325 tests** (eran 309). Los 16 nuevos fijan la regla que no se puede romper: un documento del proyecto A no es visible desde B en **ninguno** de los tres ámbitos, ni desde ningún proyecto ajeno, ni sin proyecto activo.

**Contra la base real**, creando un documento interno en un proyecto y consultándolo desde otro:

| Desde | general / proyecto / ambos | Ve el confidencial |
|---|---:|---|
| Proyecto B | 3 / 0 / 3 | **no** en los tres |
| Proyecto A (su dueño) | 3 / 2 / 5 | sí, es suyo (salvo en general) |
| Sin proyecto activo | 3 / 3 / 3 | **no** |

Y en la interfaz: el selector con los tres ámbitos —los dos de proyecto deshabilitados sin proyecto activo—, el distintivo de origen en cada tarjeta, y «My Documents (0)» al pedir sólo el ámbito del proyecto en uno sin documentos internos.

## Fuera de alcance

- **Mostrar el origen en los resultados de la búsqueda semántica**: el dato viaja, pero el panel no pinta esos resultados — la línea que los guardaba está comentada desde antes de este cambio.
- **`versionId` en el ámbito**: cobra sentido con #41, cuando haya documentos atados a una versión.
- **Las otras tres colecciones** (`conversations`, `agent_memory`, `guardrail_violations_vec`) siguen globales; el issue nombra la de conocimiento, que es la que mezcla clientes.

Con esto, el #41 queda desbloqueado de verdad. Diseño y decisiones en `docs/WISDOM_AMBITOS.md`.

Closes #39